### PR TITLE
Fix incorrect paths in sass command

### DIFF
--- a/qdrant-landing/README.md
+++ b/qdrant-landing/README.md
@@ -14,7 +14,7 @@ npm install -g sass
 
 ``` bash
 cd qdrant-landing
-sass --watch --style=compressed ./qdrant-landing/themes/qdrant/static/css/main.scss ./qdrant-landing/themes/qdrant/static/css/main.css
+sass --watch --style=compressed ./themes/qdrant/static/css/main.scss ./themes/qdrant/static/css/main.css
 ```
 
 # Articles


### PR DESCRIPTION
The paths in the `sass` commands were wrong. The user is instructed to change into the `qdrant-landing` directory, so we don't have to provide this in the `sass` invocation.