### PR TITLE
ID admin tools, correct grammar

### DIFF
--- a/qdrant-landing/content/documentation/guides/administration.md
+++ b/qdrant-landing/content/documentation/guides/administration.md
@@ -7,7 +7,12 @@ aliases:
 
 # Administration
 
-Qdrant exposes administration tools which enable to modify at runtime the behavior of a qdrant instance without changing its configuration manually.
+Qdrant exposes administration tools which allow you to modify the behavior of a Qdrant instance at runtime:
+
+- [Locking](#locking)
+- [Recovery mode](#recovery-mode)
+
+You do not have to change the instance configuration manually.
 
 ## Locking
 


### PR DESCRIPTION
I've modified the intro to:

- Help readers ID the admin tools at a glance. Readers who already know how to set up `Locking` and `Recovery mode` won't need to go further. Readers who don't know will have links to both.
- Correct grammar.
- Capitalize "Qdrant"

IMO, the whole page could use a good rewrite, but one step at a time.