### PR TITLE
Update link checker CI/CD job

### DIFF
--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -22,6 +22,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.9.1
         with:
-          args: --offline qdrant-landing/public
+          args: 'qdrant-landing/public'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -20,9 +20,8 @@ jobs:
         run: cd qdrant-landing && hugo -b 'https://qdrant.tech/'
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.8.0
+        uses: lycheeverse/lychee-action@v1.9.1
         with:
           args: --offline qdrant-landing/public
-          fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,3 +6,4 @@ file://.*
 http://localhost.*
 https://your-application-name.*
 https://fonts.googleapis.com/
+https://qdrant.to/linkedin

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -35,7 +35,7 @@ If you offload vectors to a local disk, we recommend you use a solid-state (SSD 
 Each Qdrant instance requires three open ports:
 
 * `6333` - For the HTTP API, for the [Monitoring](/documentation/guides/monitoring/) health and metrics endpoints
-* `6334` - For the [gRPC](https://abc.def) API
+* `6334` - For the [gRPC](/documentation/interfaces/#grpc-interface) API
 * `6335` - For [Distributed deployment](/documentation/guides/distributed_deployment/)
 
 All Qdrant instances in a cluster must be able to:

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -35,7 +35,7 @@ If you offload vectors to a local disk, we recommend you use a solid-state (SSD 
 Each Qdrant instance requires three open ports:
 
 * `6333` - For the HTTP API, for the [Monitoring](/documentation/guides/monitoring/) health and metrics endpoints
-* `6334` - For the [gRPC](/documentation/interfaces/#grpc-interface) API
+* `6334` - For the [gRPC](https://abc.def) API
 * `6335` - For [Distributed deployment](/documentation/guides/distributed_deployment/)
 
 All Qdrant instances in a cluster must be able to:


### PR DESCRIPTION
@generall , someone was asking, why doesn't our CI/CD check our links. I realized (see screenshot) that lychee has been set up and essentially disabled. 

With the recent fixes made to .lycheeignore and updating to v1.9.1, I suggest it's time to have a working link checker in our CI/CD. So I've set up this PR to update the internal-dead-links.yml file. 

With this PR, the link check job still shows green, even with broken links. But until we're sure that the CI/CD job really works, maybe that's OK? Or should we push it now (and include Nirant's URL in `.lycheeignore`?


![Screenshot from 2024-01-18 10-41-07](https://github.com/qdrant/landing_page/assets/3287976/644e7907-1b7f-4bbd-824d-571d5bc7aed0)
