### PR TITLE
Add `read-only-api-key` configuration example

### DIFF
--- a/qdrant-landing/content/documentation/guides/configuration.md
+++ b/qdrant-landing/content/documentation/guides/configuration.md
@@ -253,7 +253,7 @@ service:
 
   # Set an api-key.
   # If set, all requests must include a header with the api-key.
-  # example header: `api-key: <API-KEY>`
+  # Example header: `api-key: <API-KEY>`
   #
   # If you enable this you should also enable TLS.
   # (Either above or via an external service like nginx.)
@@ -261,6 +261,17 @@ service:
   #
   # Uncomment to enable.
   # api_key: your_secret_api_key_here
+   
+  # Set an api-key for read-only operations.
+  # If set, all read requests must include a header with the api-key.
+  # Example header: `api-key: <API-KEY>`
+  #
+  # If you enable this you should also enable TLS.
+  # (Either above or via an external service like nginx.)
+  # Sending an api-key over an unencrypted channel is insecure.
+  #
+  # Uncomment to enable.
+  # read_only_api_key: your_secret_read_only_api_key_here
 
 cluster:
   # Use `enabled: true` to run Qdrant in distributed deployment mode


### PR DESCRIPTION
It's hard to search for this info because the search plugin does not seem to show the stuff inside code blocks. We may consider structuring the descriptions of the [configuration page](https://qdrant.tech/documentation/guides/configuration/) examples in another way, or fixing the plugin.