### PR TITLE
Describe how to update collection parameters for unnamed vector

### DIFF
--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -293,12 +293,11 @@ client.update_collection(
 )
 ```
 
-For updating vector parameters in a collection that does not have named vectors,
-you can use an empty (`""`) name.
+**Note:** In order to update vector parameters in a collection that does not have named vectors, you can use an empty (`""`) name.
 
 Calls to this endpoint may be blocking as it waits for existing optimizers to
-finish. It is not recommended to use this in a production database as it may
-introduce huge overhead due to rebuilding the index.
+finish. We recommended against using this in a production database as it may
+introduce huge overhead due to the rebuilding of the index.
 
 ## Collection info
 

--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -293,6 +293,9 @@ client.update_collection(
 )
 ```
 
+For updating vector parameters in a collection that does not have named vectors,
+you can use an empty (`""`) name.
+
 Calls to this endpoint may be blocking as it waits for existing optimizers to
 finish. It is not recommended to use this in a production database as it may
 introduce huge overhead due to rebuilding the index.


### PR DESCRIPTION
We've had some support questions on how to update vector parameters in a collection that does not have named vectors.

This adds a note that in such case, an empty vector name is used.