### PR TITLE
Draft 2, Hybrid cloud

### DIFF
--- a/qdrant-landing/content/documentation/cloud/_index.md
+++ b/qdrant-landing/content/documentation/cloud/_index.md
@@ -7,41 +7,58 @@ aliases:
 
 # About Qdrant Cloud
 
-Qdrant Cloud is our SaaS (software-as-a-service) solution, providing managed Qdrant instances on the cloud.
-We provide you with the same fast and reliable similarity search engine, but without the need to maintain your own infrastructure.
+Qdrant Cloud is our SaaS (software-as-a-service) solution, providing managed 
+Qdrant instances on the cloud. We provide you the same fast and reliable 
+similarity search engine, but without the need to maintain your own infrastructure.
 
-Transitioning from on-premise to the cloud version of Qdrant does not require changing anything in the way you interact with the service. All you have to do is [create a Qdrant Cloud account](https://qdrant.to/cloud/) and [provide a new API key](/documentation/cloud/authentication/) to each request.
+Transitioning from on-premise to the cloud version of Qdrant does not change
+how you interact with the service. All you need is a [Qdrant Cloud account](https://qdrant.to/cloud/)
+and an [API key](/documentation/cloud/authentication/) for each request.
 
-The transition is even easier if you use the official client libraries. For example, the [Python Client](https://github.com/qdrant/qdrant-client/) has the support of the API key already built-in, so you only need to provide it once, when the QdrantClient instance is created.
+Our official [client libraries](/documentation/interfaces/#client-libraries/)
+can help. For example, if you use the [Python Client](https://github.com/qdrant/qdrant-client/)
+you can take advantage of the built-in API key. With that client, you provide
+the API key only once, when the QdrantClient instance is created.
 
-### Cluster configuration
+*Available as of v1.8.2* <!-- MUST CONFIRM -->
 
-Each instance comes pre-configured with the following tools, features and support services:
+You can also attach your own infrastructure as a private region on the Hybrid
+Cloud. Once attached, you can control this cloud using the same tools and UI
+that you use for other cloud providers. For details, see our 
+[Hybrid Cloud](/documentation/cloud/hybrid-cloud/) documentation.
 
-- Automatically created with the latest available version of Qdrant.
-- Upgradeable to later versions of Qdrant as they are released.
-- Equipped with monitoring and logging to observe the health of each cluster. 
-- Accessible through the Qdrant Cloud Console.
+## Cluster configuration
+
+Each instance comes pre-configured with the following tools, features, and 
+support services:
+
+- Uses the latest available version of Qdrant.
+- Supports upgrades to later versions of Qdrant as they are released.
+- Includes monitoring and logging to observe the health of each cluster.
+- Configurable through the Qdrant Cloud Console.
 - Vertically scalable.
-- Offered on AWS and GCP, with Azure currently in development. 
+- Available natively on AWS and GCP, and Azure. 
+- Available on other providers if you use the Hybrid Cloud.
 
-### Getting started with Qdrant Cloud
+## Getting started with Qdrant Cloud
 
-To use Qdrant Cloud, you will need to create at least one cluster. There are two ways to start:
+To use Qdrant Cloud, you need at least one cluster. You can create one in the
+following ways:
 
 1. [**Create a Free Tier cluster**](/documentation/cloud/quickstart-cloud/) with 
-   1 node and a default configuration (1 GB RAM, 0.5 CPU and 4 GB Disk). This
+   one node and a default configuration (1 GB RAM, 0.5 CPU and 4 GB Disk). This
    option is perfect for prototyping. You don't need a credit card to join.
-2. [**Configure a custom cluster**](/documentation/cloud/create-cluster/) with additional nodes and more resources. For this option, you will have to provide billing information.
+2. [**Configure a custom cluster**](/documentation/cloud/create-cluster/) with
+   additional nodes and resources. For this option, you need billing information.
 
-We recommend that you use the Free Tier cluster for testing purposes. The
-capacity should be enough to serve up to 1 M vectors of 768 dimensions. To
-calculate your needs, refer to our documentation on [Capacity and sizing](/documentation/cloud/capacity-sizing/). 
+If you're testing Qdrant, We recommend the Free Tier cluster. The capacity
+should be enough to serve up to 1 M vectors of 768 dimensions. To calculate
+your needs, refer to our documentation on [Capacity and sizing](/documentation/cloud/capacity-sizing/).
 
-### Support & Troubleshooting
+## Support & Troubleshooting
 
 All Qdrant Cloud users are welcome to join our [Discord community](https://qdrant.to/discord/).
 Our Support Engineers are available to help you anytime.
 
-Additionally, paid customers can also contact support through channels provided during cluster
+Paid customers can also contact support through channels provided during cluster
 creation and/or on-boarding.

--- a/qdrant-landing/content/documentation/cloud/hybrid-cloud.md
+++ b/qdrant-landing/content/documentation/cloud/hybrid-cloud.md
@@ -155,7 +155,7 @@ Make sure to select your hybrid cloud as the target region.
 
 ### Authentication at your Qdrant clusters
 
-### Exposing Qdrant Clusters to your client applications
+### Exposing Qdrant clusters to your client applications
 
 ## Operator configuration
 

--- a/qdrant-landing/content/documentation/cloud/hybrid-cloud.md
+++ b/qdrant-landing/content/documentation/cloud/hybrid-cloud.md
@@ -64,7 +64,7 @@ You can also mirror the images and charts to your own registry.
 
 ### Required artifacts
 
-To set up your cloud, you need the following:
+To set up your cloud, you need the following artifacts:
 
 Container images
 
@@ -73,7 +73,7 @@ Container images
 - `registry.cloud.qdrant.io/qdrant/qdrant-operator`
 - `registry.cloud.qdrant.io/qdrant/qdrant-cloud-cluster-manager`
 
-OCI Helm charts
+Open Containers Initiative (OCI) Helm charts
 
 - `registry.cloud.qdrant.io/qdrant-charts/qdrant-cloud-agent`
 - `registry.cloud.qdrant.io/qdrant-charts/qdrant-operator`
@@ -115,11 +115,14 @@ message:
 ### Hybrid Cloud regions
 
 Once you create a Hybrid Cloud Region, you can review what you just configured.
-You can also review the:
+In the UI, you can also review the:
 
-- Hybrid Cloud ID, which you can use in Kubernetes commands
-- Operator Pod State <!-- Need more info --> 
-- Agent Pod State <!-- Need more info -->
+- Hybrid Cloud ID: For use in Kubernetes commands
+- Operator Pod State: Typically `Unknown` or `Ready` 
+- Agent Pod State: Typically `Unknown` or `Ready`
+
+Until you run the Hybrid Cloud installation commands shown in this page, the
+state of the Operator and Agent Pods are typically unknown.
 
 ### Generate Installation Command
 
@@ -130,7 +133,7 @@ This includes several commands which:
 - Adds credentials to the Docker registry, labeled `qdrant-registry-creds`
 - Sets up a secret key based on an API key, labeled `access-key`. 
 - Signs into the Helm registry at `registry.cloud.qdrant.io`.
-- Installs a Helm chart <!-- Need more info -->
+- Installs a Helm chart from the OCI registry.
 
 These commands create the necessary API keys for the registry and the Qdrant
 Cloud API. It also generates the `kubectl` and `helm install` commands to install

--- a/qdrant-landing/content/documentation/cloud/hybrid-cloud.md
+++ b/qdrant-landing/content/documentation/cloud/hybrid-cloud.md
@@ -1,0 +1,164 @@
+---
+title: Hybrid Cloud
+weight: 90
+---
+
+# Hybrid Cloud
+
+*Available as of v1.8.2*
+
+The Qdrant Hybrid Cloud allows you to attach your own infrastructure as a private
+region of the Qdrant Cloud. You can use Qdrant Cloud to manage your clusters, and
+run them in your own infrastructure.
+
+## How it works
+
+When you onboard a Kubernetes cluster as a hybrid cloud region, you can deploy
+the Qdrant Kubernetes Operator into this cluster. This operator manages the
+Qdrant databases within your Kubernetes cluster. The operator connects to the 
+Qdrant cloud as `cloud.qdrant.io` on port `443`. You can then have the same
+cloud management features and transport telemetry as is available with any 
+Qdrant-managed cloud provider.
+
+The Qdrant Cloud does not need access to the API of your Kubernetes cluster, 
+or to any cloud provider, or other platform APIs. 
+
+The Qdrant databases operate solely within your network, using your storage and
+compute resources.
+
+<!-- Do we still need this section after release? -->
+## Signing up for Hybrid Cloud
+
+The Qdrant Hybrid Cloud is currently in private beta. To sign up and join the waiting
+list, [contact us](https://qdrant.tech/surveys/hybrid-saas/).
+
+## Creating a Hybrid Cloud region
+
+The following sections specify prerequisites and required artifacts. You can then
+set up a Qdrant cluster in your private region.
+
+### Prerequisites
+
+To create a hybrid cloud region, you need a [standard compliant](https://www.cncf.io/training/certification/software-conformance/)
+Kubernetes cluster. You can run this cluster can run in any SaaS or local environment,
+with tools that range from AWS EKS to VMWare vSphere.
+
+For storage, you need to set up the Kubernetes cluster with a Container Storage
+Interface (CSI) driver that provides block storage. For vertical scaling, the
+CSI driver needs to support volume expansion. For backups and restores, the
+driver needs to support CSI snapshots and restores.
+
+<aside role="status">Network storage systems like NFS or object storage systems 
+such as S3 are not supported.</aside>
+
+For access, you also need a `cluster-admin` user. <!-- does a root user work? 
+what about a user with cluster-admin privileges? -->
+
+For networks, your cluster needs to connect to the Qdrant Cloud. In other words,
+the Qdrant Cloud Agent creates an outgoing connection to `cloud.qdrant.io` on
+port `443`.
+
+By default, the Qdrant Cloud Agent and Operator pulls Helm charts and container
+images from `registry.cloud.qdrant.io`. The Qdrant database pulls from `docker.io`.
+You can also mirror the images and charts to your own registry.
+
+### Required artifacts
+
+To set up your cloud, you need the following:
+
+Container images
+
+- `docker.io/qdrant/qdrant`
+- `registry.cloud.qdrant.io/qdrant/qdrant-cloud-agent`
+- `registry.cloud.qdrant.io/qdrant/qdrant-operator`
+- `registry.cloud.qdrant.io/qdrant/qdrant-cloud-cluster-manager`
+
+OCI Helm charts
+
+- `registry.cloud.qdrant.io/qdrant-charts/qdrant-cloud-agent`
+- `registry.cloud.qdrant.io/qdrant-charts/qdrant-operator`
+
+## Installation
+
+To set up your Hybrid Cloud, open the Qdrant Cloud Console at
+[cloud.qdrant.io](https://cloud.qdrant.io). On the dashboard, select
+**Hybrid Cloud Regions**, and then select **Create**.
+
+You can then enter:
+
+- Name: The Kubernetes namespace for the operator and agent. Once you select a
+  name, you can't change it.
+- Agent version: The version of the Qdrant cloud agent.
+- Operator version: Version of the Kubernetes operator.
+
+You can then enter the YAML configuration for your Kubernetes operator. Qdrant
+supports a specific list of configuration options, as described in the
+[Operator Configuration](#operator-configuration) section.
+
+If you have special requirements for any of the following, activate the
+**Show advanced configuration** option:
+
+- Proxy server
+- Container registry URL for Qdrant Operator and Agent images. The default is
+  <https://registry.cloud.qdrant.io/qdrant/>.
+- Helm chart repository URL for the Qdrant Operator and Agent. The default is
+  <oci://registry.cloud.qdrant.io/qdrant-charts>.
+- CA certificate
+
+Once complete, select Create. If successful, you'll briefly see the following
+message: 
+
+> Successfully created the Hybrid Cloud Region
+
+<!-- Question: does Actions > Edit allow uses to edit anything but the name? -->
+
+### Hybrid Cloud regions
+
+Once you create a Hybrid Cloud Region, you can review what you just configured.
+You can also review the:
+
+- Hybrid Cloud ID, which you can use in Kubernetes commands
+- Operator Pod State <!-- Need more info --> 
+- Agent Pod State <!-- Need more info -->
+
+### Generate Installation Command
+
+After reviewing your configuration, select **Generate Installation Command**.
+This includes several commands which:
+
+- Creates a Kubernetes namespace
+- Adds credentials to the Docker registry, labeled `qdrant-registry-creds`
+- Sets up a secret key based on an API key, labeled `access-key`. 
+- Signs into the Helm registry at `registry.cloud.qdrant.io`.
+- Installs a Helm chart <!-- Need more info -->
+
+These commands create the necessary API keys for the registry and the Qdrant
+Cloud API. It also generates the `kubectl` and `helm install` commands to install
+the Qdrant Cloud Agent and Operator into your cluster.
+
+You need this command only for the initial installation. After that, you can
+update the agent and operator using the Qdrant Cloud Console.
+
+Requirements:
+
+- Your docker server needs access to registry.cloud.qdrant.io
+- 
+
+## Creating a Qdrant cluster
+
+Once you have created a hybrid cloud region, you can create a Qdrant cluster in
+that region. Use the same process to [Create a cluster](/documentation/cloud/create-cluster/). 
+Make sure to select your hybrid cloud as the target region.
+
+### Authentication at your Qdrant clusters
+
+### Exposing Qdrant Clusters to your client applications
+
+## Operator configuration
+
+You should configure the Qdrant Operator with the configuration for the hybrid
+cloud. Use the following options, in YAML format:
+
+```yaml
+settings:
+```

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -47,7 +47,7 @@ All Qdrant instances in a cluster must be able to:
 
 Qdrant can be installed in different ways depending on your needs:
 
-For production, you can use our Qdrant Cloud to run Qdrant either fully managed in our infrastructure or with Hybrid SaaS in yours. 
+For production, you can use our Qdrant Cloud to run Qdrant either fully managed in our infrastructure or with Hybrid Cloud in yours. 
 
 For testing or development setups, you can run the Qdrant container or as a binary executable. 
 

--- a/qdrant-landing/content/surveys/hybrid-saas.md
+++ b/qdrant-landing/content/surveys/hybrid-saas.md
@@ -1,9 +1,9 @@
 ---
-title: Join the waiting list for the Qdrant Hybrid SaaS solution.
-section_title: Request early access to the Qdrant Hybrid SaaS
+title: Join the waiting list for the Qdrant Hybrid Cloud solution.
+section_title: Request early access to the Qdrant Hybrid Cloud
 form:
   - id: 0
-    header: "Get <span style='color: var(--brand-primary);'>Early Access</span> to Qdrant Hybrid SaaS"
+    header: "Get <span style='color: var(--brand-primary);'>Early Access</span> to Qdrant Hybrid Cloud"
     label: All right! 😊 What is your e-mail? *
     placeholder: name@example.com
     type: email

--- a/qdrant-landing/styles/Google/Headings.yml
+++ b/qdrant-landing/styles/Google/Headings.yml
@@ -18,6 +18,7 @@ exceptions:
   - gRPC
   - HNSW
   - Hugging Face
+  - Hybrid Cloud
   - I
   - IDs
   - JAR


### PR DESCRIPTION
Based in large part on #597 , and my interpretation of the updated Hybrid cloud steps in our UI (with the flag turned on)

Draft not yet complete.

Unknowns:
- Is this available as of some Qdrant version number (next would be v1.8.2)
  - Alternative: specify a date
- Are "Qdrant Cloud" and "Hybrid Cloud" both "products?" (do I capitalize both words?)
- What to enter in the "Operator Configuration" section 
  - UI suggests that docs should supply a "Full list of configuration options"
  - I have a blank "Operator configuration" section 
- "Signing up for Qdrant Cloud"
  - Do we still need this section?

Empty sections:
- Authentication
  - There's a reference to an API key. Is that enough?
  - Are there any other authentication requirements
- Exposing Qdrant clusters to your client applications
  - Best guess, requires open ports in the clients (80, 443, 6333, 6334)