### PR TITLE
feat: Add case studies link to website footer

### DIFF
--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -124,9 +124,16 @@ keywords = "search engine, vector database, neural network, matching, filter, Sa
     url = "/demo/"
 
   [[menu.main]]
+    identifier = "case-studies"
+    name = "Case Studies"
+    weight = 5
+    parent = "product"
+    url = "/case-studies/"
+
+  [[menu.main]]
     identifier = "pricing"
     name = "Pricing"
-    weight = 5
+    weight = 6
     parent = "product"
     url = "/pricing/"
 


### PR DESCRIPTION
This should help with making it more visible. I almost couldn't find it. 