### PR TITLE
Add link to Web UI in quick start guide

### DIFF
--- a/qdrant-landing/content/documentation/quick-start.md
+++ b/qdrant-landing/content/documentation/quick-start.md
@@ -28,7 +28,7 @@ docker run -p 6333:6333 \
 
 Under the default configuration all data will be stored in the `./qdrant_storage` directory. This will also be the only directory that both the Container and the host machine can both see. 
 
-Qdrant is how accessible:
+Qdrant is now accessible:
 - API: [localhost:6333](http://localhost:6333)
 - Web UI: [localhost:6333/dashboard](http://localhost:6333/dashboard)
 

--- a/qdrant-landing/content/documentation/quick-start.md
+++ b/qdrant-landing/content/documentation/quick-start.md
@@ -28,7 +28,9 @@ docker run -p 6333:6333 \
 
 Under the default configuration all data will be stored in the `./qdrant_storage` directory. This will also be the only directory that both the Container and the host machine can both see. 
 
-Qdrant should now be accessible at [localhost:6333](http://localhost:6333)
+Qdrant is how accessible:
+- API: [localhost:6333](http://localhost:6333)
+- Web UI: [localhost:6333/dashboard](http://localhost:6333/dashboard)
 
 ## Initialize the client 
 


### PR DESCRIPTION
In our quick start guide, we only linked to the API URL after starting the Qdrant container. This adds a link to the Web UI as well.

At the bottom: 
![image](https://github.com/qdrant/landing_page/assets/856222/689ea82c-96e6-4765-95be-1f2262f340f5)
