### PR TITLE
Reference to 'Official' clients

### DIFF
--- a/qdrant-landing/content/documentation/interfaces.md
+++ b/qdrant-landing/content/documentation/interfaces.md
@@ -5,6 +5,9 @@ weight: 14
 
 # Interfaces
 
+These are the "official" clients used by Qdrant. The groups behind each client
+are responsible for their support.
+
 > **Note:** If you are using a language that is not listed here, you can use the REST API directly or generate a client for your language 
 using [OpenAPI](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)
 or [protobuf](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/proto) definitions. 

--- a/qdrant-landing/content/documentation/interfaces.md
+++ b/qdrant-landing/content/documentation/interfaces.md
@@ -5,8 +5,7 @@ weight: 14
 
 # Interfaces
 
-These are the "official" clients used by Qdrant. The organizations behind each client
-are responsible for their support.
+Qdrant supports these "official" clients. 
 
 > **Note:** If you are using a language that is not listed here, you can use the REST API directly or generate a client for your language 
 using [OpenAPI](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)

--- a/qdrant-landing/content/documentation/interfaces.md
+++ b/qdrant-landing/content/documentation/interfaces.md
@@ -5,7 +5,7 @@ weight: 14
 
 # Interfaces
 
-These are the "official" clients used by Qdrant. The groups behind each client
+These are the "official" clients used by Qdrant. The organizations behind each client
 are responsible for their support.
 
 > **Note:** If you are using a language that is not listed here, you can use the REST API directly or generate a client for your language 


### PR DESCRIPTION
The docs cite "official clients" in several locations. I've included "official clients" in the [Interfaces](https://qdrant.tech/documentation/interfaces/) page, to reflect my understanding from @generall .

Anyone who uses our search text box to search for "official clients" should then see it on the Interfaces page.