### PR TITLE
Expose gRPC port in quick start command

### DIFF
--- a/qdrant-landing/content/documentation/quick-start.md
+++ b/qdrant-landing/content/documentation/quick-start.md
@@ -20,7 +20,7 @@ docker pull qdrant/qdrant
 And run the service inside the docker:
 
 ```bash
-docker run -p 6333:6333 \
+docker run -p 6333:6333 -p 6334:6334 \
     -v $(pwd)/qdrant_storage:/qdrant/storage \
     qdrant/qdrant
 ```

--- a/qdrant-landing/content/documentation/quick-start.md
+++ b/qdrant-landing/content/documentation/quick-start.md
@@ -17,7 +17,7 @@ Download image from [DockerHub](https://hub.docker.com/r/qdrant/qdrant):
 docker pull qdrant/qdrant
 ```
 
-And run the service inside the docker:
+And run the service inside the Docker:
 
 ```bash
 docker run -p 6333:6333 -p 6334:6334 \
@@ -36,7 +36,7 @@ Now Qdrant should be accessible at [localhost:6333](http://localhost:6333)
 ![Local mode workflow](https://raw.githubusercontent.com/qdrant/qdrant-client/master/docs/images/try-develop-deploy.png)
 
 
-With python client it is possible to try Qdrant without running docker container at all.
+With python client it is possible to try Qdrant without running Docker container at all.
 
 Simply install it
 


### PR DESCRIPTION
This exposes port 6334 for gRPC in the quick start command.

The gRPC interface seems to be used more commonly. I've seen some issues caused by this port not being exposed. This hopefully prevents that.

Asking @generall for review to approve whether this is a good idea.