### PR TITLE
Added MathJax support

### DIFF
--- a/qdrant-landing/themes/qdrant/layouts/partials/css.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/css.html
@@ -28,3 +28,5 @@
 <!-- highlight.js -->
 {{ if .Site.Params.highlight | default false }} <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/default.min.css"> {{ end }}
 <link rel="stylesheet" href="{{ "css/lang-switcher.css" | absURL }}">
+
+<link rel="stylesheet" href="{{ "css/mathjax.css" | absURL }}">

--- a/qdrant-landing/themes/qdrant/layouts/partials/js.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/js.html
@@ -1,3 +1,4 @@
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script src="{{ "js/jquery.js" | absURL }}"></script>
 <script src="{{ "js/popper.min.js" | absURL }}"></script>
 <script src="{{ "js/jquery.scrollTo.js" | absURL }}"></script>
@@ -65,3 +66,25 @@
 {{ end }}
 <script src="{{ "js/lang-switcher.js" | absURL }}"></script>
 <script src="{{ "js/copy-code.js" | absURL }}"></script>
+
+<!-- MathJax support -->
+<script>
+  MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$','$$'], ['\\[', '\\]']],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+    }
+  };
+
+  window.addEventListener('load', (event) => {
+    document.querySelectorAll("mjx-container").forEach(function(x){
+      x.parentElement.classList += 'has-jax'})
+  });
+
+</script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/qdrant-landing/themes/qdrant/static/css/mathjax.css
+++ b/qdrant-landing/themes/qdrant/static/css/mathjax.css
@@ -1,0 +1,6 @@
+code.has-jax {
+	-webkit-font-smoothing: antialiased;
+	background: inherit !important;
+	border: none !important;
+	font-size: 100%;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7085263/159269170-52696f66-2449-43ec-910a-489ac3275a65.png)

Added MathJax support. 

For inline math use: `$ here math $` or `\\( here math \\)`

For display outline math use:
```
$$
here math
$$
```

or 

```
\\[
here math
\\]
```