### PR TITLE
Article Improvements

### DIFF
--- a/qdrant-landing/content/articles/fastembed.md
+++ b/qdrant-landing/content/articles/fastembed.md
@@ -81,9 +81,9 @@ This model strikes a balance between speed and accuracy, ideal for real-world ap
 embeddings: List[np.ndarray] = list(embedding_model.embed(documents))
 ```
 
-Finally, we call the embed() method on our embedding_model object, passing in the documents list. The method returns a Python generator, so we convert it to a list to get all the embeddings. These embeddings are NumPy arrays, optimized for fast mathematical operations.
+Finally, we call the `embed()` method on our embedding_model object, passing in the documents list. The method returns a Python generator, so we convert it to a list to get all the embeddings. These embeddings are NumPy arrays, optimized for fast mathematical operations.
 
-The embed() method returns a list of NumPy arrays, each corresponding to the embedding of a document in your original documents list. The dimensions of these arrays are determined by the model you chose; for “BAAI/bge-base-en” it’s a 768-dimensional vector.
+The `embed()` method returns a list of NumPy arrays, each corresponding to the embedding of a document in your original documents list. The dimensions of these arrays are determined by the model you chose e.g. for “BAAI/bge-small-en-v1.5” it’s a 384-dimensional vector.
 
 You can easily parse these NumPy arrays for any downstream application—be it clustering, similarity comparison, or feeding them into a machine learning model for further analysis.
 

--- a/qdrant-landing/content/articles/fastembed.md
+++ b/qdrant-landing/content/articles/fastembed.md
@@ -97,6 +97,8 @@ FastEmbed is built for inference speed, without sacrificing (too much) performan
 
 We use `BAAI/bge-small-en-v1.5` as our DefaultEmbedding, hence we've chosen that for comparison:
 
+![](/articles_data/fastembed/throughput.png)
+
 ## Under the Hood
 
 **Quantized Models**: We quantize the models for CPU (and Mac Metal) – giving you the best buck for your compute model. Our default model is so small, you can run this in AWS Lambda if you’d like!

--- a/qdrant-landing/content/articles/fastembed.md
+++ b/qdrant-landing/content/articles/fastembed.md
@@ -49,10 +49,10 @@ These 3 lines of code do a lot of heavy lifting for you: They download the quant
 Let’s delve into a more advanced example code snippet line-by-line:
 
 ```python
-from fastembed.embedding import FlagEmbedding as Embedding
+from fastembed.embedding import DefaultEmbedding
 ```
 
-Here, we import the FlagEmbedding class from FastEmbed and alias it as Embedding. This is the core class responsible for generating embeddings based on your chosen text model. This is also the class which you can import directly as DefaultEmbedding which is BAAI/bge-small-en
+Here, we import the FlagEmbedding class from FastEmbed and alias it as Embedding. This is the core class responsible for generating embeddings based on your chosen text model. This is also the class which you can import directly as DefaultEmbedding which is [BAAI/bge-small-en-v1.5](https://huggingface.co/baai/bge-small-en-v1.5)
 
 ```python
 documents: List[str] = [
@@ -69,10 +69,10 @@ Note the use of prefixes “passage” and “query” to differentiate the type
 
 The use of text prefixes like “query” and “passage” isn’t merely syntactic sugar; it informs the algorithm on how to treat the text for embedding generation. A “query” prefix often triggers the model to generate embeddings that are optimized for similarity comparisons, while “passage” embeddings are fine-tuned for contextual understanding. If you omit the prefix, the default behavior is applied, although specifying it is recommended for more nuanced results.
 
-Next, we initialize the Embedding model with the model name “BAAI/bge-base-en” and specify a maximum token length of 512.
+Next, we initialize the Embedding model with the default model: [BAAI/bge-small-en-v1.5](https://huggingface.co/baai/bge-small-en-v1.5) and specify a maximum token length of 512.
 
 ```python
-embedding_model = Embedding(model_name="BAAI/bge-base-en", max_length=512)
+embedding_model = DefaultEmbedding()
 ```
 
 This model strikes a balance between speed and accuracy, ideal for real-world applications.

--- a/qdrant-landing/content/articles/fastembed.md
+++ b/qdrant-landing/content/articles/fastembed.md
@@ -203,7 +203,7 @@ client.add(
 )
 ```
 
-Behind the scenes, Qdrant is using FastEmbed to make the text embedding, generate ids if they’re missing and then adding them to the index with metadata.
+Behind the scenes, Qdrant is using FastEmbed to make the text embedding, generate ids if they’re missing and then adding them to the index with metadata. This uses the DefaultEmbedding model: [BAAI/bge-small-en-v1.5](https://huggingface.co/baai/bge-small-en-v1.5)
 
 ![INDEX TIME: Sequence Diagram for Qdrant and FastEmbed](/articles_data/fastembed/image2.png)
 


### PR DESCRIPTION
1. Explicitly mentions the default embedding model when we use the qdrant client with a link. 

2. Added hugging face link to the default model we use

3. Consistent model usage through the article: Removed the base-en model mention which is 768 dim, since that was making it harder to follow