### PR TITLE
Update configuration to Qdrant v1.7.0

### DIFF
--- a/qdrant-landing/content/documentation/guides/configuration.md
+++ b/qdrant-landing/content/documentation/guides/configuration.md
@@ -149,6 +149,12 @@ storage:
     # So total number of threads used for optimization will be `max_optimization_threads * max_indexing_threads`
     max_optimization_threads: 1
 
+    # Prevent DDoS of too many concurrent updates in distributed mode.
+    # One external update usually triggers multiple internal updates, which breaks internal
+    # timings. For example, the health check timing and consensus timing.
+    # If null - auto selection.
+    update_rate_limit: null
+
   optimizers:
     # The minimal fraction of deleted vectors in a segment, required to perform segment optimization
     deleted_threshold: 0.2
@@ -253,7 +259,7 @@ service:
 
   # Set an api-key.
   # If set, all requests must include a header with the api-key.
-  # Example header: `api-key: <API-KEY>`
+  # example header: `api-key: <API-KEY>`
   #
   # If you enable this you should also enable TLS.
   # (Either above or via an external service like nginx.)
@@ -263,8 +269,8 @@ service:
   # api_key: your_secret_api_key_here
    
   # Set an api-key for read-only operations.
-  # If set, all read requests must include a header with the api-key.
-  # Example header: `api-key: <API-KEY>`
+  # If set, all requests must include a header with the api-key.
+  # example header: `api-key: <API-KEY>`
   #
   # If you enable this you should also enable TLS.
   # (Either above or via an external service like nginx.)


### PR DESCRIPTION
This updates the configuration in our documentation to what we have in Qdrant 1.7.0.

Since this is copy-paste, it's fine to merge this right after the first approval. :+1: 