### PR TITLE
Fix the description of the snapshot recovery

### DIFF
--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -9,7 +9,7 @@ aliases:
 
 *Available since v0.8.4*
 
-Snapshots are performed on a per collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
+Snapshots are performed on a per-collection basis and consist in a `tar` archive file containing the necessary data to restore the collection at the time of the snapshot.
 
 This feature can be used to archive data or easily replicate an existing deployment.
 
@@ -94,7 +94,9 @@ Only available through the REST API for the time being.
 
 There is a difference in recovering snapshots in single-deployment node and distributed deployment mode.
 
-### Recover in single deployment mode
+### Recover during start-up
+
+<aside role="status">This method cannot be used in a cluster deployment.</aside>
 
 Single deployment is simpler, you can recover any collection on the start-up and it will be immediately available in the service.
 Restoring snapshots is done through the Qdrant CLI at startup time.
@@ -111,15 +113,17 @@ The target collection **must** be absent otherwise the program will exit with an
 
 If you wish instead to overwrite an existing collection, use the `--force_snapshot` flag with caution.
 
-### Recover in cluster deployment
+### Recover via API
 
 *Available as of v0.11.3*
+
+<aside role="status">You can use this method for both single-node and cluster setups.</aside>
 
 Recovering in cluster mode is more sophisticated, as Qdrant should maintain consistency across peers even during the recovery process.
 As the information about created collections is stored in the consensus, even a newly attached cluster node will automatically create collections.
 Recovering non-existing collections with snapshots won't make this collection known to the consensus.
 
-To recover snapshot in this case one can use snapshot recovery API:
+To recover snapshot via API one can use snapshot recovery endpoint:
 
 ```http
 PUT /collections/<collection_name>/snapshots/recover
@@ -137,7 +141,7 @@ client = QdrantClient("qdrant-node-2", port=6333)
 client.recover_snapshot("collection_name", "http://qdrant-node-1:6333/collections/collection_name/snapshots/snapshot-2022-10-10.shapshot")
 ```
 
-The recovery snapshot can also be uploaded as a file to the cluster:
+The recovery snapshot can also be uploaded as a file to the Qdrant server:
 ```bash
 curl -X POST 'http://qdrant-node-1:6333/collections/collection_name/snapshots/upload' \
     -H 'Content-Type:multipart/form-data' \


### PR DESCRIPTION
I updated the docs of snapshot recovery, as they were inaccurate. Recovery via API is also possible for single node deployments.