### PR TITLE
Mike Jang's proposed readability improvement

### DIFF
--- a/qdrant-landing/content/documentation/overview/_index.md
+++ b/qdrant-landing/content/documentation/overview/_index.md
@@ -9,15 +9,18 @@ aliases:
 
 ![qdrant](https://qdrant.tech/images/logo_with_text.png)
 
-Vector databases are a relatively new way for interacting with abstract data representations 
-derived from opaque machine learning models such as deep learning architectures. These 
-representations are often called vectors or embeddings and they are a compressed version of 
-the data used to train a machine learning model to accomplish a task like sentiment analysis, 
-speech recognition, object detection, and many others.
+Vector databases can help you interact with machine learning models. As a compressed version of data used to train such models, it can help you accomplish tasks like:
 
-These new databases shine in many applications like [semantic search](https://en.wikipedia.org/wiki/Semantic_search) 
-and [recommendation systems](https://en.wikipedia.org/wiki/Recommender_system), and here, we'll 
-learn about one of the most popular and fastest growing vector databases in the market, [Qdrant](https://qdrant.tech).
+- Sentiment analysis
+- Speech recognition
+- Object detection
+
+These new databases shine in applications such as:
+
+- [Semantic search](https://en.wikipedia.org/wiki/Semantic_search)
+- [Recommendation systems](https://en.wikipedia.org/wiki/Recommender_system)
+
+We'll learn about one of the most popular and fastest growing vector databases in the market, [Qdrant](https://qdrant.tech).
 
 ## What is Qdrant?
 


### PR DESCRIPTION
In this PR, I'm improving the "readability" of https://qdrant.tech/documentation/overview/. I've used [Vale](https://vale.sh) to measure the [Flesch-Kincaid](https://readabilityformulas.com/learn-how-to-use-the-flesch-kincaid-grade-level/) readability of that section.

The readability of the [current section is > 18](https://drive.google.com/file/d/1-sHNg7RiPthf2KsruKZvr879HVp7-ENv/view?usp=drive_link). In other words, a typical user would stress as if they were reading a US graduate school textbook.

As shown in the linked screenshot, Vale includes suggestions to address this problem.

The readability of my [proposed change is 8.5](https://drive.google.com/file/d/14XbtRb9JMyTb5esHC7lKQSxjYfYnuWJL/view?usp=drive_link). A knowledgeable user who can read at a US high school level can understand this content, at a glance.