### PR TITLE
Fix broken link in PQ article

### DIFF
--- a/qdrant-landing/content/articles/product-quantization.md
+++ b/qdrant-landing/content/articles/product-quantization.md
@@ -217,6 +217,6 @@ Product Quantization tends to be favored in certain specific scenarios:
 
 In circumstances that do not align with the above, Scalar Quantization should be the preferred choice.
 
-Qdrant documentation on [Product Quantization](/documentation/quantization/#setting-up-product-quantization) 
+Qdrant documentation on [Product Quantization](/documentation/guides/quantization/#setting-up-product-quantization) 
 will help you to set and configure the new quantization for your data and achieve even 
 up to 64x memory reduction.

--- a/qdrant-landing/content/articles/product-quantization.md
+++ b/qdrant-landing/content/articles/product-quantization.md
@@ -14,6 +14,7 @@ keywords:
   - vector search
   - product quantization
   - memory optimization
+aliases: [ /articles/product_quantization/ ]
 ---
 
 Qdrant 1.1.0 brought the support of [Scalar Quantization](/articles/scalar-quantization/),


### PR DESCRIPTION
This PR fixes a broken link in the Product Quantization article.

![image](https://github.com/qdrant/landing_page/assets/2649301/a4c3d910-1446-4fe8-b53b-17ff0bac2894)
