### PR TITLE
Add advice about number of nodes to distributed_deployment

### DIFF
--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -819,10 +819,11 @@ Let's walk through them from best to worst.
 
 **Recover with replicated collection**
 
-If the number of failed nodes is less than the replication factor of the collection, then no data is lost.
-Your cluster should still be able to perform read, search and update queries.
+If the number of failed nodes is less than the replication factor of the collection, then your cluster should still be able to perform read, search and update queries.
 
 Now, if the failed node restarts, consensus will trigger the replication process to update the recovering node with the newest updates it has missed.
+
+If the failed node never restarts, you can recover the lost shards if you have a 3+ node cluster. You cannot recover lost shards in smaller clusters because recovery operations go through [raft](#raft) which requires >50% of the nodes to be healthy.
 
 **Recreate node with replicated collections**
 

--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -13,17 +13,22 @@ In this mode, multiple Qdrant services communicate with each other to distribute
 
 ## How many Qdrant nodes should I run?
 
-The ideal number of Qdrant nodes depends on how much you value resilience, performance/scalability, and cost-saving in relation to each other.
+The ideal number of Qdrant nodes depends on how much you value cost-saving, resilience, and performance/scalability in relation to each other.
 
-If you need to save on costs above all else, you can run a single Qdrant node. The downsides are that your cluster will experience downtime during node restarts, performance is limited to the resources of a single server, and the full loss of one node cannot be recovered from without backups. Single-node clusters are generally only recommended for non-production workloads.
+- **Prioritizing cost-saving**: If cost is most important to you, run a single Qdrant node. This is not recommended for production environments. Drawbacks:
+  - Resilience: Users will experience downtime during node restarts, and recovery is not possible unless you have backups or snapshots.
+  - Performance: Limited to the resources of a single server.
 
-If you need to ensure your cluster does not experience downtime during maintenance, you can run two or more Qdrant nodes with replicated shards. Running only two nodes means your cluster will still respond to most read and write requests even when one node goes down, but not operations on collections. Creating, editing, and deleting collections must flow through the consensus protocol, so you need at least two healthy nodes to perform collection operations. Since collection operations are rarely needed, two-node clusters are a good balance between resilience and cost.
+- **Prioritizing resilience**: If resilience is most important to you, run a Qdrant cluster with three or more nodes and two or more shard replicas. Clusters with three or more nodes and replication can perform all operations even while one node is down. Additionally, they gain performance benefits from load-balancing and they can recover from the permanent loss of one node without the need for backups or snapshots (but backups are still strongly recommended). This is most recommended for production environments. Drawbacks:
+   - Cost: Larger clusters are be more costly than smaller clusters, which is the only drawback of this configuration.
 
-If you need to increase performance or scalability, you can run two or more Qdrant nodes without replicating shards to every node. By not replicating shards, you gain the ability to scale beyond a single node, and you gain performance benefits without having to use up as much RAM or disk space. The downside is that resilience suffers, since non-replicated shards cannot be served when the node holding that shard is down.
+- **Balancing cost, resilience, and performance**: Running a two-node Qdrant cluster with replicated shards allows the cluster to respond to most read/write requests even when one node is down, such as during maintenance events. Having two nodes also means greater performance than a single-node cluster while still being cheaper than a three-node cluster. Drawbacks:
+   - Resilience (uptime): The cluster cannot perform operations on collections when one node is down. Those operations require >50% of nodes to be running, so this is only possible in a 3+ node cluster. Since creating, editing, and deleting collections are usually rare operations, many user find this drawback to be negligible.
+   - Resilience (data integrity): If the data on one of the two nodes is permanently lost or corrupted, it cannot be recovered aside from snapshots or backups. Only 3+ node clusters can recover from the permanent loss of a single node since recovery operations require >50% of the cluster to be healthy.
+   - Cost: Replicating your shards requires storing two copies of your data.
+   - Performance: The maximum performance of a Qdrant cluster increases as you add more nodes.
 
-If you need to maximize resilience and performance/scalability, you can run three or more Qdrant nodes, with each shard replicated to at least two nodes. Running three nodes means all operations continue to work when one node is down, and you gain the increased performance/scalability from the multiple nodes.
-
-In summary, single-node clusters are best for non-production workloads, replicated two-node clusters strike a good balance, but replicated 3+ node clusters are the gold standard.
+In summary, single-node clusters are best for non-production workloads, replicated 3+ node clusters are the gold standard, and replicated 2-node clusters strike a good balance.
 
 ## Enabling distributed mode in self-hosted Qdrant
 

--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -127,17 +127,23 @@ Example result:
 }
 ```
 
+Note that enabling distributed mode does not automatically replicate your data. See the section on [making use of a new distributed Qdrant cluster](#making-use-of-a-new-distributed-qdrant-cluster) for the next steps.
+
 ## Enabling distributed mode in Qdrant Cloud
 
-In Qdrant Cloud, when you click "Scale Up" to increase your cluster size to >1, the distributed mode settings are set automatically, resulting in a new empty node starting up. For best results, ensure your cluster is running Qdrant v1.7.4 or higher.
+For best results, first ensure your cluster is running Qdrant v1.7.4 or higher. Older versions of Qdrant do support distributed mode, but improvements in v1.7.4 make distributed clusters more resilient during outages.
+
+In the [Qdrant Cloud console](https://cloud.qdrant.io/), click "Scale Up" to increase your cluster size to >1. Qdrant Cloud configures the distributed mode settings automatically.
+
+After the scale-up process completes, you will have a new empty node running alongside your existing node(s). To replicate data into this new empty node, see the next section.
 
 ## Making use of a new distributed Qdrant cluster
 
-When you enable distributed mode and scale up to 2 or more nodes, your data does not move to the new node automatically; it starts out empty. To make use of your new empty node, you will have to do one of the following:
+When you enable distributed mode and scale up to two or more nodes, your data does not move to the new node automatically; it starts out empty. To make use of your new empty node, do one of the following:
 
-* You can replicate your existing data to the new node by [creating new shard replicas](#creating-new-shard-replicas)
-* You can create a new replicated collection by setting the [replication_factor](#replication-factor) to 2 or more (can only be set at creation time)
-* You can move data (without replicating it) onto the new node by [moving shards](#moving-shards)
+* Replicate your existing data to the new node by [creating new shard replicas](#creating-new-shard-replicas)
+* Create a new replicated collection by setting the [replication_factor](#replication-factor) to 2 or more (can only be set at creation time)
+* Move data (without replicating it) onto the new node by [moving shards](#moving-shards)
 
 ## Raft
 
@@ -855,14 +861,14 @@ Once all shards of the collection are recovered, the collection will become oper
 
 ### Temporary node failure
 
-If properly configured, running Qdrant in distributed mode can make your cluster resistent to outages when one node is down temporarily.
+If properly configured, running Qdrant in distributed mode can make your cluster resistant to outages when one node fails temporarily.
 
-Here is how differently-configured Qdrant clusters respond to one node going down temporarily:
+Here is how differently-configured Qdrant clusters respond:
 
-* 1-node clusters: All operations will time out or fail for a few second to a few minutes, depending on how long it takes to restart and load data from disk.
-* 2-node clusters where shards ARE NOT replicated: All operations will time out or fail for a few second to a few minutes, depending on how long it takes to restart and load data from disk.
-* 2-node clusters where all shards ARE replicated to both nodes: All requests except for operations on collections will continue to work during the outage.
-* 3+-node clusters where all shards are replicated to at least 2 nodes: All requests will continue to work during the outage.
+* 1-node clusters: All operations time out or fail for up to a few minutes. It depends on how long it takes to restart and load data from disk.
+* 2-node clusters where shards ARE NOT replicated: All operations will time out or fail for up to a few minutes. It depends on how long it takes to restart and load data from disk.
+* 2-node clusters where all shards ARE replicated to both nodes: All requests except for operations on collections continue to work during the outage.
+* 3+-node clusters where all shards are replicated to at least 2 nodes: All requests continue to work during the outage.
 
 ## Consistency guarantees
 


### PR DESCRIPTION
Based on the slack thread in cloud-dev on March 4th, I've added some extra details about distributed setups.

Since we have Qdrant Cloud maintenance scheduled soon, some users are wanting to know exactly what to do to make their clusters highly available, and want to know exactly what happens when one node goes down temporarily.