### PR TITLE
docs: Rust client usage update

### DIFF
--- a/qdrant-landing/content/documentation/cloud/quickstart-cloud.md
+++ b/qdrant-landing/content/documentation/cloud/quickstart-cloud.md
@@ -68,3 +68,26 @@ var client = new QdrantClient(
   apiKey: "<paste-your-api-key-here>"
 );
 ```
+
+```rust
+use qdrant_client::client::QdrantClient;
+
+let client = QdrantClient::from_url("xyz-example.eu-central.aws.cloud.qdrant.io:6334")
+    .with_api_key("<paste-your-api-key-here>")
+    .build()
+    .unwrap();
+```
+
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+
+QdrantClient client =
+    new QdrantClient(
+        QdrantGrpcClient.newBuilder(
+                "xyz-example.eu-central.aws.cloud.qdrant.io",
+                6334,
+                true)
+            .withApiKey("<paste-your-api-key-here>")
+            .build());
+```

--- a/qdrant-landing/content/documentation/concepts/explore.md
+++ b/qdrant-landing/content/documentation/concepts/explore.md
@@ -327,6 +327,26 @@ client.recommend("{collection_name}", {
 });
 ```
 
+```rust
+use qdrant_client::qdrant::{LookupLocation, RecommendPoints};
+
+client
+    .recommend(&RecommendPoints {
+        collection_name: "{collection_name}".to_string(),
+        positive: vec![100.into(), 231.into()],
+        negative: vec![718.into()],
+        using: Some("image".to_string()),
+        limit: 10,
+        lookup_from: Some(LookupLocation {
+            collection_name: "{external_collection_name}".to_string(),
+            vector_name: Some("{external_vector_name}".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+    .await?;
+```
+
 ```java
 import java.util.List;
 
@@ -660,6 +680,49 @@ client.discover("{collection_name}", {
 });
 ```
 
+```rust
+use qdrant_client::{
+    client::QdrantClient,
+    qdrant::{
+        target_vector::Target, vector_example::Example, ContextExamplePair, DiscoverPoints,
+        TargetVector, VectorExample,
+    },
+};
+
+let client = QdrantClient::from_url("http://localhost:6334").build()?;
+
+client
+    .discover(&DiscoverPoints {
+        collection_name: "{collection_name}".to_string(),
+        target: Some(TargetVector {
+            target: Some(Target::Single(VectorExample {
+                example: Some(Example::Vector(vec![0.2, 0.1, 0.9, 0.7].into())),
+            })),
+        }),
+        context: vec![
+            ContextExamplePair {
+                positive: Some(VectorExample {
+                    example: Some(Example::Id(100.into())),
+                }),
+                negative: Some(VectorExample {
+                    example: Some(Example::Id(718.into())),
+                }),
+            },
+            ContextExamplePair {
+                positive: Some(VectorExample {
+                    example: Some(Example::Id(200.into())),
+                }),
+                negative: Some(VectorExample {
+                    example: Some(Example::Id(300.into())),
+                }),
+            },
+        ],
+        limit: 10,
+        ..Default::default()
+    })
+    .await?;
+```
+
 ```java
 import java.util.List;
 
@@ -787,6 +850,41 @@ client.discover("{collection_name}", {
     ],
     limit: 10,
 });
+```
+
+```rust
+use qdrant_client::{
+    client::QdrantClient,
+    qdrant::{vector_example::Example, ContextExamplePair, DiscoverPoints, VectorExample},
+};
+
+let client = QdrantClient::from_url("http://localhost:6334").build()?;
+
+client
+    .discover(&DiscoverPoints {
+        collection_name: "{collection_name}".to_string(),
+        context: vec![
+            ContextExamplePair {
+                positive: Some(VectorExample {
+                    example: Some(Example::Id(100.into())),
+                }),
+                negative: Some(VectorExample {
+                    example: Some(Example::Id(718.into())),
+                }),
+            },
+            ContextExamplePair {
+                positive: Some(VectorExample {
+                    example: Some(Example::Id(200.into())),
+                }),
+                negative: Some(VectorExample {
+                    example: Some(Example::Id(300.into())),
+                }),
+            },
+        ],
+        limit: 10,
+        ..Default::default()
+    })
+    .await?;
 ```
 
 ```java

--- a/qdrant-landing/content/documentation/concepts/search.md
+++ b/qdrant-landing/content/documentation/concepts/search.md
@@ -610,7 +610,7 @@ client.search("{collection_name}", {
 use qdrant_client::{
     client::QdrantClient,
     qdrant::{
-        with_payload_selector::SelectorOptions, PayloadIncludeSelector, SearchPoints,
+        with_payload_selector::SelectorOptions, PayloadExcludeSelector, SearchPoints,
         WithPayloadSelector,
     },
 };
@@ -622,7 +622,7 @@ client
         collection_name: "{collection_name}".to_string(),
         vector: vec![0.2, 0.1, 0.9, 0.7],
         with_payload: Some(WithPayloadSelector {
-            selector_options: Some(SelectorOptions::Include(PayloadIncludeSelector {
+            selector_options: Some(SelectorOptions::Exclude(PayloadExcludeSelector {
                 fields: vec!["city".to_string()],
             })),
         }),
@@ -804,6 +804,7 @@ client
         collection_name: "{collection_name}".to_string(),
         search_points: searches,
         read_consistency: None,
+        ..Default::default()
     })
     .await?;
 ```

--- a/qdrant-landing/content/documentation/guides/quantization.md
+++ b/qdrant-landing/content/documentation/guides/quantization.md
@@ -1006,7 +1006,7 @@ client
         vector: vec![0.2, 0.1, 0.9, 0.7],
         params: Some(SearchParams {
             quantization: Some(QuantizationSearchParams {
-                rescore: Some(true),
+                rescore: Some(false),
                 ..Default::default()
             }),
             ..Default::default()


### PR DESCRIPTION
This PR fixes some Rust client usage examples and adds missing examples of `1.7` features.