### PR TITLE
Add TypeScript examples for Documentation / Guides

### DIFF
--- a/qdrant-landing/content/documentation/faq/database-optimization.md
+++ b/qdrant-landing/content/documentation/faq/database-optimization.md
@@ -19,24 +19,26 @@ Read more about [configuring the optimal](../../tutorials/optimize/) use of Qdra
 
 There are two main scenarios of Qdrant usage in terms of resource consumption:
 
-- **Performance-optimized** - when you need to serve vector search as fast(many) as possible. In this case, you need to have as much vector data in RAM as possible. Use our [calculator](https://cloud.qdrant.io/calculator) to estimate the required RAM.
-- **Storage-optimized** - when you need to store many vectors and minimize costs by compromising some search speed. In this case, pay attention to the disk speed instead. More about it in the article about [Memory Consumption](../../../articles/memory-consumption/).
+- **Performance-optimized** -- when you need to serve vector search as fast (many) as possible. In this case, you need to have as much vector data in RAM as possible. Use our [calculator](https://cloud.qdrant.io/calculator) to estimate the required RAM.
+- **Storage-optimized** -- when you need to store many vectors and minimize costs by compromising some search speed. In this case, pay attention to the disk speed instead. More about it in the article about [Memory Consumption](../../../articles/memory-consumption/).
 
 ### I configured on-disk vector storage, but memory usage is still high. Why? 
 
-First of all, memory usage metrics as reported by `top` or `htop` might be misleading. They are not showing the amount of memory required to run the service.
-If you see RSS memory usage of 10GB, it doesn't mean that it won't work on a machine with 8GB of RAM.
+Firstly, memory usage metrics as reported by `top` or `htop` may be misleading. They are not showing the minimal amount of memory required to run the service.
+If the RSS memory usage is 10 GB, it doesn't mean that it won't work on a machine with 8 GB of RAM.
 
-Qdrant uses many techniques to reduce search latency, including caching the disk data in RAM and preloading the data from disk to RAM.
+Qdrant uses many techniques to reduce search latency, including caching disk data in RAM and preloading data from disk to RAM.
 As a result, the Qdrant process might use more memory than the minimum required to run the service.
 
-If you want to limit the memory usage of the service, we recommend using [limits in docker](https://docs.docker.com/config/containers/resource_constraints/#memory) or Kubernetes.
+> Unused RAM is wasted RAM
+
+If you want to limit the memory usage of the service, we recommend using [limits in Docker](https://docs.docker.com/config/containers/resource_constraints/#memory) or Kubernetes.
 
 
 ### My requests are very slow or time out. What should I do?
 
 There are several possible reasons for that:
 
-- **Using filters without payload index** - If you're performing a search with a filter but you don't have a payload index, Qdrant will have to load whole payload data from disk to check the filtering condition. Ensure you have adequately configured [payload indexes](../../concepts/indexing/#payload-index).
-- **Usage of on-disk vector storage with slow disks** - If you're using on-disk vector storage, ensure you have fast enough disks. We recommend using local SSDs with at least 50k IOPS. Read more about the influence of the disk speed on the search latency in the article about [Memory Consumption](../../../articles/memory-consumption/).
-- **Large limit or nonoptimal query parameters** - A large limit or offset might lead to significant performance degradation. Please pay close attention to the query/collection parameters that significantly diverge from the defaults. They might be the reason for the performance issues.
+- **Using filters without payload index** -- If you're performing a search with a filter but you don't have a payload index, Qdrant will have to load whole payload data from disk to check the filtering condition. Ensure you have adequately configured [payload indexes](../../concepts/indexing/#payload-index).
+- **Usage of on-disk vector storage with slow disks** -- If you're using on-disk vector storage, ensure you have fast enough disks. We recommend using local SSDs with at least 50k IOPS. Read more about the influence of the disk speed on the search latency in the article about [Memory Consumption](../../../articles/memory-consumption/).
+- **Large limit or non-optimal query parameters** -- A large limit or offset might lead to significant performance degradation. Please pay close attention to the query/collection parameters that significantly diverge from the defaults. They might be the reason for the performance issues.

--- a/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
+++ b/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
@@ -10,7 +10,7 @@ weight: 1
 As much as you want, but be aware that each collection requires additional resources.
 It is _highly_ recommended not to create many small collections, as it will lead to significant resource consumption overhead.
 
-We consider creating a collection for each user/dialog/document as an anti-pattern.
+We consider creating a collection for each user/dialog/document as an antipattern.
 
 Please read more about collections, isolation, and multiple users in our [Multitenancy](../../tutorials/multiple-partitions/) tutorial.
 
@@ -38,13 +38,13 @@ What Qdrant can do:
 
 What Qdrant plans to introduce in the future:
 
-- Support for sparse vectors, as used in [SPADE](https://github.com/naver/splade) or similar model
+- Support for sparse vectors, as used in [SPADE](https://github.com/naver/splade) or similar models
 
 What Qdrant doesn't plan to support:
 
 - BM25 or other non-vector-based retrieval or ranking functions
 - Built-in ontologies or knowledge graphs
-- Query analizers and other NLP tools
+- Query analyzers and other NLP tools
 
 Of course, you can always combine Qdrant with any specialized tool you need, including full-text search engines.
 Read more about [our approach](../../../articles/hybrid-search/) to hybrid search.  
@@ -68,7 +68,7 @@ But in some cases, we might be able to help you with that through manual interve
 
 ### How do I avoid issues when updating to the latest version?
 
-We only guarantee compatibility if you update between consequent versions. You would need to upgrade versions one at a time 1.1 -> 1.2, then 1.2 -> 1.3, then 1.3 -> 1.4.
+We only guarantee compatibility if you update between consequent versions. You would need to upgrade versions one at a time: `1.1 -> 1.2`, then `1.2 -> 1.3`, then `1.3 -> 1.4`.
 
 ### Do you guarantee compatibility across versions?
 

--- a/qdrant-landing/content/documentation/guides/administration.md
+++ b/qdrant-landing/content/documentation/guides/administration.md
@@ -28,7 +28,7 @@ POST /locks
 
 Write flags enables/disables write lock.
 If the write lock is set to true, qdrant doesn't allow creating new collections or adding new data to the existing storage.
-However deletion operations or updates are not forbidden under the write lock.
+However, deletion operations or updates are not forbidden under the write lock.
 This feature enables administrators to prevent a qdrant process from using more disk space while permitting users to search and delete unnecessary data.
 
 You can optionally provide the error message that should be used for error responses to users.

--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -388,7 +388,7 @@ Qdrant provides a few options to control consistency guarantees:
 - Write `ordering` param, can be used with update and delete operations to ensure that the operations are executed in the same order on all replicas. If this option is used, qdrant will route the operation to the leader replica of the shard and wait for the response before responding to the client. This option is useful to avoid data inconsistency in case of concurrent updates of the same documents. This options is preferred if read operations are more frequent than update and if search performance is critical.
 
 
-### Write concern factor
+### Write consistency factor
 
 The `write_consistency_factor` represents the number of replicas that must acknowledge a write operation before responding to the client. It is set to one by default.
 It can be configured at the collection's creation time.

--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -150,11 +150,25 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     name="{collection_name}",
     vectors_config=models.VectorParams(size=300, distance=models.Distance.COSINE),
-    shard_number=6
+    shard_number=6,
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 300,
+    distance: "Cosine",
+  },
+  shard_number: 6,
+});
 ```
 
 We recommend selecting the number of shards as a factor of the number of nodes you are currently running in your cluster.
@@ -225,12 +239,27 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     name="{collection_name}",
     vectors_config=models.VectorParams(size=300, distance=models.Distance.COSINE),
     shard_number=6,
     replication_factor=2,
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 300,
+    distance: "Cosine",
+  },
+  shard_number: 6,
+  replication_factor: 2,
+});
 ```
 
 This code sample creates a collection with a total of 6 logical shards backed by a total of 12 physical shards.
@@ -384,13 +413,29 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     name="{collection_name}",
     vectors_config=models.VectorParams(size=300, distance=models.Distance.COSINE),
     shard_number=6,
     replication_factor=2,
     write_consistency_factor=2,
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 300,
+    distance: "Cosine",
+  },
+  shard_number: 6,
+  replication_factor: 2,
+  write_consistency_factor: 2,
+});
 ```
 
 Write operations will fail if the number of active replicas is less than the `write_consistency_factor`.
@@ -442,14 +487,26 @@ client.search(
             )
         ]
     ),
-    search_params=models.SearchParams(
-        hnsw_ef=128,
-        exact=False
-    ),
+    search_params=models.SearchParams(hnsw_ef=128, exact=False),
     query_vector=[0.2, 0.1, 0.9, 0.7],
     limit=3,
     consistency="majority",
 )
+```
+
+```typescript
+client.search("{collection_name}", {
+  filter: {
+    must: [{ key: "city", match: { value: "London" } }],
+  },
+  params: {
+    hnsw_ef: 128,
+    exact: false,
+  },
+  vector: [0.2, 0.1, 0.9, 0.7],
+  limit: 3,
+  consistency: "majority",
+});
 ```
 
 ### Write ordering
@@ -497,10 +554,25 @@ client.upsert(
             [0.9, 0.1, 0.1],
             [0.1, 0.9, 0.1],
             [0.1, 0.1, 0.9],
-        ]
+        ],
     ),
