### PR TITLE
Clearly note that searches don't include payload/vector data by default

### DIFF
--- a/qdrant-landing/content/documentation/concepts/search.md
+++ b/qdrant-landing/content/documentation/concepts/search.md
@@ -137,6 +137,10 @@ Example result of this API would be
 
 The `result` contains ordered by `score` list of found point ids.
 
+Note that payload and vector data is missing in these results by default.
+See [payload and vector in the result](#payload-and-vector-in-the-result) on how
+to include it.
+
 *Available as of v0.10.0*
 
 If the collection was created with multiple vectors, the name of the vector to use for searching should be provided:
@@ -179,8 +183,9 @@ It will exclude all results with a score worse than the given.
 
 ### Payload and vector in the result
 
-By default, retrieval methods do not return any stored information.
-Additional parameters `with_vectors` and `with_payload` could alter this behavior.
+By default, retrieval methods do not return any stored information such as
+payload and vectors. Additional parameters `with_vectors` and `with_payload`
+alter this behavior.
 
 Example:
 

--- a/qdrant-landing/content/documentation/quick-start.md
+++ b/qdrant-landing/content/documentation/quick-start.md
@@ -285,7 +285,10 @@ print(search_result[2])
 # ScoredPoint(id=3, score=1.208, ...)
 ```
 
-But result is different if we add a filter:
+Note that payload and vector data is missing in these results by default.
+See [payload and vector in the result](../concepts/search#payload-and-vector-in-the-result) on how to enable it.
+
+But the result is different if we add a filter:
 
 ```bash
 curl -L -X POST 'http://localhost:6333/collections/test_collection/points/search' \


### PR DESCRIPTION
Clearly note that retrieval methods, such as search, don't return payload or vector data by default. Also point to information on how to enable it if desired.

I've seen various user reports on that this is unexpected and that it could be stated better. This attempts to improve that.