### PR TITLE
fix: fix with_vectors arg in python examples

### DIFF
--- a/qdrant-landing/content/documentation/concepts/points.md
+++ b/qdrant-landing/content/documentation/concepts/points.md
@@ -689,7 +689,7 @@ client.scroll(
     ),
     limit=1,
     with_payload=True,
-    with_vector=False,
+    with_vectors=False,
 )
 ```
 

--- a/qdrant-landing/content/documentation/concepts/search.md
+++ b/qdrant-landing/content/documentation/concepts/search.md
@@ -576,7 +576,7 @@ client = QdrantClient("localhost", port=6333)
 client.search(
     collection_name="{collection_name}",
     query_vector=[0.2, 0.1, 0.9, 0.7],
-    with_vector=True,
+    with_vectors=True,
     with_payload=True,
     limit=10,
     offset=100


### PR DESCRIPTION
qdrant-client does not have `with_vector` argument, instead it has `with_vectors`