### PR TITLE
Wrapped tables

### DIFF
--- a/qdrant-landing/themes/qdrant/layouts/articles/single.html
+++ b/qdrant-landing/themes/qdrant/layouts/articles/single.html
@@ -13,7 +13,8 @@
                 </div>
                 {{ partial "breadcrumbs" . }}
                 <h1>{{ .Title }}</h1>
-                {{ .Content }}
+                {{ $wrappedTable := printf "<div class=table-responsive> ${1} </div>" }}
+                {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
             </article>
             <div class="pt-3">{{ partial "author" . }}</div>
             <div class="article__info mt-4">

--- a/qdrant-landing/themes/qdrant/layouts/documentation/list.html
+++ b/qdrant-landing/themes/qdrant/layouts/documentation/list.html
@@ -1,7 +1,8 @@
 {{ define "main" }}
 <article class="documentation__article col-12 col-md-9 col-lg-8 pb-5">
 
-    {{ .Content }}
+    {{ $wrappedTable := printf "<div class=table-responsive> ${1} </div>" }}
+    {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
 
 </article>
 {{ end }}

--- a/qdrant-landing/themes/qdrant/layouts/documentation/single.html
+++ b/qdrant-landing/themes/qdrant/layouts/documentation/single.html
@@ -3,7 +3,8 @@
 <div class="col-12 col-md-9 col-lg-8 pb-5">
 
     <article class="documentation__article">
-        {{ .Content }}
+        {{ $wrappedTable := printf "<div class=table-responsive> ${1} </div>" }}
+        {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
     </article>
 
     <div style="overflow: auto">

--- a/qdrant-landing/themes/qdrant/static/js/script.js
+++ b/qdrant-landing/themes/qdrant/static/js/script.js
@@ -236,11 +236,4 @@
     handlePreloader();
   });
 
-  $('.documentation, .article').each(function() {
-    $(this).find('table').each(function() {
-      // wrap table in a container so that it can be responsive
-      $(this).wrap('<div class="table-responsive"></div>');
-    });
-  });
-
 })(window.jQuery);

--- a/qdrant-landing/themes/qdrant/static/js/script.js
+++ b/qdrant-landing/themes/qdrant/static/js/script.js
@@ -236,4 +236,11 @@
     handlePreloader();
   });
 
+  $('.documentation, .article').each(function() {
+    $(this).find('table').each(function() {
+      // wrap table in a container so that it can be responsive
+      $(this).wrap('<div class="table-responsive"></div>');
+    });
+  });
+
 })(window.jQuery);


### PR DESCRIPTION
This PR adds wrapping tables on documentation pages and on single articles pages into `div.table-responsive`.

Tried variants with js and regex, the second one seems to be better because of working on the building step, which guarantees not to affect user experience.