### PR TITLE
From release article, link to sparse vectors article

### DIFF
--- a/qdrant-landing/content/articles/qdrant-1.7.x.md
+++ b/qdrant-landing/content/articles/qdrant-1.7.x.md
@@ -51,7 +51,7 @@ Things have changed since then, as so many of you wanted a single tool for spars
 
 If you're coming across the topic of sparse vectors for the first time, our [Brief History of Search](https://qdrant.tech/documentation/overview/vector-search/) explains the difference between sparse and dense vectors.
 
-Check out the [sparse vectors article](../sparse-vectors/) and [sparse vectors index docs](/documentation/concepts/indexing/#sparse-vector-index) for more details on what this new index means for Qdrant users. Stay tuned for a full article with code examples on how to use sparse vectors in Qdrant!
+Check out the [sparse vectors article](../sparse-vectors/) and [sparse vectors index docs](/documentation/concepts/indexing/#sparse-vector-index) for more details on what this new index means for Qdrant users.
 
 ### Discovery API
 

--- a/qdrant-landing/content/articles/qdrant-1.7.x.md
+++ b/qdrant-landing/content/articles/qdrant-1.7.x.md
@@ -51,7 +51,7 @@ Things have changed since then, as so many of you wanted a single tool for spars
 
 If you're coming across the topic of sparse vectors for the first time, our [Brief History of Search](https://qdrant.tech/documentation/overview/vector-search/) explains the difference between sparse and dense vectors.
 
-Check out the [sparse vectors index docs](/documentation/concepts/indexing/#sparse-vector-index) for more details on what this new index means for Qdrant users. Stay tuned for a full article with code examples on how to use sparse vectors in Qdrant!
+Check out the [sparse vectors article](../sparse-vectors/) and [sparse vectors index docs](/documentation/concepts/indexing/#sparse-vector-index) for more details on what this new index means for Qdrant users. Stay tuned for a full article with code examples on how to use sparse vectors in Qdrant!
 
 ### Discovery API
 


### PR DESCRIPTION
We're about to publish the sparse vectors article. I suggest to link to it from the 1.7 release article, as it may result in more traffic.

Rendered at the bottom of this section: https://deploy-preview-460--condescending-goldwasser-91acf0.netlify.app/articles/qdrant-1.7.x/#sparse-vectors