### PR TITLE
docs: Correct path in the GitHub feedback links on Windows systems.

### DIFF
--- a/qdrant-landing/themes/qdrant/layouts/partials/feedback.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/feedback.html
@@ -10,7 +10,7 @@
   </p>
   <p class="feedback__response feedback__response_no">
     {{.Site.Params.feedback.on_no | safeHTML }}
-    <br>You can <a class="text-brand-p" href="{{ .Site.Params.githubDocPrefix }}{{ .File.Path }}" target="_blank">edit</a> this page on GitHub, or <a class="text-brand-p" href="{{ .Site.Params.githubIssueLink }}" target="_blank">create</a> a GitHub issue.
+    <br>You can <a class="text-brand-p" href="{{ .Site.Params.githubDocPrefix }}{{ path.Clean .File.Path }}" target="_blank">edit</a> this page on GitHub, or <a class="text-brand-p" href="{{ .Site.Params.githubIssueLink }}" target="_blank">create</a> a GitHub issue.
   </p>
 </div>
 

--- a/qdrant-landing/themes/qdrant/layouts/partials/table_of_content.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/table_of_content.html
@@ -9,7 +9,7 @@
         <div class="divider mb-2"></div>
         <ul class="tableOfContent__footer">
             <li>
-                <a class="text-brand-p" href="{{ .Site.Params.githubDocPrefix }}{{ .File.Path }}" target="_blank">
+                <a class="text-brand-p" href="{{ .Site.Params.githubDocPrefix }}{{ path.Clean .File.Path }}" target="_blank">
                     <i class="fab fa-github"></i> Edit on GitHub
                 </a>
             </li>


### PR DESCRIPTION
This will allow for correct path in the GitHub URLs on Windows systems in development.