### PR TITLE
Fixed variable name

### DIFF
--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -15,7 +15,7 @@ This feature can be used to archive data or easily replicate an existing deploym
 
 ## Store snapshots
 
-The target directory used to store generated snapshots is controlled through the [configuration](../../guides/configuration) or using the ENV variable: `QDRANT__STORAGE__SNAPSHOT_PATH=./snapshots`.
+The target directory used to store generated snapshots is controlled through the [configuration](../../guides/configuration) or using the ENV variable: `QDRANT__STORAGE__SNAPSHOTS_PATH=./snapshots`.
 
 You can set the snapshots storage directory from the [config.yaml](https://github.com/qdrant/qdrant/blob/master/config/config.yaml) file. If no value is given, default is `./snapshots`.
 ```yaml


### PR DESCRIPTION
The variable name used in config is `snapshots_path`. Hence the related ENV variables is `QDRANT__STORAGE__SNAPSHOTS_PATH`.

Using `QDRANT__STORAGE__SNAPSHOT_PATH` doesn't work.