### PR TITLE
Add approximate point and vector counts section

### DIFF
--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -638,23 +638,23 @@ You may be interested in the count attributes:
 - `vectors_count` - total number of vectors in a collection, useful if you have multiple vectors per point
 - `indexed_vectors_count` - total number of vectors stored in the HNSW or sparse index. Qdrant does not store all the vectors in the index, but only if an index segment might be created for a given configuration.
 
-The above counts are not exact but should be considered approximate. Depending
+The above counts are not exact, but should be considered approximate. Depending
 on how you use Qdrant these may give very different numbers than what you may
 expect. It's therefore important **not** to rely on them.
 
-To be more specific, these numbers represent the number of points and vectors in
+More specifically, these numbers represent the count of points and vectors in
 Qdrant's internal storage. Internally, Qdrant may temporarily duplicate points
 as part of automatic optimizations. It may keep changed or deleted points for a
 bit. And it may delay indexing of new points. All of that is for optimization
 reasons.
 
 Updates you do are therefore not directly reflected in these numbers. If you see
-a wildly different count of points it will likely resolve itself once a new
+a wildly different count of points, it will likely resolve itself once a new
 round of automatic optimizations has completed.
 
-So to clarify: these numbers don't represent the exact amount of points or
-vectors you have inserted, nor does it represent the exact number of
-distinguishable points or vectors you can query.
+To clarify: these numbers don't represent the exact amount of points or vectors
+you have inserted, nor does it represent the exact number of distinguishable
+points or vectors you can query.
 
 _Note: these numbers may be removed in a future version of Qdrant._
 

--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -630,11 +630,31 @@ The following color statuses are possible:
 - 🟡 `yellow`: collection is optimizing
 - 🔴 `red`: an error occurred which the engine could not recover from
 
-There are some other attributes you might be interested in:
+### Approximate point and vector counts
+
+You may be interested in the count attributes:
 
 - `points_count` - total number of objects (vectors and their payloads) stored in the collection
-- `vectors_count` - total number of vectors in a collection. If there are multiple vectors per object, it won't be equal to `points_count`.
-- `indexed_vectors_count` - total number of vectors stored in the HNSW index. Qdrant does not store all the vectors in the index, but only if an index segment might be created for a given configuration.
+- `vectors_count` - total number of vectors in a collection, useful if you have multiple vectors per point
+- `indexed_vectors_count` - total number of vectors stored in the HNSW or sparse index. Qdrant does not store all the vectors in the index, but only if an index segment might be created for a given configuration.
+
+The above counts are not exact but should be considered approximate. Depending
+on how you use Qdrant these may give very different numbers than what you may
+expect. It's therefore important **not** to rely on them.
+
+To be more specific, these numbers represent the number of points and vectors in
+Qdrant's internal storage. Internally, Qdrant may temporarily duplicate points
+as part of automatic optimizations. It may keep changed or deleted points for a
+bit. And it may delay indexing of new points. All of that is for optimization
+reasons.
+
+Updates you do are therefore not directly reflected in these numbers. If you see
+a wildly different count of points it will likely resolve itself once a new
+round of automatic optimizations has completed.
+
+So to clarify: these numbers don't represent the exact amount of points or
+vectors you have inserted, nor does it represent the exact number of
+distinguishable points or vectors you can query.
 
 ### Indexing vectors in HNSW
 

--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -656,6 +656,8 @@ So to clarify: these numbers don't represent the exact amount of points or
 vectors you have inserted, nor does it represent the exact number of
 distinguishable points or vectors you can query.
 
+_Note: these numbers may be removed in a future version of Qdrant._
+
 ### Indexing vectors in HNSW
 
 In some cases, you might be surprised the value of `indexed_vectors_count` is lower than `vectors_count`. This is an intended behaviour and


### PR DESCRIPTION
Describe that point and vector counts shown in the collection info are approximate. Tell users not to rely on these numbers, and briefly explain why.

We can point users to this section if questions are asked about these counts. We've had quite a bunch of these.

Rendered: https://deploy-preview-443--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/collections/#approximate-point-and-vector-counts