### PR TITLE
Fix rendering RSS in Hugo 0.120.1

### DIFF
--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -9,9 +9,7 @@ canonifyURLs = true
 
 keywords = "search engine, vector database, neural network, matching, filter, SaaS, approximate nearest neighbor search, image search, recommender system, vectors, knn algorithm, hnsw, vector search, embeddings, similarity"
 
-
 [params]
-  author = "Andrey Vasnetsov"
   description = "Qdrant is an Open-Source Vector Database and Vector Search Engine written in Rust. It provides fast and scalable vector similarity search service with convenient API."
   keywords = ["vector search engine", "neural network", "matching", "SaaS",
     "approximate nearest neighbor search", "image search", "recommender system", "vectors",
@@ -78,6 +76,10 @@ keywords = "search engine, vector database, neural network, matching, filter, Sa
   cloudDocVersion = "v0.1.x"
 
   googleTagManager = "GTM-KRLCXD5"
+
+[params.author]
+  name = "Andrey Vasnetsov"
+  email = "info@qdrant.tech"
 
 [taxonomies]
     tag = "tags"


### PR DESCRIPTION
One of the GH actions was failing due to the recent release of Hugo.
See: https://github.com/qdrant/landing_page/actions/runs/6704856656/job/18218119886?pr=376

This PR changes the config.toml, so all the variables are exposed properly.