### PR TITLE
Documentation for parameterized integer index

### DIFF
--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -185,22 +185,40 @@ Available tokenizers are:
 
 See [Full Text match](../filtering/#full-text-match) for examples of querying with full-text index.
 
-### Integer index parameters
+### Parameterized index
 
 *Available as of v1.8.0*
 
-The `integer` index also has a parameterized variant which allows fine-tuning
-indexing and search performance.
+We've added a parameterized variant to the `integer` index, which allows
+you to fine-tune indexing and search performance.
 
-Generally speaking, we recommend using the standard `integer` index variant
-above without parameters or fine-tuning. Accidentally configuring this
-incorrectly will have a significant effect on performance.
+Both the regular and parameterized `integer` indexes use the following flags:
 
-The following flags can be set to build an optimized index:
-- `lookup` - `true` to enable support for direct lookup ([Match](../filtering/#match)) filters, `false` to disable
-- `range` - `true` to enable support for [Range](../filtering/#range) filters, `false` to disable
+- `lookup`: enables support for direct lookup using
+  [Match](/documentation/concepts/filtering/#match) filters.
+- `range`: enables support for
+  [Range](/documentation/concepts/filtering/#range) filters.
 
-For example, to set up an optimized integer index only supporting range filters:
+The regular `integer` index assumes both `lookup` and `range` are `true`. In
+contrast, to configure a parameterized index, you would set only one of these
+filters to `true`:
+
+| `lookup` | `range` | Result                      |
+|----------|---------|-----------------------------|
+| `true`   | `true`  | Regular integer index       |
+| `true`   | `false` | Parameterized integer index |
+| `false`  | `true`  | Parameterized integer index |
+| `false`  | `false` | No integer index            |
+
+The parameterized index can enhance performance in collections with millions
+of points. We encourage you to try it out. If it does not enhance performance
+in your use case, you can always restore the regular `integer` index.
+
+Note: If you set `"lookup": true` with a range filter, that may lead to
+significant performance issues.
+
+For example, the following code sets up a parameterized integer index which
+supports only range filters:
 
 ```http
 PUT /collections/{collection_name}/index

--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -185,6 +185,94 @@ Available tokenizers are:
 
 See [Full Text match](../filtering/#full-text-match) for examples of querying with full-text index.
 
+### Integer index parameters
+
+*Available as of v1.8.0*
+
+The `integer` index also has a parameterized variant which allows fine-tuning
+indexing and search performance.
+
+Generally speaking, we recommend using the standard `integer` index variant
+above without parameters or fine-tuning. Accidentally configuring this
+incorrectly will have a significant effect on performance.
+
+The following flags can be set to build an optimized index:
+- `lookup` - `true` to enable support for direct lookup ([Match](../filtering/#match)) filters, `false` to disable
+- `range` - `true` to enable support for [Range](../filtering/#range) filters, `false` to disable
+
+For example, to set up an optimized integer index only supporting range filters:
+
+```http
+PUT /collections/{collection_name}/index
+{
+    "field_name": "name_of_the_field_to_index",
+    "field_schema": {
+        "type": "integer",
+        "lookup": false,
+        "range": true
+    }
+}
+```
+
+```python
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+
+client = QdrantClient(host="localhost", port=6333)
+
+client.create_payload_index(
+    collection_name="{collection_name}",
+    field_name="name_of_the_field_to_index",
+    field_schema=models.IntegerParams(
+        type="integer",
+        lookup=False,
+        range=True,
+    ),
+)
+```
+
+```typescript
+import { QdrantClient, Schemas } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createPayloadIndex("{collection_name}", {
+  field_name: "name_of_the_field_to_index",
+  field_schema: {
+    type: "integer",
+    lookup: false,
+    range: true,
+  },
+});
+```
+
+```rust
+use qdrant_client::{
+    client::QdrantClient,
+    qdrant::{
+        payload_index_params::IndexParams, FieldType, PayloadIndexParams,
+        IntegerParams, TokenizerType,
+    },
+};
+
+let client = QdrantClient::from_url("http://localhost:6334").build()?;
+
+client
+    .create_field_index(
+        "{collection_name}",
+        "name_of_the_field_to_index",
+        FieldType::Integer,
+        Some(&PayloadIndexParams {
+            index_params: Some(IndexParams::IndexParams(IndexParams {
+                lookup: false,
+                range: true,
+            })),
+        }),
+        None,
+    )
+    .await?;
+```
+
 ## Vector Index
 
 A vector index is a data structure built on vectors through a specific mathematical model.

--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -223,7 +223,7 @@ client = QdrantClient(host="localhost", port=6333)
 client.create_payload_index(
     collection_name="{collection_name}",
     field_name="name_of_the_field_to_index",
-    field_schema=models.IntegerParams(
+    field_schema=models.IntegerIndexParams(
         type="integer",
         lookup=False,
         range=True,
@@ -251,7 +251,7 @@ use qdrant_client::{
     client::QdrantClient,
     qdrant::{
         payload_index_params::IndexParams, FieldType, PayloadIndexParams,
-        IntegerParams, TokenizerType,
+        IntegerIndexParams, TokenizerType,
     },
 };
 
@@ -263,7 +263,7 @@ client
         "name_of_the_field_to_index",
         FieldType::Integer,
         Some(&PayloadIndexParams {
-            index_params: Some(IndexParams::IndexParams(IndexParams {
+            index_params: Some(IndexParams::IntegerIndexParams(IntegerIndexParams {
                 lookup: false,
                 range: true,
             })),


### PR DESCRIPTION
Documentation for Qdrant 1.8.

This documents the parameterized integer index added in <https://github.com/qdrant/qdrant/pull/3380>.

It is a specialized integer index type, that some might want to use for further fine-tuning. Generally speaking it is recommended to use the standard integer index without parameters.

Rendered: https://deploy-preview-520--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/indexing/#integer-index-parameters