### PR TITLE
Fix 404 link and use ref shortcode to refer to other pages

### DIFF
--- a/qdrant-landing/content/documentation/cloud/_index.md
+++ b/qdrant-landing/content/documentation/cloud/_index.md
@@ -8,7 +8,7 @@ weight: 20
 Qdrant Cloud is our SaaS (software-as-a-service) solution, providing managed Qdrant instances on the cloud.
 We provide you with the same fast and reliable similarity search engine, but without the need to maintain your own infrastructure.
 
-Transitioning from on-premise to the cloud version of Qdrant does not require changing anything in the way you interact with the service. All you have to do is [create a Qdrant Cloud account](https://qdrant.to/cloud) and [provide a new API key](../cloud/authentication/) to each request. 
+Transitioning from on-premise to the cloud version of Qdrant does not require changing anything in the way you interact with the service. All you have to do is [create a Qdrant Cloud account](https://qdrant.to/cloud) and [provide a new API key]({{< ref "/documentation/cloud/authentication" >}}) to each request.
 
 The transition is even easier if you use the official client libraries. For example, the [Python Client](https://github.com/qdrant/qdrant-client) has the support of the API key already built-in, so you only need to provide it once, when the QdrantClient instance is created.
 
@@ -26,14 +26,13 @@ Each instance comes pre-configured with the following tools, features and suppor
 ### Getting started with Qdrant Cloud
 
 To use Qdrant Cloud, you will need to create at least one cluster. There are two ways to start:
-1. [**Create a Free Tier cluster**](../cloud/quickstart-cloud/) with 1 node and a default configuration (1GB RAM, 0.5 CPU and 4GB Disk). This option is perfect for prototyping and you don't need a credit card to join.
-2. [**Configure a custom cluster**](../cloud/create-cluster/) with additional nodes and more resources. For this option, you will have to provide billing information.
+1. [**Create a Free Tier cluster**]({{< ref "/documentation/cloud/quickstart-cloud" >}}) with 1 node and a default configuration (1GB RAM, 0.5 CPU and 4GB Disk). This option is perfect for prototyping and you don't need a credit card to join.
+2. [**Configure a custom cluster**]({{< ref "/documentation/cloud/create-cluster" >}}) with additional nodes and more resources. For this option, you will have to provide billing information.
 
-We recommend that you use the Free Tier cluster for testing purposes. The capacity should be enough to serve up to 1M vectors of 768dim. To calculate your needs, refer to [capacity planning](../capacity/). 
+We recommend that you use the Free Tier cluster for testing purposes. The capacity should be enough to serve up to 1M vectors of 768dim. To calculate your needs, refer to [capacity planning]({{< ref "/documentation/cloud/capacity-sizing" >}}). 
 
 ### Support & Troubleshooting
 
 All Qdrant Cloud users are welcome to join our [Discord community](https://qdrant.to/discord). Our Support Engineers are available to help you anytime.
 
 Additionally, paid customers can also contact support via channels provided during cluster creation and/or on-boarding.
-


### PR DESCRIPTION
## What does this PR do?

- Fixes link giving 404
- Uses Hugo `ref` shortcode to link other content pages.

## Link to issue

#276 

## References
From https://gohugo.io/content-management/cross-references/

> The `ref` and `relref` shortcodes display the absolute and relative permalinks to a document, respectively.

## Notes for maintainers

- This is applicable to editors who are not familiar with Hugo shortcode and use Netlify CMS. While editing `qdrant-landing\content\documentation\cloud\_index.md`, they may see some strange strings like: 

    ```go
    {{< ref "/documentation/cloud/quickstart-cloud" >}}
    ```
    They should don't delete these since these shortcodes link to other pages.
- Please see the note for maintainers here: #276.