### PR TITLE
Update tutorial to describe migration

### DIFF
--- a/qdrant-landing/content/documentation/tutorials/create-snapshot.md
+++ b/qdrant-landing/content/documentation/tutorials/create-snapshot.md
@@ -15,6 +15,9 @@ This tutorial will show you how to create a snapshot of a collection and restore
 
 <aside role="status">Snapshots cannot be created in local mode of Python SDK. You need to spin up a Qdrant Docker container or use Qdrant Cloud.</aside>
 
+You can use the techniques described in this page to migrate a cluster. Follow the instructions
+in this tutorial to create and download snapshots. When you [Restore from snapshot](#restore-from-snapshot), restore your data to the new cluster.
+
 ## Prerequisites
 
 Let's assume you already have a running Qdrant instance or a cluster. If not, you can follow the [installation guide](/documentation/guides/installation/) to set up a local Qdrant instance or use [Qdrant Cloud](https://cloud.qdrant.io/) to create a cluster in a few clicks.


### PR DESCRIPTION
Hi @joekrejci . I agree, this tutorial should serve your purpose. The [Restore from snapshot](https://qdrant.tech/documentation/tutorials/create-snapshot/#restore-from-snapshot) section already suggests that you can use the steps to restore info to a new cluster.

I've added a paragraph which should be consumed by our search interface, so we won't have trouble finding info for your use case in the future.