### PR TITLE
Use consistent PR links in Qdrant 1.7 release article

### DIFF
--- a/qdrant-landing/content/articles/qdrant-1.7.x.md
+++ b/qdrant-landing/content/articles/qdrant-1.7.x.md
@@ -107,15 +107,15 @@ There are multiple scenarios in which you may prefer one over the other. Please 
 
 Beyond introducing new features, Qdrant 1.7.0 enhances performance and addresses various minor issues. Here's a rundown of the key improvements:
 
-1. Improvement of HNSW Index Building on High CPU Systems [pull request](https://github.com/qdrant/qdrant/pull/2869)
+1. Improvement of HNSW Index Building on High CPU Systems ([PR#2869](https://github.com/qdrant/qdrant/pull/2869)).
 
-2. Improving [Search Tail Latencies](https://github.com/qdrant/qdrant/pull/2931): Improvement for high CPU systems with many parallel searches, directly impacting the user experience by reducing latency
+2. Improving [Search Tail Latencies](https://github.com/qdrant/qdrant/pull/2931): improvement for high CPU systems with many parallel searches, directly impacting the user experience by reducing latency.
 
-3. [Adding Index for Geo Map Payloads](https://github.com/qdrant/qdrant/pull/2768): Index for geo map payloads can significantly improve search performance, especially for applications involving geographical data
+3. [Adding Index for Geo Map Payloads](https://github.com/qdrant/qdrant/pull/2768): index for geo map payloads can significantly improve search performance, especially for applications involving geographical data.
 
-4. Stability of Consensus on Big High Load Clusters: Enhancing the stability of consensus in large, high-load environments is critical for ensuring the reliability and scalability of the system (https://github.com/qdrant/qdrant/pull/3013, https://github.com/qdrant/qdrant/pull/3026, https://github.com/qdrant/qdrant/pull/2942, https://github.com/qdrant/qdrant/pull/3103, https://github.com/qdrant/qdrant/pull/3054)
+4. Stability of Consensus on Big High Load Clusters: enhancing the stability of consensus in large, high-load environments is critical for ensuring the reliability and scalability of the system ([PR#3013](https://github.com/qdrant/qdrant/pull/3013), [PR#3026](https://github.com/qdrant/qdrant/pull/3026), [PR#2942](https://github.com/qdrant/qdrant/pull/2942), [PR#3103](https://github.com/qdrant/qdrant/pull/3103), [PR#3054](https://github.com/qdrant/qdrant/pull/3054)).
 
-5. Configurable Timeout for Searches [PR#2748](https://github.com/qdrant/qdrant/pull/2748), [PR#2771](https://github.com/qdrant/qdrant/pull/2771): Allowing users to configure the timeout for searches provides greater flexibility and can help optimize system performance under different operational conditions.
+5. Configurable Timeout for Searches: allowing users to configure the timeout for searches provides greater flexibility and can help optimize system performance under different operational conditions ([PR#2748](https://github.com/qdrant/qdrant/pull/2748), [PR#2771](https://github.com/qdrant/qdrant/pull/2771)).
 
 ## Release notes
 


### PR DESCRIPTION
The PR links in the minor improvements list were kind of a mess in my opinion. This PR tries to make it more consistent.