### PR TITLE
Add alt text for article cover image

### DIFF
--- a/qdrant-landing/themes/qdrant/layouts/articles/single.html
+++ b/qdrant-landing/themes/qdrant/layouts/articles/single.html
@@ -8,7 +8,7 @@
                 <div class="article__cover mt-lg-5 mb-4">
                     <picture>
                         <source srcset="{{ .Params.preview_dir }}/title.webp" type="image/webp">
-                        <img src="{{ .Params.preview_dir }}/title.jpg">
+                        <img alt="{{ .Title }}" src="{{ .Params.preview_dir }}/title.jpg">
                     </picture>
                 </div>
                 {{ partial "breadcrumbs" . }}

--- a/qdrant-landing/themes/qdrant/layouts/case-studies/single.html
+++ b/qdrant-landing/themes/qdrant/layouts/case-studies/single.html
@@ -8,7 +8,7 @@
                 <div class="article__cover mt-lg-5 mb-4">
                     <picture>
                         <source srcset="{{ .Params.preview_dir }}/title.webp" type="image/webp">
-                        <img src="{{ .Params.preview_dir }}/title.jpg">
+                        <img alt="{{ .Title }}" src="{{ .Params.preview_dir }}/title.jpg">
                     </picture>
                 </div>
                 {{ partial "breadcrumbs" . }}


### PR DESCRIPTION
## What does this PR do?

Adds alt text for cover images.

## What problem does it fix?

By adding alt text to images we can ensure that a webpage conforms to basic [accessibility guidelines](https://www.w3.org/TR/WCAG20-TECHS/H37.html). It also helps search engines [discover and index images](https://developers.google.com/search/docs/appearance/google-images#descriptive-alt-text%20descriptive-titles-captions-filenames).