### PR TITLE
Removed sendFeedback function

### DIFF
--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -83,7 +83,6 @@ keywords = "search engine, vector database, neural network, matching, filter, Sa
 
 [params.feedback]
   enable = true
-  max_value = 100
   title = "Feedback"
   question = "Was this page helpful?"
   positive = "Yes"

--- a/qdrant-landing/themes/qdrant/layouts/partials/feedback.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/feedback.html
@@ -23,24 +23,13 @@
     yesButton.disabled = true;
     noButton.disabled = true;
   };
-  const sendFeedback = (value) => {
-    if (typeof gtag !== 'function') return;
-    gtag('event', 'page_helpful', {
-      'event_category': 'Helpful',
-      'event_label': window.location.pathname,
-      'value': value
-    });
-  };
   yesButton.addEventListener('click', () => {
     yesResponse.classList.add('feedback__response_visible');
     disableButtons();
-    {{ $maxValue := .Site.Params.feedback.max_value | default 100 -}}
-    sendFeedback({{ $maxValue }});
   });
   noButton.addEventListener('click', () => {
     noResponse.classList.add('feedback__response_visible');
     disableButtons();
-    sendFeedback(0);
   });
 </script>
 


### PR DESCRIPTION
@generall @mjang it's appeared that we should not trigger GA events programmatically, and will do it from GTM interface. You can ask @Alyonkka for additional information.

In this PR: removed `sendFeedback` function and it's call because we need to do it from GTM UI, not programmatically.