### PR TITLE
Add documentation for `datetime` payload (v1.8)

### DIFF
--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -1821,12 +1821,11 @@ datetimeRange("date",
 
 ```csharp
 using Qdrant.Client.Grpc;
-using System;
 
 Conditions.DatetimeRange(
     field: "date",
     gt: new DateTime(2023, 2, 8, 10, 49, 0, DateTimeKind.Utc),
-    lte: new DateTime(2024, 1, 31, 10, 14, 31, DateTimeKind.Utc),
+    lte: new DateTime(2024, 1, 31, 10, 14, 31, DateTimeKind.Utc)
 );
 ```
 

--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -1749,6 +1749,9 @@ Can be applied to [float](../payload/#float) and [integer](../payload/#integer) 
 
 ### Datetime Range
 
+The datetime range is a unique range condition, used for [datetime](../payload/#datetime) payloads, which supports RFC 3339 formats. 
+You do not need to convert dates to UNIX timestaps. During comparison, timestamps are parsed and converted to UTC.
+
 _Available as of v1.8.0_
 
 ```json

--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -1747,6 +1747,90 @@ Comparisons that can be used:
 
 Can be applied to [float](../payload/#float) and [integer](../payload/#integer) payloads.
 
+### Datetime Range
+
+_Available as of v1.8.0_
+
+```json
+{
+  "key": "date",
+  "range": {
+    "gt": "2023-02-08T10:49:00Z"
+    "gte": null,
+    "lt": null,
+    "lte": "2024-01-31 10:14:31Z"
+  }
+}
+```
+
+```python
+models.FieldCondition(
+    key="date",
+    range=models.DatetimeRange(
+        gt="2023-02-08T10:49:00Z",
+        gte=None,
+        lt=None,
+        lte="2024-01-31T10:14:31Z",
+    ),
+)
+```
+
+```typescript
+{
+    key: 'date',
+    range: {
+        gt: '2023-02-08T10:49:00Z',
+        gte: null,
+        lt: null,
+        lte: '2024-01-31T10:14:31Z'
+    }
+}
+```
+
+```rust
+Condition::datetime_range(
+    "date",
+    DatetimeRange {
+        gt: Some(Timestamp::date_time(2023, 2, 8, 10, 49, 0).unwrap()),
+        gte: None,
+        lt: None,
+        lte: Some(Timestamp::date_time(2024, 1, 31, 10, 14, 31).unwrap()),
+    },
+)
+```
+
+```java
+import static io.qdrant.client.ConditionFactory.datetimeRange;
+
+import com.google.protobuf.Timestamp;
+import io.qdrant.client.grpc.Points.DatetimeRange;
+import java.time.Instant;
+
+long gt = Instant.parse("2023-02-08T10:49:00Z").getEpochSecond();
+long lte = Instant.parse("2024-01-31T10:14:31Z").getEpochSecond();
+
+datetimeRange("date",
+    DatetimeRange.newBuilder()
+        .setGt(Timestamp.newBuilder().setSeconds(gt))
+        .setLte(Timestamp.newBuilder().setSeconds(lte))
+        .build());
+```
+
+```csharp
+using Qdrant.Client.Grpc;
+using System;
+
+Conditions.DatetimeRange(
+    field: "date",
+    gt: new DateTime(2023, 2, 8, 10, 49, 0, DateTimeKind.Utc),
+    lte: new DateTime(2024, 1, 31, 10, 14, 31, DateTimeKind.Utc),
+);
+```
+
+Datetime range is a special case of the range condition, which is used for [datetime](../payload/#datetime) payloads.
+It shares the same field names as the range condition.
+During comparison, timestamps are parsed and converted to UTC.
+
 ### Geo
 
 #### Geo Bounding Box

--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -1829,10 +1829,6 @@ Conditions.DatetimeRange(
 );
 ```
 
-Datetime range is a special case of the range condition, which is used for [datetime](../payload/#datetime) payloads.
-It shares the same field names as the range condition.
-During comparison, timestamps are parsed and converted to UTC.
-
 ### Geo
 
 #### Geo Bounding Box

--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -105,8 +105,9 @@ Available field types are:
 * `keyword` - for [keyword](../payload/#keyword) payload, affects [Match](../filtering/#match) filtering conditions.
 * `integer` - for [integer](../payload/#integer) payload, affects [Match](../filtering/#match) and [Range](../filtering/#range) filtering conditions.
 * `float` - for [float](../payload/#float) payload, affects [Range](../filtering/#range) filtering conditions.
-* `bool` - for [bool](../payload/#bool) payload, affects [Match](../filtering/#match) filtering conditions (available as of 1.4.0).
+* `bool` - for [bool](../payload/#bool) payload, affects [Match](../filtering/#match) filtering conditions (available as of v1.4.0).
 * `geo` - for [geo](../payload/#geo) payload, affects [Geo Bounding Box](../filtering/#geo-bounding-box) and [Geo Radius](../filtering/#geo-radius) filtering conditions.
+* `datetime` - for [datetime](../payload/#datetime) payload, affects [Range](../filtering/#range) filtering conditions (available as of v1.8.0).
 * `text` - a special kind of index, available for [keyword](../payload/#keyword) / string payloads, affects [Full Text search](../filtering/#full-text-match) filtering conditions.
 
 Payload index may occupy some additional memory, so it is recommended to only use index for those fields that are used in filtering conditions.

--- a/qdrant-landing/content/documentation/concepts/payload.md
+++ b/qdrant-landing/content/documentation/concepts/payload.md
@@ -143,7 +143,7 @@ Coordinate should be described as an object containing two fields: `lon` - for l
 
 `datetime` - date and time in [RFC 3339] format.
 
-Example of single and multiple `datetime` values:
+See the following examples of single and multiple `datetime` values:
 
 ```json
 {

--- a/qdrant-landing/content/documentation/concepts/payload.md
+++ b/qdrant-landing/content/documentation/concepts/payload.md
@@ -137,6 +137,35 @@ Example of single and multiple `geo` values:
 
 Coordinate should be described as an object containing two fields: `lon` - for longitude, and `lat` - for latitude.
 
+### Datetime
+
+*Available as of v1.8.0*
+
+`datetime` - date and time in [RFC 3339] format.
+
+Example of single and multiple `datetime` values:
+
+```json
+{
+    "created_at": "2023-02-08T10:49:00Z",
+    "updated_at": [
+        "2023-02-08T13:52:00Z",
+        "2023-02-21T21:23:00Z"
+    ]
+}
+```
+
+The following formats are supported:
+- `"2023-02-08T10:49:00Z"` ([RFC 3339], UTC)
+- `"2023-02-08T11:49:00+01:00"` ([RFC 3339], with timezone)
+- `"2023-02-08T10:49:00"` (without timezone, UTC is assumed)
+- `"2023-02-08T10:49"` (without timezone and seconds)
+- `"2023-02-08"` (only date, midnight is assumed)
+
+The `T` and `Z` symbols are case-insensitive, and `T` can be replaced with a space.
+
+[RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+
 ## Create point with payload
 REST API ([Schema](https://qdrant.github.io/qdrant/redoc/index.html#tag/points/operation/upsert_points))
 


### PR DESCRIPTION
Related issue: https://github.com/qdrant/qdrant/issues/3320.