### PR TITLE
Use QdrantVectorStore instead of GPTQdrantIndex that was removed from LI

### DIFF
--- a/qdrant-landing/content/documentation/integrations/llama-index.md
+++ b/qdrant-landing/content/documentation/integrations/llama-index.md
@@ -8,16 +8,17 @@ weight: 200
 LlamaIndex (formerly GPT Index) acts as an interface between your external data and Large Language Models. So you can bring your 
 private data and augment LLMs with it. LlamaIndex simplifies data ingestion and indexing, integrating Qdrant as a vector index.
 
-Installing LlamaIndex is straightforward if we use pip as a package manager:
+Installing LlamaIndex is straightforward if we use pip as a package manager. Qdrant is not installed by default, so we need to 
+install it separately:
 
 ```bash
-pip install llama-index
+pip install llama-index qdrant-client
 ```
 
 LlamaIndex requires providing an instance of `QdrantClient`, so it can interact with Qdrant server.
 
 ```python
-from llama_index import GPTQdrantIndex
+from llama_index.vector_stores.qdrant import QdrantVectorStore
 
 import qdrant_client
 
@@ -26,7 +27,7 @@ client = qdrant_client.QdrantClient(
     api_key="<qdrant-api-key>", # For Qdrant Cloud, None for local instance
 )
 
-index = GPTQdrantIndex.from_documents(documents, client=client, collection_name="documents")
+index = QdrantVectorStore(client=client, collection_name="documents")
 ```
 
 The library [comes with a notebook](https://github.com/jerryjliu/llama_index/blob/main/docs/examples/vector_stores/QdrantIndexDemo.ipynb) 


### PR DESCRIPTION
This PR changes the example of using LlamaIndex. We need a more comprehensive example, and I'll suggest one in a separate PR.