### PR TITLE
update quickstart

### DIFF
--- a/qdrant-landing/content/documentation/quick-start.md
+++ b/qdrant-landing/content/documentation/quick-start.md
@@ -7,8 +7,9 @@ aliases:
 # Quickstart
 
 In this short example, you will use the Python Client to create a Collection, load data into it and run a basic search query. 
+The first few steps will show you how to self-host Qdrant using Docker. However, you can always sign up for [Qdrant Cloud](../cloud/quickstart-cloud/) and spin up a cluster with much less effort. Your first cluster is completely free.
 
-<aside role="status">Before you start, please make sure Docker is installed and running on your system.</aside>
+<aside role="status">Before you start, please make sure Docker is installed and running on your system. You should also have the latest version of Python, so that you can run the code inside of a virtual environment.</aside>
 
 ## Download and run
 
@@ -31,6 +32,8 @@ Under the default configuration all data will be stored in the `./qdrant_storage
 Qdrant should now be accessible at [localhost:6333](http://localhost:6333)
 
 ## Initialize the client 
+
+For local prototyping, we like to use Jupyter Notebooks or Google Colab. Open up your virtual environment to run the following Python code:
 
 ```python
 from qdrant_client import QdrantClient


### PR DESCRIPTION
This PR addresses [308](https://github.com/qdrant/landing_page/issues/308). 
Quickstart users should know that they need to switch over to a venv after self-hosting in Docker.
Just-making it more obvious.
Also, adding more details about Qdrant Cloud.