-    ordering="strong"
+    ordering="strong",
 )
+```
+
+```typescript
+client.upsert("{collection_name}", {
+  batch: {
+    ids: [1, 2, 3],
+    payloads: [{ color: "red" }, { color: "green" }, { color: "blue" }],
+    vectors: [
+      [0.9, 0.1, 0.1],
+      [0.1, 0.9, 0.1],
+      [0.1, 0.1, 0.9],
+    ],
+  },
+  ordering: "strong",
+});
 ```
 
 

--- a/qdrant-landing/content/documentation/guides/multiple-partitions.md
+++ b/qdrant-landing/content/documentation/guides/multiple-partitions.md
@@ -59,9 +59,36 @@ client.upsert(
             payload={"group_id": "user_2"},
             vector=[0.1, 0.1, 0.9],
         ),
-    ]
+    ],
 )
 ```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.upsert("{collection_name}", {
+  points: [
+    {
+      id: 1,
+      payload: { group_id: "user_1" },
+      vector: [0.9, 0.1, 0.1],
+    },
+    {
+      id: 2,
+      payload: { group_id: "user_1" },
+      vector: [0.1, 0.9, 0.1],
+    },
+    {
+      id: 3,
+      payload: { group_id: "user_2" },
+      vector: [0.1, 0.1, 0.9],
+    },
+  ],
+});
+```
+
 2. Use a filter along with `group_id` to filter vectors for each user.
 
 ```http
