### PR TITLE
Document customizable temporary directory

### DIFF
--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -13,22 +13,21 @@ Snapshots are performed on a per collection basis and consist in a `tar` archive
 
 This feature can be used to archive data or easily replicate an existing deployment.
 
+## Store snapshots
+
 The target directory used to store generated snapshots is controlled through the [configuration](../../guides/configuration) or using the ENV variable: `QDRANT__STORAGE__SNAPSHOT_PATH=./snapshots`.
 
+You can set the snapshots storage directory from the [config.yaml](https://github.com/qdrant/qdrant/blob/master/config/config.yaml) file. If no value is given, default is `./snapshots`.
 ```yaml
 storage:
-  # Where to store snapshots
+  # Specify where you want to store snapshots.
   snapshots_path: ./snapshots
 ```
 
-It defaults to `./snapshots` if no value is provided.
-
 *Available as of v1.3.0*
 
-While a snapshot is being created, it creates some temporary files. These are
-placed in the configured storage directory by default. It may have a limited
-capacity or be a slow network attached disk. To change this temporary directory
-to something more suited on your system you could set the following:
+While a snapshot is being created, temporary files are by default placed in the configured storage directory. 
+This location may have limited capacity or be on a slow network-attached disk. You may specify a separate location for temporary files:
 
 ```yaml
 storage:

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -7,7 +7,7 @@ aliases:
 
 # Snapshots
 
-*Available since v0.8.4*
+*Available as of v0.8.4*
 
 Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -23,6 +23,19 @@ storage:
 
 It defaults to `./snapshots` if no value is provided.
 
+*Available as of v1.3.0*
+
+While a snapshot is being created, it creates some temporary files. These are
+placed in the configured storage directory by default. It may have a limited
+capacity or be a slow network attached disk. To change this temporary directory
+to something more suited on your system you could set the following:
+
+```yaml
+storage:
+  # Where to store temporary files
+  temp_path: /tmp
+```
+
 ## Create snapshot
 
 To create a new snapshot for an existing collection:

--- a/qdrant-landing/content/documentation/guides/configuration.md
+++ b/qdrant-landing/content/documentation/guides/configuration.md
@@ -115,7 +115,11 @@ storage:
   # Where to store snapshots
   snapshots_path: ./snapshots
 
-  # If true - point's payload will not be stored in memory.
+  # Optional setting. Specify where else to store temp files as default is ./storage.
+  # Route to another location on your system to reduce network disk use. 
+  temp_path: /tmp
+
+  # If true - a point's payload will not be stored in memory.
   # It will be read from the disk every time it is requested.
   # This setting saves RAM by (slightly) increasing the response time.
   # Note: those payload values that are involved in filtering and are indexed - remain in RAM.


### PR DESCRIPTION
Draft for documentation on the customizable temporary directory feature.

I'm not sure if I like it being placed here, but I don't have a better suggestion. Any ideas? Putting it in _Configuration_ or in a _Tutorial_ section could be an option.