### PR TITLE
Remove empty lines in HTTP examples, reformat some of them

### DIFF
--- a/qdrant-landing/content/articles/memory-consumption.md
+++ b/qdrant-landing/content/articles/memory-consumption.md
@@ -173,8 +173,7 @@ In the second experiment, we tested how well our system performs when **vectors 
 Create collection with:
 
 ```http
-PUT /collections/benchmark 
-
+PUT /collections/benchmark
 {
   ...
   "optimizers_config": {
@@ -222,7 +221,6 @@ Create collection with:
 
 ```http
 PUT /collections/benchmark 
-
 {
   ...
   "hnsw_config": {

--- a/qdrant-landing/content/articles/new-recommendation-api.md
+++ b/qdrant-landing/content/articles/new-recommendation-api.md
@@ -35,9 +35,8 @@ combine them within a single request. That makes the new implementation backward
 Qdrant instance without any changes in your code. And the default behaviour of the API is still the same as before. However, we 
 extended the API, so **you can now choose the strategy of how to find the recommended points**.
 
-```http request
+```http
 POST /collections/{collection_name}/points/recommend
-
 {
   "positive": [100, 231],
   "negative": [718, [0.2, 0.3, 0.4, 0.5]],

--- a/qdrant-landing/content/articles/qdrant-1.3.x.md
+++ b/qdrant-landing/content/articles/qdrant-1.3.x.md
@@ -69,7 +69,6 @@ Here is how you can configure the oversampling factor - define how many extra ve
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
   "params": {
     "quantization": {
@@ -122,7 +121,6 @@ When using the grouping API, add the `with_lookup` parameter to bring the inform
 
 ```http
 POST /collections/chunks/points/search/groups
-
 {
     // Same as in the regular search API
     "vector": [1.1],

--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -33,7 +33,6 @@ These settings can be changed at any time by a corresponding request.
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 300,
@@ -121,7 +120,6 @@ Make sure the vectors have the same size and distance function when setting up t
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 100,
@@ -192,7 +190,6 @@ Each named vector in this mode has its distance and size:
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
         "image": {
@@ -323,7 +320,6 @@ The following command enables indexing for segments that have more than 10000 kB
 
 ```http
 PATCH /collections/{collection_name}
-
 {
     "optimizers_config": {
         "indexing_threshold": 10000
@@ -390,7 +386,6 @@ use `""` as name:
 
 ```http
 PATCH /collections/{collection_name}
-
 {
     "vectors": {
         "": {
@@ -404,7 +399,6 @@ To put vector data on disk for a collection that **does have** named vectors:
 
 ```http
 PATCH /collections/{collection_name}
-
 {
     "vectors": {
         "my_vector": {
@@ -419,7 +413,6 @@ both for the whole collection, and for `my_vector` specifically:
 
 ```http
 PATCH /collections/{collection_name}
-
 {
     "vectors": {
         "my_vector": {
@@ -568,7 +561,6 @@ distributed and indexed.
 
 ```http
 GET /collections/{collection_name}
-
 {
     "result": {
         "status": "green",
@@ -669,7 +661,6 @@ Since all changes of aliases happen atomically, no concurrent requests will be a
 
 ```http
 POST /collections/aliases
-
 {
     "actions": [
         {
@@ -715,7 +706,6 @@ client.create_alias("example_collection", "production_collection").await?;
 
 ```http
 POST /collections/aliases
-
 {
     "actions": [
         {
@@ -760,7 +750,6 @@ For example, you can switch underlying collection with the following command:
 
 ```http
 POST /collections/aliases
-
 {
     "actions": [
         {

--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -40,7 +40,6 @@ Example:
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must": [
@@ -48,7 +47,7 @@ POST /collections/{collection_name}/points/scroll
             { "key": "color", "match": { "value": "red" } }
         ]
     }
-  ...
+    ...
 }
 ```
 
@@ -131,7 +130,6 @@ Example:
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "should": [
@@ -212,7 +210,6 @@ Example:
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must_not": [
@@ -285,7 +282,6 @@ It is also possible to use several clauses simultaneously:
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must": [
@@ -362,7 +358,6 @@ Also, the conditions could be recursively nested. Example:
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must_not": [
@@ -657,7 +652,6 @@ You can search on a nested field using a dot notation.
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "should": [
@@ -717,7 +711,6 @@ You can also search through arrays by projecting inner values using the `[]` syn
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "should": [
@@ -793,7 +786,6 @@ And the leaf nested field can also be an array.
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "should": [
@@ -885,7 +877,6 @@ The following query would match both points:
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must": [
@@ -969,7 +960,6 @@ The key should point to an array of objects and can be used with or without the 
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must": [
@@ -1080,7 +1070,6 @@ The `has_id` condition is not supported within the nested object filter. If you 
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must": [
@@ -1762,14 +1751,13 @@ For example, the user could mark some specific search results as irrelevant, or 
 
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must": [
             { "has_id": [1,3,5,7,9,11] }
         ]
     }
-  ...
+    ...
 }
 ```
 

--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -27,7 +27,6 @@ To mark a field as indexable, you can use the following:
 
 ```http
 PUT /collections/{collection_name}/index
-
 {
     "field_name": "name_of_the_field_to_index",
     "field_schema": "keyword"
@@ -100,7 +99,6 @@ To create a full-text index, you can use the following:
 
 ```http
 PUT /collections/{collection_name}/index
-
 {
     "field_name": "name_of_the_field_to_index",
     "field_schema": {

--- a/qdrant-landing/content/documentation/concepts/payload.md
+++ b/qdrant-landing/content/documentation/concepts/payload.md
@@ -142,7 +142,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#tag/points/o
 
 ```http
 PUT /collections/{collection_name}/points
-
 {
     "points": [
         {
@@ -285,7 +284,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/se
 
 ```http
 POST /collections/{collection_name}/points/payload
-
 {
     "payload": {
         "property1": "string",
@@ -351,7 +349,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/de
 
 ```http
 POST /collections/{collection_name}/points/payload/delete
-
 {
     "keys": ["color", "price"],
     "points": [0, 3, 100]
@@ -400,7 +397,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/cl
 
 ```http
 POST /collections/{collection_name}/points/payload/clear
-
 {
     "points": [0, 3, 100]
 }
@@ -458,7 +454,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#tag/collecti
 
 ```http
 PUT /collections/{collection_name}/index
-
 {
     "field_name": "name_of_the_field_to_index",
     "field_schema": "keyword"

--- a/qdrant-landing/content/documentation/concepts/points.md
+++ b/qdrant-landing/content/documentation/concepts/points.md
@@ -70,7 +70,6 @@ Example:
 
 ```http
 PUT /collections/{collection_name}/points
-
 {
     "points": [
         {
@@ -147,7 +146,6 @@ and
 
 ```http
 PUT /collections/{collection_name}/points
-
 {
     "points": [
         {
@@ -223,7 +221,6 @@ Create points with batch:
 
 ```http
 PUT /collections/{collection_name}/points
-
 {
     "batch": {
         "ids": [1, 2, 3],
@@ -279,7 +276,6 @@ or record-oriented equivalent:
 
 ```http
 PUT /collections/{collection_name}/points
-
 {
     "points": [
         {
@@ -415,9 +411,9 @@ Even with such a system, Qdrant ensures data consistency.
 *Available as of v0.10.0*
 
 If the collection was created with multiple vectors, each vector data can be provided using the vector's name:
+
 ```http
 PUT /collections/{collection_name}/points
-
 {
     "points": [
         {
@@ -544,7 +540,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/up
 
 ```http
 PUT /collections/{collection_name}/points/vectors
-
 {
     "points": [
         {
@@ -646,7 +641,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/de
 
 ```http
 POST /collections/{collection_name}/points/vectors/delete
-
 {
     "points": [0, 3, 100],
     "vectors": ["text", "image"]
@@ -701,7 +695,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/se
 
 ```http
 POST /collections/{collection_name}/points/payload
-
 {
     "payload": {
         "property1": "string",
@@ -764,7 +757,6 @@ is to use filters.
 
 ```http
 POST /collections/{collection_name}/points/payload
-
 {
     "payload": {
         "property1": "string",
@@ -853,7 +845,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/ov
 
 ```http
 PUT /collections/{collection_name}/points/payload
-
 {
     "payload": {
         "property1": "string",
@@ -920,7 +911,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/de
 
 ```http
 POST /collections/{collection_name}/points/payload/delete
-
 {
     "keys": ["color", "price"],
     "points": [0, 3, 100]
@@ -965,7 +955,6 @@ Alternatively, you can use filters to delete payload keys from the points.
 
 ```http
 POST /collections/{collection_name}/points/payload/delete
-
 {
     "keys": ["color", "price"],
     "filter": {
@@ -1039,7 +1028,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/cl
 
 ```http
 POST /collections/{collection_name}/points/payload/clear
-
 {
     "points": [0, 3, 100]
 }
@@ -1084,7 +1072,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/de
 
 ```http
 POST /collections/{collection_name}/points/delete
-
 {
     "points": [0, 3, 100]
 }
@@ -1127,7 +1114,6 @@ Alternative way to specify which points to remove is to use filter.
 
 ```http
 POST /collections/{collection_name}/points/delete
-
 {
     "filter": {
         "must": [
@@ -1201,7 +1187,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/ge
 
 ```http
 POST /collections/{collection_name}/points
-
 {
     "ids": [0, 3, 100]
 }
@@ -1244,7 +1229,7 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/ge
 GET /collections/{collection_name}/points/{point_id}
 ```
 
-<!-- 
+<!--
 Python client:
 
 ```python
@@ -1256,9 +1241,9 @@ Python client:
 Sometimes it might be necessary to get all stored points without knowing ids, or iterate over points that correspond to a filter.
 
 REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#operation/scroll_points)):
+
 ```http
 POST /collections/{collection_name}/points/scroll
-
 {
     "filter": {
         "must": [
@@ -1372,9 +1357,9 @@ Among others, for example, we can highlight the following scenarios:
 * Debugging the query execution speed
 
 REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#tag/points/operation/count_points)):
+
 ```http
 POST /collections/{collection_name}/points/count
-
 {
     "filter": {
         "must": [
@@ -1466,7 +1451,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#tag/points/o
 
 ```http
 POST /collections/{collection_name}/points/batch
-
 {
     "operations": [
         {

--- a/qdrant-landing/content/documentation/concepts/search.md
+++ b/qdrant-landing/content/documentation/concepts/search.md
@@ -61,7 +61,6 @@ REST API - API Schema definition is available [here](https://qdrant.github.io/qd
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "filter": {
         "must": [
@@ -197,7 +196,6 @@ If the collection was created with multiple vectors, the name of the vector to u
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "vector": {
         "name": "image",
@@ -271,7 +269,6 @@ Example:
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "vector": [0.2, 0.1, 0.9, 0.7],
     "with_vectors": true,
@@ -319,7 +316,6 @@ You can even specify an array of items to include, such as `city`,
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "vector": [0.2, 0.1, 0.9, 0.7],
     "with_payload": ["city", "village", "town"]
@@ -370,7 +366,6 @@ Or use `include` or `exclude` explicitly. For example, to exclude `city`:
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "vector": [0.2, 0.1, 0.9, 0.7],
     "with_payload": {
@@ -457,7 +452,6 @@ In order to use it, simply pack together your search requests. All the regular a
 
 ```http
 POST /collections/{collection_name}/points/search/batch
-
 {
     "searches": [
         {
@@ -773,7 +767,6 @@ If the collection was created with multiple vectors, the name of the vector shou
 
 ```http
 POST /collections/{collection_name}/points/recommend
-
 {
   "positive": [100, 231],
   "negative": [718],
@@ -994,7 +987,6 @@ Example:
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "vector": [0.2, 0.1, 0.9, 0.7],
     "with_vectors": true,
@@ -1133,7 +1125,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#tag/points/o
 
 ```http
 POST /collections/{collection_name}/points/search/groups
-
 {
     // Same as in the regular search API
     "vector": [1.1],
@@ -1187,7 +1178,6 @@ REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#tag/points/o
 
 ```http
 POST /collections/{collection_name}/points/recommend/groups
-
 {
     // Same as in the regular recommend API
     "negative": [1],
@@ -1307,15 +1297,14 @@ In this case, to bring the information from the documents into the chunks groupe
 
 ```http
 POST /collections/chunks/points/search/groups
-
 {
     // Same as in the regular search API
     "vector": [1.1],
 
     // Grouping parameters
-    "group_by": "document_id",  
-    "limit": 2,                 
-    "group_size": 2,            
+    "group_by": "document_id",
+    "limit": 2,
+    "group_size": 2,
 
     // Lookup parameters
     "with_lookup": {

--- a/qdrant-landing/content/documentation/concepts/snapshots.md
+++ b/qdrant-landing/content/documentation/concepts/snapshots.md
@@ -184,7 +184,6 @@ To recover snapshot via API one can use snapshot recovery endpoint:
 
 ```http
 PUT /collections/{collection_name}/snapshots/recover
-
 {
   "location": "http://qdrant-node-1:6333/collections/{collection_name}/snapshots/snapshot-2022-10-10.shapshot"
 }

--- a/qdrant-landing/content/documentation/concepts/storage.md
+++ b/qdrant-landing/content/documentation/concepts/storage.md
@@ -44,7 +44,6 @@ There are two ways to configure the usage of memmap(also known as on-disk) stora
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -118,7 +117,6 @@ There are two ways to do this:
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -198,7 +196,6 @@ To enable this, you need to set the `hnsw_config.on_disk` parameter to `true` du
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,

--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -132,7 +132,6 @@ When you create a collection, Qdrant splits the collection into `shard_number` s
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 300,
@@ -211,13 +210,12 @@ Use the [Update collection cluster setup API](https://qdrant.github.io/qdrant/re
 
 ```http
 POST /collections/{collection_name}/cluster
-
 {
-  "move_shard": {
-    "shard_id": 0,
-    "from_peer_id": 381894127,
-    "to_peer_id": 467122995
-  }
+    "move_shard": {
+        "shard_id": 0,
+        "from_peer_id": 381894127,
+        "to_peer_id": 467122995
+    }
 }
 ```
 
@@ -249,11 +247,10 @@ Currently, the replication factor of a collection can only be configured at crea
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
-      "size": 300,
-      "distance": "Cosine"
+        "size": 300,
+        "distance": "Cosine"
     },
     "shard_number": 6,
     "replication_factor": 2,
@@ -326,13 +323,12 @@ A replica can be added on a specific peer by specifying the peer from which to r
 
 ```http
 POST /collections/{collection_name}/cluster
-
 {
-  "replicate_shard": {
-    "shard_id": 0,
-    "from_peer_id": 381894127,
-    "to_peer_id": 467122995
-  }
+    "replicate_shard": {
+        "shard_id": 0,
+        "from_peer_id": 381894127,
+        "to_peer_id": 467122995
+    }
 }
 ```
 
@@ -340,12 +336,11 @@ And a replica can be removed on a specific peer.
 
 ```http
 POST /collections/{collection_name}/cluster
-
 {
-  "drop_replica": {
-    "shard_id": 0,
-    "peer_id": 381894127
-  }
+    "drop_replica": {
+        "shard_id": 0,
+        "peer_id": 381894127
+    }
 }
 ```
 
@@ -445,11 +440,10 @@ It can be configured at the collection's creation time.
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
-      "size": 300,
-      "distance": "Cosine"
+        "size": 300,
+        "distance": "Cosine"
     },
     "shard_number": 6,
     "replication_factor": 2,
@@ -529,7 +523,6 @@ is consistent across cluster nodes.
 
 ```http
 POST /collections/{collection_name}/points/search?consistency=majority
-
 {
     "filter": {
         "must": [
@@ -631,7 +624,6 @@ sequentially.
 
 ```http
 PUT /collections/{collection_name}/points?ordering=strong
-
 {
     "batch": {
         "ids": [1, 2, 3],

--- a/qdrant-landing/content/documentation/guides/multiple-partitions.md
+++ b/qdrant-landing/content/documentation/guides/multiple-partitions.md
@@ -18,7 +18,6 @@ When an instance is shared between multiple users, you may need to partition vec
 
 ```http
 PUT /collections/{collection_name}/points
-
 {
     "points": [
         {
@@ -136,7 +135,6 @@ client
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "filter": {
         "must": [
@@ -224,7 +222,6 @@ To implement this approach, you should:
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -304,7 +301,6 @@ client
 
 ```http
 PUT /collections/{collection_name}/index
-
 {
     "field_name": "group_id",
     "field_schema": "keyword"

--- a/qdrant-landing/content/documentation/guides/optimize.md
+++ b/qdrant-landing/content/documentation/guides/optimize.md
@@ -24,11 +24,10 @@ To configure in-memory quantization, with on-disk original vectors, you need to 
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
-      "size": 768,
-      "distance": "Cosine"
+        "size": 768,
+        "distance": "Cosine"
     },
     "optimizers_config": {
         "memmap_threshold": 20000
@@ -127,7 +126,6 @@ Optionally, you can disable rescoring with search `params`, which will reduce th
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "params": {
         "quantization": {
@@ -200,7 +198,6 @@ In case you need high precision, but don't have enough RAM to store vectors in m
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -305,7 +302,6 @@ Is is possible to achieve high search speed and tunable accuracy by applying qua
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -406,7 +402,6 @@ There are also some search-time parameters you can use to tune the search accura
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "params": {
         "hnsw_ef": 128,
@@ -483,9 +478,7 @@ To prefer minimizing latency, you can set up Qdrant to use as many cores as poss
 You can do this by setting the number of segments in the collection to be equal to the number of cores in the system. In this case, each segment will be processed in parallel, and the final result will be obtained faster.
 
 ```http
-
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -561,7 +554,6 @@ Large segments benefit from the size of the index and overall smaller number of 
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,

--- a/qdrant-landing/content/documentation/guides/quantization.md
+++ b/qdrant-landing/content/documentation/guides/quantization.md
@@ -149,7 +149,6 @@ To enable scalar quantization, you need to specify the quantization parameters i
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -260,7 +259,6 @@ To enable binary quantization, you need to specify the quantization parameters i
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 1536,
@@ -351,7 +349,6 @@ To enable product quantization, you need to specify the quantization parameters 
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -454,7 +451,6 @@ However, there are a few options that you can use to control the search process:
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "params": {
         "quantization": {
@@ -556,7 +552,6 @@ In order to disable quantization, you can set `ignore` to `true` in the search r
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "params": {
         "quantization": {
@@ -646,7 +641,6 @@ This mode is enabled by setting `always_ram` to `true` in the quantization confi
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -749,7 +743,6 @@ Consider disabling `rescore` to improve the search speed:
 
 ```http
 POST /collections/{collection_name}/points/search
-
 {
     "params": {
         "quantization": {
@@ -823,7 +816,6 @@ This mode is enabled by setting `always_ram` to `false` in the quantization conf
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,

--- a/qdrant-landing/content/documentation/tutorials/bulk-upload.md
+++ b/qdrant-landing/content/documentation/tutorials/bulk-upload.md
@@ -23,7 +23,6 @@ To disable indexing during upload, set `indexing_threshold` to `0`:
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,
@@ -69,7 +68,6 @@ After upload is done, you can enable indexing by setting `indexing_threshold` to
 
 ```http
 PATCH /collections/{collection_name}
-
 {
     "optimizers_config": {
         "indexing_threshold": 20000
@@ -128,7 +126,6 @@ By creating multiple shards, you can parallelize upload of a large dataset. From
 
 ```http
 PUT /collections/{collection_name}
-
 {
     "vectors": {
       "size": 768,


### PR DESCRIPTION
This removes the empty line in HTTP examples between the method/path and body.

I've done this because our Web UI doesn't support this formatting:

![image](https://github.com/qdrant/landing_page/assets/856222/c52c00c4-2393-402b-8261-3edb33cdce0d)
