### PR TITLE
ci: fix redundant environment variable specification in `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,17 +2,15 @@
 publish = "qdrant-landing/public"
 command = "cd qdrant-landing ; hugo --gc --minify"
 
-[context.production.environment]
+[build.environment]
 HUGO_VERSION = "0.93.3"
+
+[context.production.environment]
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]
 command = "cd qdrant-landing ; hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
-
-[context.deploy-preview.environment]
-HUGO_VERSION = "0.93.3"
-
 
 [[headers]]
     for = "/*"


### PR DESCRIPTION
## What does this PR do?

Fixes redundant environment variable specification (across contexts) in `netlify.toml`.

## Explanation

The environment variable `HUGO_VERSION` holds the same value for all contexts (production, deploy-preview). Specifying it separately for each context becomes redundant.

Specifying it once under `[build.environment]` should be enough.

## Reference

From https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts :

>any property of a context-aware key, such as [build] or [[plugins]], will be applied to all contexts unless the same property key is present in a more specific context.