### PR TITLE
add two notebook tutorials

### DIFF
--- a/qdrant-landing/content/documentation/tutorials/_index.md
+++ b/qdrant-landing/content/documentation/tutorials/_index.md
@@ -24,6 +24,8 @@ These tutorials demonstrate different ways you can build vector search into your
 
 Complex instructions that are supported with a throrough explanation. Follow along by trying out the code and get the most out of each example.
 
-| Jupyter Notebook             | Description                                  | Stack  |   
+| Jupyter Notebook      | Description                                  | Stack  |   
 |-----------------------|----------------------------------------------|--------|
+| [Qdrant 101 - Getting Started](https://githubtocolab.com/qdrant/examples/blob/master/qdrant_101_getting_started/getting_started.ipynb)    | Basics of search and recommendation systems. | Qdrant | 
+| [Qdrant 101 - Text Data](https://githubtocolab.com/qdrant/examples/blob/master/qdrant_101_text_data/qdrant_and_text_data.ipynb)    | Work with text data to develop a semantic search and a recommendation engine. | Qdrant | 
 | [Build a Q&A Engine](https://githubtocolab.com/qdrant/examples/blob/master/llama_index_recency/Qdrant%20and%20LlamaIndex%20%E2%80%94%20A%20new%20way%20to%20keep%20your%20Q%26A%20systems%20up-to-date.ipynb)    | Design a question/answer system that updates. | Qdrant, LlamaIndex, Cohere | 

--- a/qdrant-landing/content/documentation/tutorials/q101-getting-started.md
+++ b/qdrant-landing/content/documentation/tutorials/q101-getting-started.md
@@ -1,0 +1,7 @@
+---
+title: Qdrant 101 - Getting Started
+weight: 1
+type: external-link
+external_url: https://githubtocolab.com/qdrant/examples/blob/master/qdrant_101_getting_started/getting_started.ipynb
+sitemapExclude: True
+---

--- a/qdrant-landing/content/documentation/tutorials/q101-text-data.md
+++ b/qdrant-landing/content/documentation/tutorials/q101-text-data.md
@@ -1,0 +1,7 @@
+---
+title: Qdrant 101 - Text Data
+weight: 2
+type: external-link
+external_url: https://githubtocolab.com/qdrant/examples/blob/master/qdrant_101_text_data/qdrant_and_text_data.ipynb
+sitemapExclude: True
+---


### PR DESCRIPTION
add links to two jupyter notebook tutorials to show on the tutorials index and individual sidebar links