### PR TITLE
Update collections.md to correct list collection aliases section

### DIFF
--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -484,7 +484,7 @@ from qdrant_client import QdrantClient
 
 client = QdrantClient("localhost", port=6333)
 
-client.list_collection_aliases(
+client.get_collection_aliases(
   collection_name="{collection_name}"
 )
 ```


### PR DESCRIPTION
In [Collections page](https://qdrant.tech/documentation/concepts/collections/#list-all-collections) of the documentation, the referred python function for getting the collection alias name is wrong. I couldn't find when it was changed from `list_collection_aliases` to `get_collection_aliases`, but it no longer exists on the codebase. The correct function is `get_collection_aliases` ([link](https://github.com/qdrant/qdrant-client/blob/82ecb104ed919596d7753c1a31017dfada8d3e02/qdrant_client/client_base.py#L221)).

## Changes
* Change referred method from `list_collection_aliases` to `get_collection_aliases`. 