### PR TITLE
fix: broken link at concepts/collections

### DIFF
--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -212,7 +212,7 @@ client.update_collection(
 
 The following parameters can be updated:
 
-* `optimizers_config` - see [optimizer](./optimizer/) for details.
+* `optimizers_config` - see [optimizer](../optimizer/) for details.
 * `hnsw_config` - see [indexing](../indexing/#vector-index) for details.
 * `quantization_config` - see [quantization](../../guides/quantization/#setting-up-quantization-in-qdrant) for details.
 * `vectors` - vector-specific configuration, including individual `hnsw_config`, `quantization_config` and `on_disk` settings.


### PR DESCRIPTION
Leads to https://qdrant.tech/documentation/concepts/collections/optimizer/ instead of https://qdrant.tech/documentation/concepts/optimizer/.