@@ -104,6 +131,21 @@ client.search(
     limit=10,
 )
 ```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.search("{collection_name}", {
+  filter: {
+    must: [{ key: "group_id", match: { value: "user_1" } }],
+  },
+  vector: [0.1, 0.1, 0.9],
+  limit: 10,
+});
+```
+
 ## Calibrate performance
 
 The speed of indexation may become a bottleneck in this case, as each user's vector will be indexed into the same collection. To avoid this bottleneck, consider _bypassing the construction of a global vector index_ for the entire collection and building it only for individual groups instead.
@@ -135,7 +177,7 @@ from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     hnsw_config=models.HnswConfigDiff(
@@ -143,6 +185,23 @@ client.recreate_collection(
         m=0,
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  hnsw_config: {
+    payload_m: 16,
+    m: 0,
+  },
+});
 ```
 
 3. Create keyword payload index for `group_id` field.
@@ -158,10 +217,17 @@ PUT /collections/{collection_name}/index
 
 ```python
 client.create_payload_index(
-  collection_name="{collection_name}", 
-  field_name="group_id", 
-  field_schema=models.PayloadSchemaType.KEYWORD
+    collection_name="{collection_name}",
+    field_name="group_id",
+    field_schema=models.PayloadSchemaType.KEYWORD,
 )
+```
+
+```typescript
+client.createPayloadIndex("{collection_name}", {
+  field_name: "group_id",
+  field_schema: "keyword",
+});
 ```
 
 ## Limitations

--- a/qdrant-landing/content/documentation/guides/optimize.md
+++ b/qdrant-landing/content/documentation/guides/optimize.md
@@ -48,7 +48,7 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(memmap_threshold=20000),
@@ -59,6 +59,28 @@ client.recreate_collection(
         ),
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  optimizers_config: {
+    memmap_threshold: 20000,
+  },
+  quantization_config: {
+    scalar: {
+      type: "int8",
+      always_ram: true,
+    },
+  },
+});
 ```
 
 `mmmap_threshold` will ensure that vectors will be stored on disk, while `always_ram` will ensure that quantized vectors will be stored in RAM.
