### PR TITLE
Document Kubernetes `healthz`, `readyz` and `livez` endpoints

### DIFF
--- a/qdrant-landing/content/documentation/guides/monitoring.md
+++ b/qdrant-landing/content/documentation/guides/monitoring.md
@@ -51,3 +51,19 @@ There are also some metrics which are exposed in distributed mode only.
 | cluster_commit                   | counter | Index of last committed (finalized) operation cluster peer is aware of |
 | cluster_pending_operations_total | gauge   | Total number of pending operations for cluster peer                    |
 | cluster_voter                    | gauge   | Whether the cluster peer is a voter or learner                         |
+
+## Kubernetes health endpoints
+
+*Available as of v1.5.0*
+
+Qdrant exposes three endpoints, namely `/healthz`, `/livez` and `/readyz`, to
+indicate the current status of the Qdrant server.
+
+These currently provide the most basic status response, returning HTTP 200 if
+Qdrant is started and ready to be used.
+
+Regardless of whether an [API key](../security#authentication) is configured,
+the endpoints are always accessible.
+
+You can read more about Kubernetes health endpoints
+[here](https://kubernetes.io/docs/reference/using-api/health-checks/).


### PR DESCRIPTION
Adds documentation for the `healthz`, `readyz` and `livez` endpoints to be used with Kubernetes.

I'm not super keen on putting this in 'Monitoring', but I didn't want to create yet another page for it.