### PR TITLE
Fixed typo in the neural-search.md tutorial

### DIFF
--- a/qdrant-landing/content/documentation/tutorials/neural-search.md
+++ b/qdrant-landing/content/documentation/tutorials/neural-search.md
@@ -256,7 +256,7 @@ from qdrant_client.models import Filter
         "must": [{
             "key": "city", # Store city information in a field of the same name 
             "match": { # This condition checks if payload field has the requested value
-                "value": "city_of_interest"
+                "value": city_of_interest
             }
         }]
     })


### PR DESCRIPTION

I opened issue #404 about a typo in the [Create a Simple Neural Search Service](https://qdrant.tech/documentation/tutorials/neural-search) tutorial.

```
    city_of_interest = "Berlin"

    # Define a filter for cities
    city_filter = Filter(**{
        "must": [{
            "key": "city", # Store city information in a field of the same name 
            "match": { # This condition checks if payload field has the requested value
                "value": "city_of_interest"
            }
        }]
    })
```

I fixed the typo by replacing the line:
`                "value": "city_of_interest"`
with:
`                "value": city_of_interest`
