### PR TITLE
Link to the trust center

### DIFF
--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -188,6 +188,15 @@ keywords = "search engine, vector database, neural network, matching, filter, Sa
     [menu.main.params]
         external = true
 
+  [[menu.main]]
+    identifier = "trust-center"
+    name = "Trust Center"
+    weight = 8
+    parent = "resources"
+    url = "http://qdrant.to/trust-center"
+    [menu.main.params]
+      external = true
+
 [[menu.main]]
   identifier = "community"
   name = "Community"


### PR DESCRIPTION
Added a link to the trust center under the Resources submenu:

![image](https://github.com/qdrant/landing_page/assets/7085263/53419037-2071-45cc-a8c1-9f779c9b269d)
