### PR TITLE
fix aliases for SEO

### DIFF
--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -1,6 +1,8 @@
 ---
 title: Collections
 weight: 30
+aliases:
+  - ../collections
 ---
 
 # Collections

--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -1,6 +1,8 @@
 ---
 title: Filtering
 weight: 60
+aliases:
+  - ../filtering
 ---
 
 # Filtering

--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -1,6 +1,8 @@
 ---
 title: Indexing
 weight: 90
+xaliases:
+  - ../indexing
 ---
 
 # Indexing

--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -1,7 +1,7 @@
 ---
 title: Indexing
 weight: 90
-xaliases:
+aliases:
   - ../indexing
 ---
 

--- a/qdrant-landing/content/documentation/concepts/optimizer.md
+++ b/qdrant-landing/content/documentation/concepts/optimizer.md
@@ -1,6 +1,8 @@
 ---
 title: Optimizer
 weight: 70
+aliases:
+  - ../optimizer
 ---
 
 # Optimizer

--- a/qdrant-landing/content/documentation/concepts/payload.md
+++ b/qdrant-landing/content/documentation/concepts/payload.md
@@ -1,6 +1,8 @@
 ---
 title: Payload
 weight: 40
+aliases:
+  - ../payload
 ---
 
 # Payload

--- a/qdrant-landing/content/documentation/concepts/points.md
+++ b/qdrant-landing/content/documentation/concepts/points.md
@@ -1,6 +1,8 @@
 ---
 title: Points
 weight: 40
+aliases:
+  - ../points
 ---
 
 # Points

--- a/qdrant-landing/content/documentation/concepts/search.md
+++ b/qdrant-landing/content/documentation/concepts/search.md
@@ -1,6 +1,8 @@
 ---
 title: Search
 weight: 50
+aliases:
+  - ../search
 ---
 
 # Similarity search

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -1,6 +1,8 @@
 ---
 title: Snapshots
 weight: 110
+aliases:
+  - ../snapshots
 ---
 
 # Snapshots

--- a/qdrant-landing/content/documentation/concepts/storage.md
+++ b/qdrant-landing/content/documentation/concepts/storage.md
@@ -1,6 +1,8 @@
 ---
 title: Storage
 weight: 80
+aliases:
+  - ../storage
 ---
 
 # Storage

--- a/qdrant-landing/content/documentation/guides/administration.md
+++ b/qdrant-landing/content/documentation/guides/administration.md
@@ -1,6 +1,8 @@
 ---
 title: Administration
 weight: 10
+aliases:
+  - ../administration
 ---
 
 # Administration

--- a/qdrant-landing/content/documentation/guides/configuration.md
+++ b/qdrant-landing/content/documentation/guides/configuration.md
@@ -1,6 +1,8 @@
 ---
 title: Configuration
 weight: 160
+aliases:
+  - ../configuration
 ---
 
 # Configuration

--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -1,6 +1,8 @@
 ---
 title: Distributed deployment
 weight: 100
+aliases:
+  - ../distributed_deployment
 ---
 
 # Distributed deployment

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -1,6 +1,9 @@
 ---
 title: Installation
 weight: 10
+aliases:
+  - ../install
+  - ../installation
 ---
 
 # Installation options

--- a/qdrant-landing/content/documentation/guides/monitoring.md
+++ b/qdrant-landing/content/documentation/guides/monitoring.md
@@ -1,6 +1,8 @@
 ---
 title: Monitoring
 weight: 155
+aliases:
+  - ../monitoring
 ---
 
 # Monitoring

--- a/qdrant-landing/content/documentation/guides/quantization.md
+++ b/qdrant-landing/content/documentation/guides/quantization.md
@@ -1,6 +1,8 @@
 ---
 title: Quantization
 weight: 120
+aliases:
+  - ../quantization
 ---
 
 # Quantization

--- a/qdrant-landing/content/documentation/guides/security.md
+++ b/qdrant-landing/content/documentation/guides/security.md
@@ -1,6 +1,8 @@
 ---
 title: Security
 weight: 165
+aliases:
+  - ../security
 ---
 
 # Security

--- a/qdrant-landing/content/documentation/guides/telemetry.md
+++ b/qdrant-landing/content/documentation/guides/telemetry.md
@@ -1,6 +1,8 @@
 ---
 title: Telemetry
 weight: 150
+aliases:
+  - ../telemetry
 ---
 
 # Telemetry

--- a/qdrant-landing/content/documentation/quick-start.md
+++ b/qdrant-landing/content/documentation/quick-start.md
@@ -1,6 +1,8 @@
 ---
 title: Quickstart
 weight: 11
+aliases:
+  - quick_start
 ---
 
 # Quickstart


### PR DESCRIPTION
In order to avoid indexing/ranking issues with the search engines, I fixed path aliases to keep the indexes connected to the same content.

The only pages that aren't the same are "Integrations" and "How-Tos". Those have been separated into multiple topics. I hope that doesn't cause any issues. 