### PR TITLE
Document snapshot priority

### DIFF
--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -251,7 +251,6 @@ To recover from an URL you specify a request parameter:
 
 ```http
 PUT /collections/{collection_name}/snapshots/recover
-
 {
   "location": "http://qdrant-node-1:6333/collections/{collection_name}/snapshots/snapshot-2022-10-10.shapshot",
   "priority": "snapshot"

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -207,8 +207,7 @@ import { QdrantClient } from "@qdrant/js-client-rest";
 const client = new QdrantClient({ host: "localhost", port: 6333 });
 
 client.recoverSnapshot("{collection_name}", {
-  location:
-    "http://qdrant-node-1:6333/collections/collection_name/snapshots/snapshot-2022-10-10.shapshot",
+  location: "http://qdrant-node-1:6333/collections/collection_name/snapshots/snapshot-2022-10-10.shapshot",
 });
 ```
 
@@ -218,7 +217,6 @@ The recovery snapshot can also be uploaded as a file to the Qdrant server:
 curl -X POST 'http://qdrant-node-1:6333/collections/collection_name/snapshots/upload' \
     -H 'Content-Type:multipart/form-data' \
     -F 'snapshot=@/path/to/snapshot-2022-10-10.shapshot'
-
 ```
 
 <aside role="status">You probably want to set the <a href="#snapshot-priority">snapshot priority</a> explicitly during recovery to prevent unexpected results.</aside>
@@ -248,6 +246,48 @@ contain any points and that source was preferred.
 managing shards and transferring shards between clusters manually without any
 additional synchronization. Using it incorrectly will leave your cluster in a
 broken state.
+
+For recovery from an URL you specify a request parameter:
+
+```http
+PUT /collections/{collection_name}/snapshots/recover
+
+{
+  "location": "http://qdrant-node-1:6333/collections/{collection_name}/snapshots/snapshot-2022-10-10.shapshot",
+  "priority": "snapshot"
+}
+```
+
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient("qdrant-node-2", port=6333)
+
+client.recover_snapshot(
+    "{collection_name}",
+    "http://qdrant-node-1:6333/collections/collection_name/snapshots/snapshot-2022-10-10.shapshot",
+    priority=models.SnapshotPriority.SNAPSHOT,
+)
+```
+
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.recoverSnapshot("{collection_name}", {
+  location: "http://qdrant-node-1:6333/collections/collection_name/snapshots/snapshot-2022-10-10.shapshot",
+  priority: "snapshot"
+});
+```
+
+For uploading a multipart file you specify it as URL parameter:
+
+```bash
+curl -X POST 'http://qdrant-node-1:6333/collections/collection_name/snapshots/upload?priority=snapshot' \
+    -H 'Content-Type:multipart/form-data' \
+    -F 'snapshot=@/path/to/snapshot-2022-10-10.shapshot'
+```
 
 ## Snapshots for the whole storage
 

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -224,6 +224,29 @@ curl -X POST 'http://qdrant-node-1:6333/collections/collection_name/snapshots/up
 Qdrant will extract shard data from the snapshot and properly register shards in the cluster.
 If there are other active replicas of the recovered shards in the cluster, Qdrant will replicate them to the newly recovered node to maintain data consistency.
 
+### Snapshot priority
+
+When recovering a snapshot you can specify what source of data is prioritized
+during recovery. It is important because different priorities can give very
+different end results, and the default priority is probably not what you expect.
+
+The available snapshot recovery priorities are:
+
+- `replica`: (default) prefer existing data over the snapshot.
+- `snapshot`: prefer snapshot data over exiting data.
+- `no_sync`: restore snapshot without any additional synchronization.
+
+To recover a new collection from a snapshot on a Qdrant cluster, you need to set
+the `snapshot` priority. With `snapshot` priority all data from the snapshot will be
+recovered on the cluster. With `replica` priority (default) you'd end up with an
+empty collection because the collection on the cluster did not contain any
+points and that was preferred.
+
+`no_sync` is for specialized use cases and is not commonly used. It allows to
+manage shards and transfer shards between clusters manually without any
+additional synchronization. Using it incorrectly will leave your cluster in a
+broken state.
+
 ## Snapshots for the whole storage
 
 *Available as of v0.8.5*

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -180,6 +180,8 @@ Recovering in cluster mode is more sophisticated, as Qdrant should maintain cons
 As the information about created collections is stored in the consensus, even a newly attached cluster node will automatically create collections.
 Recovering non-existing collections with snapshots won't make this collection known to the consensus.
 
+<aside role="status">It is recommended to explicitly set a <a href="#snapshot-priority">snapshot priority</a> during recovery to prevent unexpected results.</aside>
+
 To recover snapshot via API one can use snapshot recovery endpoint:
 
 ```http
