### PR TITLE
docs: List mininum requirements for using the inline content in the c…

### DIFF
--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -173,6 +173,8 @@ configs:
       log_level: INFO  
 ```
 
+<aside role="status">Proving the inline <code>content</code> in the <a href="https://docs.docker.com/compose/compose-file/08-configs/">configs top-level element</a> requires <a href="https://docs.docker.com/compose/release-notes/#2231">Docker Compose v2.23.1</a> and above. This functionality is supported starting <a href="https://docs.docker.com/engine/release-notes/25.0/#2500">Docker Engine v25.0.0</a> and <a href="https://docs.docker.com/desktop/release-notes/#4260">Docker Desktop v4.26.0</a> onwards.</aside>
+
 ### From source
 
 Qdrant is written in Rust and can be compiled into a binary executable.

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -173,7 +173,7 @@ configs:
       log_level: INFO  
 ```
 
-<aside role="status">Proving the inline <code>content</code> in the <a href="https://docs.docker.com/compose/compose-file/08-configs/">configs top-level element</a> requires <a href="https://docs.docker.com/compose/release-notes/#2231">Docker Compose v2.23.1</a> and above. This functionality is supported starting <a href="https://docs.docker.com/engine/release-notes/25.0/#2500">Docker Engine v25.0.0</a> and <a href="https://docs.docker.com/desktop/release-notes/#4260">Docker Desktop v4.26.0</a> onwards.</aside>
+<aside role="status">Proving the inline <code>content</code> in the <a href="https://docs.docker.com/compose/compose-file/08-configs/">configs top-level element</a> requires <a href="https://docs.docker.com/compose/release-notes/#2231">Docker Compose v2.23.1</a> or above. This functionality is supported starting <a href="https://docs.docker.com/engine/release-notes/25.0/#2500">Docker Engine v25.0.0</a> and <a href="https://docs.docker.com/desktop/release-notes/#4260">Docker Desktop v4.26.0</a> onwards.</aside>
 
 ### From source
 


### PR DESCRIPTION
…onfigs top-level element of a docker compose file.

References:
https://github.com/compose-spec/compose-spec/pull/429
https://github.com/compose-spec/compose-spec/pull/446

This might be increasingly less important issue, but I have experienced it, as I don't update docker engine on Linux automatically. 