@@ -89,11 +111,24 @@ client.search(
     collection_name="{collection_name}",
     query_vector=[0.2, 0.1, 0.9, 0.7],
     search_params=models.SearchParams(
-        quantization=models.QuantizationSearchParams(
-            rescore=False
-        )
-    )
+        quantization=models.QuantizationSearchParams(rescore=False)
+    ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.search("{collection_name}", {
+  vector: [0.2, 0.1, 0.9, 0.7],
+  params: {
+    quantization: {
+      rescore: false,
+    },
+  },
+});
 ```
 
 ## Prefer high precision with low memory footprint
@@ -122,12 +157,31 @@ from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(memmap_threshold=20000),
-    hnsw_config=models.HnswConfigDiff(on_disk=True)
+    hnsw_config=models.HnswConfigDiff(on_disk=True),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  optimizers_config: {
+    memmap_threshold: 20000,
+  },
+  hnsw_config: {
+    on_disk: true,
+  },
+});
 ```
 
 In this scenario you can increase the precision of the search by increasing the `ef` and `m` parameters of the HNSW index, even with limited RAM.
@@ -178,7 +232,7 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(memmap_threshold=20000),
@@ -189,6 +243,28 @@ client.recreate_collection(
         ),
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  optimizers_config: {
+    memmap_threshold: 20000,
+  },
+  quantization_config: {
+    scalar: {
+      type: "int8",
+      always_ram: true,
+    },
+  },
+});
 ```
 
 There are also some search-time parameters you can use to tune the search accuracy and speed:
@@ -213,13 +289,25 @@ client = QdrantClient("localhost", port=6333)
 
 client.search(
     collection_name="{collection_name}",
-    search_params=models.SearchParams(
-        hnsw_ef=128,
-        exact=False
-    ),
+    search_params=models.SearchParams(hnsw_ef=128, exact=False),
     query_vector=[0.2, 0.1, 0.9, 0.7],
     limit=3,
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.search("{collection_name}", {
+  vector: [0.2, 0.1, 0.9, 0.7],
+  params: {
+    hnsw_ef: 128,
+    exact: false,
+  },
+  limit: 3,
+});
 ```
 
 - `hnsw_ef` - controls the number of neighbors to visit during search. The higher the value, the more accurate and slower the search will be. Recommended range is 32-512.
@@ -256,11 +344,27 @@ from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(default_segment_number=16),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  optimizers_config: {
+    default_segment_number: 16,
+  },
+});
 ```
 
 To prefer throughput, you can set up Qdrant to use as many cores as possible for processing multiple requests in parallel.
@@ -268,7 +372,6 @@ To do that, you can configure qdrant to use minimal number of segments, which is
 Large segments benefit from the size of the index and overall smaller number of vector comparisons required to find the nearest neighbors. But at the same time require more time to build index.
 
 ```http
-
 PUT /collections/{collection_name}
 
 {
@@ -287,9 +390,25 @@ from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(default_segment_number=2),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  optimizers_config: {
+    default_segment_number: 2,
+  },
+});
 ```

--- a/qdrant-landing/content/documentation/guides/quantization.md
+++ b/qdrant-landing/content/documentation/guides/quantization.md
@@ -171,7 +171,7 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     quantization_config=models.ScalarQuantization(
@@ -182,6 +182,26 @@ client.recreate_collection(
         ),
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  quantization_config: {
+    scalar: {
+      type: "int8",
+      quantile: 0.99,
+      always_ram: true,
+    },
+  },
+});
 ```
 
 There are 3 parameters that you can specify in the `quantization_config` section:
@@ -227,7 +247,7 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=1536, distance=models.Distance.COSINE),
     quantization_config=models.BinaryQuantization(
@@ -236,6 +256,24 @@ client.recreate_collection(
         ),
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 1536,
+    distance: "Cosine",
+  },
+  quantization_config: {
+    binary: {
+      always_ram: true,
+    },
+  },
+});
 ```
 
 `always_ram` - whether to keep quantized vectors always cached in RAM or not. By default, quantized vectors are loaded in the same way as the original vectors.
@@ -270,7 +308,7 @@ from qdrant_client.http import models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     quantization_config=models.ProductQuantization(
@@ -280,6 +318,25 @@ client.recreate_collection(
         ),
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  quantization_config: {
+    product: {
+      compression: "x16",
+      always_ram: true,
+    },
+  },
+});
 ```
 
 There are two parameters that you can specify in the `quantization_config` section:
@@ -329,8 +386,26 @@ client.search(
             rescore=True,
             oversampling=2.0,
         )
