### PR TITLE
fix copy content on homepage

### DIFF
--- a/qdrant-landing/content/features/filterable.md
+++ b/qdrant-landing/content/features/filterable.md
@@ -1,5 +1,5 @@
 ---
-title: Filtrable
+title: Filterable
 icon:
   - url: /features/filter.svg
 weight: 30

--- a/qdrant-landing/content/solutions/recommendation-engine.md
+++ b/qdrant-landing/content/solutions/recommendation-engine.md
@@ -10,7 +10,7 @@ default_link:
 default_link_name: 
 weight: 30
 short_description: |
-    User behavior can be represented as a semantic vector is similar way as text or images.
+    User behavior can be represented as a semantic vector in a similar way as text or images.
     Vector database allows you to create a real-time recommendation engine.
     No MapReduce cluster required.
 sitemapExclude: True


### PR DESCRIPTION
A few obvious errors as pointed out by Dave:

-filtrable is a word, although not common and easily mistaken for an error 

-other issue is of grammatical nature in the recommendations section