### PR TITLE
docs: Remove duplication /benchmarks

### DIFF
--- a/qdrant-landing/content/benchmarks/benchmark-faq.md
+++ b/qdrant-landing/content/benchmarks/benchmark-faq.md
@@ -8,15 +8,6 @@ weight: 10
 
 # Benchmarks F.A.Q.
 
-## Are we biased?
-
-Of course, we are! Even if we try to be objective, we are not experts in using all the existing vector databases.
-We develop Qdrant and try to make it stand out from the crowd.
-Due to that, we could have missed some important tweaks in different engines.
-
-We tried our best, kept scrolling the docs up and down, and experimented with different configurations to get the most out of the tools. However, we believe you can do it better than us, so all **benchmarks are fully open-sourced, and contributions are welcome**!
-
-
 ## What do we measure?
 
 There are several factors considered while deciding on which database to use.
@@ -51,7 +42,7 @@ We do, however, use the same benchmark datasets as the famous [ann-benchmarks pr
 
 There is no consensus in the world of vector databases when it comes to the best technology to implement such a tool.
 You’re free to choose Go, Java or Rust-based systems. 
-But you’re most likely to generate your embeddings using Python with PyTorch or Tensorflow, as according to stats it is the most commonly used language for Deep Learning.
+But you’re most likely to generate your embeddings using Python with PyTorch or TensorFlow, as according to stats it is the most commonly used language for Deep Learning.
 Thus, you’re probably going to use Python to put the created vectors in the database of your choice either way.
 For that reason, using Go, Java or Rust clients will rarely happen in the typical pipeline - although, we encourage you to adopt Rust stack if you care about the performance of your application.
 Python clients are also the most popular clients among all the engines, just by looking at the number of GitHub stars.


### PR DESCRIPTION
The PR intends to remove content duplication at /benchmarks.
Duplicated content:
- https://qdrant.tech/benchmarks/#are-we-biased
- https://qdrant.tech/benchmarks/#disclaimer