-    )
+    ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.search("{collection_name}", {
+  vector: [0.2, 0.1, 0.9, 0.7],
+  params: {
+    quantization: {
+      ignore: false,
+      rescore: true,
+      oversampling: 2.0,
+    },
+  },
+  limit: 10,
+});
 ```
 
 `ignore` - Toggle whether to ignore quantized vectors during the search process. By default, Qdrant will use quantized vectors if they are available.
@@ -370,7 +445,7 @@ POST /collections/{collection_name}/points/search
 ```
 
 ```python
-from qdrant_client import QdrantClient
+from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
@@ -381,8 +456,23 @@ client.search(
         quantization=models.QuantizationSearchParams(
             ignore=True,
         )
-    )
+    ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.search("{collection_name}", {
+  vector: [0.2, 0.1, 0.9, 0.7],
+  params: {
+    quantization: {
+      ignore: true,
+    },
+  },
+});
 ```
 
 - **Adjust the quantile parameter**: The quantile parameter in scalar quantization determines the quantization bounds.
@@ -426,12 +516,11 @@ PUT /collections/{collection_name}
 ```
 
 ```python
-from qdrant_client import QdrantClient
-from qdrant_client.http import models
+from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(memmap_threshold=20000),
@@ -442,6 +531,28 @@ client.recreate_collection(
         ),
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  optimizers_config: {
+    memmap_threshold: 20000,
+  },
+  quantization_config: {
+    scalar: {
+      type: "int8",
+      always_ram: true,
+    },
+  },
+});
 ```
 
 In this scenario, the number of disk reads may play a significant role in the search speed.
@@ -464,8 +575,7 @@ POST /collections/{collection_name}/points/search
 ```
 
 ```python
-from qdrant_client import QdrantClient
-from qdrant_client.http import models
+from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
@@ -473,14 +583,25 @@ client.search(
     collection_name="{collection_name}",
     query_vector=[0.2, 0.1, 0.9, 0.7],
     search_params=models.SearchParams(
-        quantization=models.QuantizationSearchParams(
-            rescore=False
-        )
-    )
+        quantization=models.QuantizationSearchParams(rescore=False)
+    ),
 )
 ```
 
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
 
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.search("{collection_name}", {
+  vector: [0.2, 0.1, 0.9, 0.7],
+  params: {
+    quantization: {
+      rescore: false,
+    },
+  },
+});
+```
 
 - **All on Disk** - all vectors, original and quantized, are stored on disk. This mode allows to achieve the smallest memory footprint, but at the cost of the search speed.
 
@@ -509,11 +630,11 @@ PUT /collections/{collection_name}
 ```
 
 ```python
-from qdrant_client import QdrantClient
+from qdrant_client import QdrantClient, models
 
 client = QdrantClient("localhost", port=6333)
 
-client.recreate_collection(
+client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),
     optimizers_config=models.OptimizersConfigDiff(memmap_threshold=20000),
@@ -524,4 +645,26 @@ client.recreate_collection(
         ),
     ),
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  vectors: {
+    size: 768,
+    distance: "Cosine",
+  },
+  optimizers_config: {
+    memmap_threshold: 20000,
+  },
+  quantization_config: {
+    scalar: {
+      type: "int8",
+      always_ram: false,
+    },
+  },
+});
 ```

--- a/qdrant-landing/content/documentation/guides/security.md
+++ b/qdrant-landing/content/documentation/guides/security.md
@@ -56,11 +56,21 @@ curl \
 ```python
 from qdrant_client import QdrantClient
 
-qdrant_client = QdrantClient(
+client = QdrantClient(
     url="https://localhost",
     port=6333,
     api_key="your_secret_api_key_here",
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({
+  url: "http://localhost",
+  port: 6333,
+  apiKey: "your_secret_api_key_here",
+});
 ```
 
 <aside role="alert">Internal communication channels are <strong>never</strong> protected by an API key. Internal gRPC uses port 6335 by default if running in distributed mode. You must ensure that this port is not publicly reachable and can only be used for node communication. By default, this setting is disabled for Qdrant Cloud and the Qdrant Helm chart.</aside>
@@ -116,10 +126,16 @@ curl -X GET https://localhost:6333
 ```python
 from qdrant_client import QdrantClient
 
-qdrant_client = QdrantClient(
+client = QdrantClient(
     url="https://localhost",
     port=6333,
 )
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ url: "https://localhost", port: 6333 });
 ```
 
 Certificate rotation is enabled with a default refresh time of one hour. This


### PR DESCRIPTION
This PR covers all the Python examples in Documentation / Guides with their counterparts in TypeScript.