### PR TITLE
On `external_url` pages, add redirect in rendered HTML

### DIFF
--- a/qdrant-landing/themes/qdrant/layouts/_default/single.html
+++ b/qdrant-landing/themes/qdrant/layouts/_default/single.html
@@ -2,6 +2,10 @@
 
 <article>
     <div class="auto-container mb-5 mt-5">
+        {{ if (eq .Params.type "external-link") }}
+            Redirecting to <a href="{{ .Params.external_url }}">external page</a>...
+            <meta http-equiv="refresh" content="0; url={{ .Params.external_url }}">
+        {{ end }}
         {{ .Content }}
     </div>
 </article>


### PR DESCRIPTION
Fixes <https://github.com/qdrant/landing_page/issues/346>

Add an automatic redirect on `external_url` pages.

This change now shows the following redirection text on empty pages and immediately redirects the user to the external URL on visit:

![image](https://github.com/qdrant/landing_page/assets/856222/a2bf542a-beca-456e-90b4-4291084df43d)

Rendered: https://deploy-preview-347--condescending-goldwasser-91acf0.netlify.app/documentation/api-reference