### PR TITLE
Removed sitemapExclude parameter from the blog index

### DIFF
--- a/qdrant-landing/content/blog/_index.md
+++ b/qdrant-landing/content/blog/_index.md
@@ -1,5 +1,4 @@
 ---
 title: Qdrant Blog
 subtitle: Check out our latest posts
-sitemapExclude: True
 ---


### PR DESCRIPTION
Not excludes the blog index from site map anymore and fixes this:
> They noticed that our blog homepage has a noindex tag, which we should remove.
