### PR TITLE
Create a collection: `recreate_collection` -> `create_collection`

### DIFF
--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -48,7 +48,7 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=100, distance=models.Distance.COSINE),
 )


### PR DESCRIPTION
In https://qdrant.tech/documentation/concepts/collections/#create-a-collection, the python example suggests `client.recreate_collection()` which users will take as default. However `recreate` is a client utility for deleting and creating a collection with the same name. It has been a problem for some Discord users who are confused by their collection being deleted.

The utility is useful but I think the introduction to collection creation should not be the place to showcase it.

There are other occurrences of `recreate_collection` in other examples, but I'm not sure if we should change all of them now.