### PR TITLE
Added hideInSidebare option to docs sidebar

### DIFF
--- a/qdrant-landing/README.md
+++ b/qdrant-landing/README.md
@@ -109,3 +109,13 @@ hugo new --kind external-link documentation/<link-title>.md
 ```
 
 It will create a file `content/documentation/<link-title>.md`. Open it and set the `external_link` parameter to the desired value.
+
+### Params
+
+Additionally, to the standard hugo front matter params, we have the following params:
+
+```yaml
+hideInSidebar: true
+```
+
+If `true`, the page will not be shown in the sidebar. It can be used in regular documentation pages and in documentation section pages (_index.md).

--- a/qdrant-landing/themes/qdrant/layouts/partials/docs_sidebar.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/docs_sidebar.html
@@ -17,7 +17,7 @@
                     <h5 class="documentation__sidebar-delimiter">{{ .Title }}</h5>
                 {{ else }}
 
-                {{ if .IsPage }}
+                {{ if and (.IsPage) (not .Params.hideInSidebar) }}
 
                     <div class="link-group {{ if eq .File.UniqueID $currentNode.File.UniqueID }}active {{ end }}">
                         <div class="link-group-heading">
@@ -37,7 +37,7 @@
 
                 {{ end }}
 
-                {{ if .IsSection }}
+                {{ if and (.IsSection) (not .Params.hideInSidebar) }}
 
                     <!-- current page is active or any sub-page is active -->
                     {{ $isActive := false }}
@@ -78,7 +78,7 @@
                                                     <i class="link-group__icon fas fa-external-link-alt"></i>
                                                 </a>
                                             </li>
-                                        {{ else }}
+                                        {{ else if not .Params.hideInSidebar }}
                                             <li class="{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active {{ end }}"><a href="{{ .Permalink }}">{{ .Title }}</a></li>
                                         {{ end }}
                                     {{ end }}


### PR DESCRIPTION
Additionally, to the standard Hugo front matter params, we have the following:

```yaml
hideInSidebar: true
```

If `true`, the page will not be shown in the sidebar. It can be used in regular documentation pages and in documentation section pages (_index.md).
