### PR TITLE
Add warning to protect internal gRPC ports

### DIFF
--- a/qdrant-landing/content/documentation/guides/security.md
+++ b/qdrant-landing/content/documentation/guides/security.md
@@ -64,7 +64,7 @@ qdrant_client = QdrantClient(
 )
 ```
 
-<aside role="alert">Internal communication channels are <strong>never</strong> protected by an API key. It (internal gRPC) uses port 6335 by default if running in distributed mode. You must make sure this port is not publicly reachable and can only be used for node communication or bad things will happen. In Qdrant Cloud and the Qdrant Helm chart access to this is disabled by default.</aside>
+<aside role="alert">Internal communication channels are <strong>never</strong> protected by an API key. Internal gRPC uses port 6335 by default if running in distributed mode. You must ensure that this port is not publicly reachable and can only be used for node communication. By default, this setting is disabled for Qdrant Cloud and the Qdrant Helm chart.</aside>
 
 ## TLS
 

--- a/qdrant-landing/content/documentation/guides/security.md
+++ b/qdrant-landing/content/documentation/guides/security.md
@@ -60,6 +60,8 @@ qdrant_client = QdrantClient(
 )
 ```
 
+<aside role="alert">Internal communication channels are **never** protected by an API key. It (internal gRPC) uses port 6335 by default if running in distributed mode. You must make sure this port is not publicly reachable and can only be used for node communication or bad things will happen. In Qdrant Cloud and the Qdrant Helm chart access to this is disabled by default.</aside>
+
 ## TLS
 
 *Available as of v1.2.0*

--- a/qdrant-landing/content/documentation/guides/security.md
+++ b/qdrant-landing/content/documentation/guides/security.md
@@ -9,6 +9,10 @@ aliases:
 
 There are various ways to secure your own Qdrant instance.
 
+By default no security measures are enabled for your own Qdrant instances and
+they are open to everyone. Read this page carefully on how to secure your
+instance for production use.
+
 ## Authentication
 
 *Available as of v1.2.0*

--- a/qdrant-landing/content/documentation/guides/security.md
+++ b/qdrant-landing/content/documentation/guides/security.md
@@ -7,11 +7,10 @@ aliases:
 
 # Security
 
-There are various ways to secure your own Qdrant instance.
 
-By default no security measures are enabled for your own Qdrant instances and
-they are open to everyone. Read this page carefully on how to secure your
-instance for production use.
+
+Please read this page carefully. Although there are various ways to secure your Qdrant instances, **they are unsecured by default**. 
+You need to enable security measures before production use. Otherwise, they are completely open to anyone
 
 ## Authentication
 

--- a/qdrant-landing/content/documentation/guides/security.md
+++ b/qdrant-landing/content/documentation/guides/security.md
@@ -64,7 +64,7 @@ qdrant_client = QdrantClient(
 )
 ```
 
-<aside role="alert">Internal communication channels are **never** protected by an API key. It (internal gRPC) uses port 6335 by default if running in distributed mode. You must make sure this port is not publicly reachable and can only be used for node communication or bad things will happen. In Qdrant Cloud and the Qdrant Helm chart access to this is disabled by default.</aside>
+<aside role="alert">Internal communication channels are <strong>never</strong> protected by an API key. It (internal gRPC) uses port 6335 by default if running in distributed mode. You must make sure this port is not publicly reachable and can only be used for node communication or bad things will happen. In Qdrant Cloud and the Qdrant Helm chart access to this is disabled by default.</aside>
 
 ## TLS
 


### PR DESCRIPTION
This adds an (important) warning for users to protect their internal gRPC ports, used for cluster communication in distributed mode. These are not protected by an API key, which may be unexpected.

I'm not 100% happy with this text. @davidmyriel Maybe you can improve it a bit if you'd like.