### PR TITLE
Set up an index page for concepts

### DIFF
--- a/qdrant-landing/content/documentation/concepts/_index.md
+++ b/qdrant-landing/content/documentation/concepts/_index.md
@@ -11,7 +11,7 @@ concepts can help you learn more about AI and the Qdrant approach.
 
 | Concept                                             | Description                                                                                                          |
 |-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| [Collections](/documentation/concepts/collections/) | Defines a named set of [points](/documentation/concepts/collections/points/) that you can use for your search        |
+| [Collections](/documentation/concepts/collections/) | Defines a named set of [points](/documentation/concepts/points/) that you can use for your search        |
 | [Payload](/documentation/concepts/payload/)         | Describes information that you can store with vectors                                                                |
 | [Points](/documentation/concepts/points/)           | Discusses a record which consists of a vector and an optional [payload](/documentation/concepts/collections/payload/ |
 | [Search](/documentation/concepts/search/)           | Describes _similarity search_, which set up related objects close to each other in vector space                      |

--- a/qdrant-landing/content/documentation/concepts/_index.md
+++ b/qdrant-landing/content/documentation/concepts/_index.md
@@ -2,7 +2,6 @@
 title: Concepts
 weight: 21
 # If the index.md file is empty, the link to the section will be hidden from the sidebar
-is_empty: true
 ---
 
 # Concepts

--- a/qdrant-landing/content/documentation/concepts/_index.md
+++ b/qdrant-landing/content/documentation/concepts/_index.md
@@ -10,44 +10,44 @@ Think of these concepts as a glossary. Each of these concepts include a link to
 detailed information, usually with examples. If you're new to AI, these concepts
 can help you learn more about AI and the Qdrant approach.
 
-##### Collections
+## Collections
 
-[Collections](/documentation/concepts/collections/) define a named set of [points](/documentation/concepts/points/) that you can use for your search.
+[Collections](/documentation/concepts/collections/) define a named set of points that you can use for your search.
 
-##### Payload
+## Payload
 
 A [Payload](/documentation/concepts/payload/) describes information that you can store with vectors.
 
-##### Points
+## Points
 
-[Points](/documentation/concepts/points/) are a record which consists of a vector and an optional [payload](/documentation/concepts/collections/payload/). 
+[Points](/documentation/concepts/points/) are a record which consists of a vector and an optional payload. 
 
-##### Search
+## Search
 
 [Search](/documentation/concepts/search/) describes _similarity search_, which set up related objects close to each other in vector space.
 
-##### Explore
+## Explore
 
 [Explore](/documentation/concepts/explore/) includes several APIs for exploring data in your collections.
 
-##### Filtering
+## Filtering
 
 [Filtering](/documentation/concepts/filtering/) defines various database-style clauses, conditions, and more.
 
-##### Optimizer
+## Optimizer
 
 [Optimizer](/documentation/concepts/optimizer/) describes options to rebuild
 database structures for faster search. They include a vacuum, a merge, and an
 indexing optimizer.
 
-##### Storage
+## Storage
 
 [Storage](/documentation/concepts/storage/) describes the configuration of storage in segments, which include indexes and an ID mapper.
 
-##### Indexing
+## Indexing
 
 [Indexing](/documentation/concepts/indexing/) lists and describes available indexes. They include payload, vector, sparse vector, and a filterable index.
 
-##### Snapshots
+## Snapshots
 
 [Snapshots](/documentation/concepts/snapshots/) describe the backup/restore process (and more) for each node at specific times.

--- a/qdrant-landing/content/documentation/concepts/_index.md
+++ b/qdrant-landing/content/documentation/concepts/_index.md
@@ -6,18 +6,48 @@ weight: 21
 
 # Concepts
 
-Think of these concepts as a detailed glossary. If you're new to AI, these
-concepts can help you learn more about AI and the Qdrant approach.
+Think of these concepts as a glossary. Each of these concepts include a link to
+detailed information, usually with examples. If you're new to AI, these concepts
+can help you learn more about AI and the Qdrant approach.
 
-| Concept                                             | Description                                                                                                          |
-|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| [Collections](/documentation/concepts/collections/) | Defines a named set of [points](/documentation/concepts/points/) that you can use for your search        |
-| [Payload](/documentation/concepts/payload/)         | Describes information that you can store with vectors                                                                |
-| [Points](/documentation/concepts/points/)           | Discusses a record which consists of a vector and an optional [payload](/documentation/concepts/collections/payload/ |
-| [Search](/documentation/concepts/search/)           | Describes _similarity search_, which set up related objects close to each other in vector space                      |
-| [Explore](/documentation/concepts/explore/)         | Includes several APIs for exploring data in your collections                                                         |
-| [Filtering](/documentation/concepts/filtering/)     | Defines various database-style conditions                                                                            |
-| [Optimizer](/documentation/concepts/optimizer/)     | Describes options to rebuild database structures for faster search                                                   |
-| [Storage](/documentation/concepts/storage/)         | Describes the configuration of storage in segments, which include indexes and an ID mapper                           |
-| [Indexing](/documentation/concepts/indexing/)       | Lists and describes available indexes                                                                                |
-| [Snapshots](/documentation/concepts/snapshots/)     | Describes the backup/restore process (and more) for each node at specific times                                      |
+##### Collections
+
+[Collections](/documentation/concepts/collections/) define a named set of [points](/documentation/concepts/points/) that you can use for your search.
+
+##### Payload
+
+A [Payload](/documentation/concepts/payload/) describes information that you can store with vectors.
+
+##### Points
+
+[Points](/documentation/concepts/points/) are a record which consists of a vector and an optional [payload](/documentation/concepts/collections/payload/). 
+
+##### Search
+
+[Search](/documentation/concepts/search/) describes _similarity search_, which set up related objects close to each other in vector space.
+
+##### Explore
+
+[Explore](/documentation/concepts/explore/) includes several APIs for exploring data in your collections.
+
+##### Filtering
+
+[Filtering](/documentation/concepts/filtering/) defines various database-style clauses, conditions, and more.
+
+##### Optimizer
+
+[Optimizer](/documentation/concepts/optimizer/) describes options to rebuild
+database structures for faster search. They include a vacuum, a merge, and an
+indexing optimizer.
+
+##### Storage
+
+[Storage](/documentation/concepts/storage/) describes the configuration of storage in segments, which include indexes and an ID mapper.
+
+##### Indexing
+
+[Indexing](/documentation/concepts/indexing/) lists and describes available indexes. They include payload, vector, sparse vector, and a filterable index.
+
+##### Snapshots
+
+[Snapshots](/documentation/concepts/snapshots/) describe the backup/restore process (and more) for each node at specific times.

--- a/qdrant-landing/content/documentation/concepts/_index.md
+++ b/qdrant-landing/content/documentation/concepts/_index.md
@@ -4,3 +4,21 @@ weight: 21
 # If the index.md file is empty, the link to the section will be hidden from the sidebar
 is_empty: true
 ---
+
+# Concepts
+
+Think of these concepts as a detailed glossary. If you're new to AI, these
+concepts can help you learn more about AI and the Qdrant approach.
+
+| Concept                                             | Description                                                                                                          |
+|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| [Collections](/documentation/concepts/collections/) | Defines a named set of [points](/documentation/concepts/collections/points/) that you can use for your search        |
+| [Payload](/documentation/concepts/payload/)         | Describes information that you can store with vectors                                                                |
+| [Points](/documentation/concepts/points/)           | Discusses a record which consists of a vector and an optional [payload](/documentation/concepts/collections/payload/ |
+| [Search](/documentation/concepts/search/)           | Describes _similarity search_, which set up related objects close to each other in vector space                      |
+| [Explore](/documentation/concepts/explore/)         | Includes several APIs for exploring data in your collections                                                         |
+| [Filtering](/documentation/concepts/filtering/)     | Defines various database-style conditions                                                                            |
+| [Optimizer](/documentation/concepts/optimizer/)     | Describes options to rebuild database structures for faster search                                                   |
+| [Storage](/documentation/concepts/storage/)         | Describes the configuration of storage in segments, which include indexes and an ID mapper                           |
+| [Indexing](/documentation/concepts/indexing/)       | Lists and describes available indexes                                                                                |
+| [Snapshots](/documentation/concepts/snapshots/)     | Describes the backup/restore process (and more) for each node at specific times                                      |


### PR DESCRIPTION
I'd like us to present an overview of all concepts shown in our docs. With this PR, I've set this up as a table, with links to each concept.

Build of new page: https://deploy-preview-559--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/ 

