### PR TITLE
navigation: fix capitalization for github

### DIFF
--- a/qdrant-landing/themes/qdrant/layouts/partials/header.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/header.html
@@ -148,7 +148,7 @@
                                <a class="btn btn_in-header" href="{{ .Site.Params.cloud }}" title="Cloud" role="button">
                                    <span class="btn__text"><i class="fas fa-cloud"></i> Cloud</span></a>
                                <a class="btn btn_in-header" href="{{ .Site.Params.github }}" target="_blank" title="GitHub" role="button">
-                                   <span class="btn__text"><i class="fab fa-github"></i> Github</span></a>
+                                   <span class="btn__text"><i class="fab fa-github"></i> GitHub</span></a>
                            </li>
 
                           </ul>


### PR DESCRIPTION
The link to GitHub in the navigation bar should be stylized as "GitHub" rather than "Github".