### PR TITLE
Update `with_payload` examples, also describe using an array directly

### DIFF
--- a/qdrant-landing/content/documentation/concepts/search.md
+++ b/qdrant-landing/content/documentation/concepts/search.md
@@ -209,7 +209,33 @@ client.search(
 )
 ```
 
-Parameter `with_payload` might also be used to `include` or `exclude` specific fields only:
+The parameter `with_payload` may also be used to scope to or filter out a
+specific payload subset. You can specify an array of items to include. For
+example, to include `city`:
+
+```http
+POST /collections/{collection_name}/points/search
+
+{
+    "vector": [0.2, 0.1, 0.9, 0.7],
+    "with_payload": ["city"]
+}
+```
+
+```python
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+
+client = QdrantClient("localhost", port=6333)
+
+client.search(
+    collection_name="{collection_name}",
+    query_vector=[0.2, 0.1, 0.9, 0.7],
+    with_payload=["city"],
+)
+```
+
+Or use `include` or `exclude` explicitly. For example, to exclude `city`:
 
 ```http
 POST /collections/{collection_name}/points/search

--- a/qdrant-landing/content/documentation/concepts/search.md
+++ b/qdrant-landing/content/documentation/concepts/search.md
@@ -209,16 +209,16 @@ client.search(
 )
 ```
 
-The parameter `with_payload` may also be used to scope to or filter out a
-specific payload subset. You can specify an array of items to include. For
-example, to include `city`:
+You can use `with_payload` to scope to or filter a specific payload subset. 
+You can even specify an array of items to include, such as `city`, 
+`village`, and `town`:
 
 ```http
 POST /collections/{collection_name}/points/search
 
 {
     "vector": [0.2, 0.1, 0.9, 0.7],
-    "with_payload": ["city"]
+    "with_payload": ["city", "village", "town"]
 }
 ```
 


### PR DESCRIPTION
The `with_payload` field also supports using an array directly, without explicit `include`/`exclude` usage.

For example:

```json
{
    "with_payload": ["city"]
}
```