### PR TITLE
Different seo schema for differen pages

### DIFF
--- a/qdrant-landing/content/benchmarks/_index.md
+++ b/qdrant-landing/content/benchmarks/_index.md
@@ -14,4 +14,6 @@ keywords:
   - vector search
   - embedding
 preview_image: /benchmarks/benchmark-1.png
+seo_schema: { "@context": "https://schema.org", "@type": "Article", "headline": "Vector Search Comparative Benchmarks", "image": [ "https://qdrant.tech/benchmarks/benchmark-1.png" ], "abstract": "The first comparative benchmark and benchmarking framework for vector search engines", "datePublished": "2022-08-23", "dateModified": "2022-08-23", "author": [{ "@type": "Organization", "name": "Qdrant", "url": "https://qdrant.tech" }] }
+ 
 ---

--- a/qdrant-landing/themes/qdrant/layouts/partials/seo_schema.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/seo_schema.html
@@ -93,9 +93,6 @@
 </script>
 {{ end }}
 
-{{ if .IsHome }}
-{{ end }}
-
 {{ $url := urls.Parse .Site.BaseURL }}
 {{ $domain := index (split $url.Host ".") 0 }}
 

--- a/qdrant-landing/themes/qdrant/layouts/partials/seo_schema.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/seo_schema.html
@@ -10,6 +10,7 @@
 <meta name="keywords" content="{{ range .Site.Params.Keywords }}{{ . }}, {{ end }} qdrant">
 {{ end }}
 
+{{ if .IsHome }}
 <script type="application/ld+json">
   {
       "@context": "https://schema.org",
@@ -66,6 +67,34 @@
       }
   }
 </script>
+{{ else if .Params.seo_schema }}
+<!--    todo: use as default option -->
+<script type="application/ld+json">
+    {{ .Params.seo_schema }}
+</script>
+{{ else if and (eq .Section "articles") .IsPage }}
+<script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "{{ .Params.title }}",
+        "image": [
+            {{ .Params.social_preview_image  | absURL }},
+        ],
+        "abstract": {{ .Params.description }},
+        "datePublished": {{ .Params.date }},
+        "dateModified": {{ .Params.date }},
+        "author": [{
+            "@type": "Person",
+            "name": {{ .Params.author }},
+            "url": {{ .Params.author_link }}
+        }]
+    }
+</script>
+{{ end }}
+
+{{ if .IsHome }}
+{{ end }}
 
 {{ $url := urls.Parse .Site.BaseURL }}
 {{ $domain := index (split $url.Host ".") 0 }}


### PR DESCRIPTION
Added SEO schema (aka schema.org) for articles and benchmark page (`article` entity). Now schema generates from article parameters but also can be overridden with the `seo_schema` param. The `organization` entity now used only on the main page. 

Also, the `seo_schema` parameter can be optionally used on other pages.