@@ -219,8 +221,6 @@ curl -X POST 'http://qdrant-node-1:6333/collections/collection_name/snapshots/up
     -F 'snapshot=@/path/to/snapshot-2022-10-10.shapshot'
 ```
 
-<aside role="status">You probably want to set the <a href="#snapshot-priority">snapshot priority</a> explicitly during recovery to prevent unexpected results.</aside>
-
 Qdrant will extract shard data from the snapshot and properly register shards in the cluster.
 If there are other active replicas of the recovered shards in the cluster, Qdrant will replicate them to the newly recovered node by default to maintain data consistency.
 
@@ -247,7 +247,7 @@ managing shards and transferring shards between clusters manually without any
 additional synchronization. Using it incorrectly will leave your cluster in a
 broken state.
 
-For recovery from an URL you specify a request parameter:
+To recover from an URL you specify a request parameter:
 
 ```http
 PUT /collections/{collection_name}/snapshots/recover
@@ -281,7 +281,7 @@ client.recoverSnapshot("{collection_name}", {
 });
 ```
 
-For uploading a multipart file you specify it as URL parameter:
+To upload a multipart file you specify it as URL parameter:
 
 ```bash
 curl -X POST 'http://qdrant-node-1:6333/collections/collection_name/snapshots/upload?priority=snapshot' \

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -221,8 +221,10 @@ curl -X POST 'http://qdrant-node-1:6333/collections/collection_name/snapshots/up
 
 ```
 
+<aside role="status">You probably want to set the <a href="#snapshot-priority">snapshot priority</a> explicitly during recovery to prevent unexpected results.</aside>
+
 Qdrant will extract shard data from the snapshot and properly register shards in the cluster.
-If there are other active replicas of the recovered shards in the cluster, Qdrant will replicate them to the newly recovered node to maintain data consistency.
+If there are other active replicas of the recovered shards in the cluster, Qdrant will replicate them to the newly recovered node by default to maintain data consistency.
 
 ### Snapshot priority
 

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -226,24 +226,24 @@ If there are other active replicas of the recovered shards in the cluster, Qdran
 
 ### Snapshot priority
 
-When recovering a snapshot you can specify what source of data is prioritized
+When recovering a snapshot, you can specify what source of data is prioritized
 during recovery. It is important because different priorities can give very
-different end results, and the default priority is probably not what you expect.
+different end results. The default priority is probably not what you expect.
 
 The available snapshot recovery priorities are:
 
-- `replica`: (default) prefer existing data over the snapshot.
-- `snapshot`: prefer snapshot data over exiting data.
+- `replica`: _(default)_ prefer existing data over the snapshot.
+- `snapshot`: prefer snapshot data over existing data.
 - `no_sync`: restore snapshot without any additional synchronization.
 
 To recover a new collection from a snapshot on a Qdrant cluster, you need to set
-the `snapshot` priority. With `snapshot` priority all data from the snapshot will be
-recovered on the cluster. With `replica` priority (default) you'd end up with an
-empty collection because the collection on the cluster did not contain any
-points and that was preferred.
+the `snapshot` priority. With `snapshot` priority, all data from the snapshot
+will be recovered onto the cluster. With `replica` priority _(default)_, you'd
+end up with an empty collection because the collection on the cluster did not
+contain any points and that source was preferred.
 
-`no_sync` is for specialized use cases and is not commonly used. It allows to
-manage shards and transfer shards between clusters manually without any
+`no_sync` is for specialized use cases and is not commonly used. It allows
+managing shards and transferring shards between clusters manually without any
 additional synchronization. Using it incorrectly will leave your cluster in a
 broken state.
 


### PR DESCRIPTION
Document the snapshot priority parameter, link to it from the recovery section and give an example of use.

This is an important parameter which can gave a significant effect on the end result of recovery. We didn't document it. This PR now describes it.

Rendered section: https://deploy-preview-428--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/snapshots/#snapshot-priority

![image](https://github.com/qdrant/landing_page/assets/856222/ea0cc523-00da-4e44-abd7-a49676f44345)

I've also added an info box linking to the new section here: https://deploy-preview-428--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/snapshots/#recover-via-api

![image](https://github.com/qdrant/landing_page/assets/856222/912d507a-d8de-4950-b37d-ce031d3b8ddc)