### PR TITLE
Update Resources -> Blog link on home page

### DIFF
--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -166,9 +166,7 @@ keywords = "search engine, vector database, neural network, matching, filter, Sa
     name = "Blog"
     weight = 5
     parent = "resources"
-    url = "https://blog.qdrant.tech/"
-    [menu.main.params]
-      external = true
+    url = "https://qdrant.tech/blog/"
 
   [[menu.main]]
     identifier = "roadmap"


### PR DESCRIPTION
The current home page includes a link from Resources -> Blog to blog.qdrant.tech. That seems out of date

![obsolete_blog_link](https://github.com/qdrant/landing_page/assets/3287976/7aed8f4c-8501-4d42-940b-23b41566e4df)
