### PR TITLE
Removed deprecated conditions in the TOC template

### DIFF
--- a/qdrant-landing/themes/qdrant/layouts/partials/table_of_content.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/table_of_content.html
@@ -4,12 +4,8 @@
     {{ $sectionLink := cond .IsSection .RelPermalink .Parent.RelPermalink }}
     {{ $subject := site.GetPage $sectionLink }}
     <div class="sticky-top">
-        {{ range $subject.RegularPages }}
-            {{ if eq .File.UniqueID $currentNode.File.UniqueID }}
-                <h5 class="tableOfContent__header">Table of contents</h5>
-                {{ .TableOfContents }}
-            {{ end }}
-        {{ end }}
+        <h5 class="tableOfContent__header">Table of contents</h5>
+        {{ .TableOfContents }}
         <br/>
     </div>
 </nav>


### PR DESCRIPTION
Deprecated conditions led to missing TOC on the top-level pages of sections, removed them to fix the problem.