### PR TITLE
Fix broken links from issue #703

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,5 @@
 https://qdrant.to/twitter
+https://qdrant.to/linkedin
 https://fonts.gstatic.com/
 https://twitter.com/intent.*
 https://www.linkedin.com/sharing.*

--- a/qdrant-landing/content/documentation/web-ui.md
+++ b/qdrant-landing/content/documentation/web-ui.md
@@ -11,7 +11,7 @@ If you've set up a deployment locally with the Qdrant [Quickstart](/documentatio
 navigate to http://localhost:6333/dashboard.
 
 If you've set up a deployment in a cloud cluster, find your Cluster URL in your
-cloud dashboard, at https://cloud.qudrant.io. Add `:6333/dashboard` to the end
+cloud dashboard, at https://cloud.qdrant.io. Add `:6333/dashboard` to the end
 of the URL. 
 
 ## Access the Web UI


### PR DESCRIPTION
From https://github.com/qdrant/landing_page/issues/703

I didn't fix all the errors. Specifically, IMO, lychee should _not_ have pointed to code examples are errors in https://qdrant.tech/articles/chatgpt-plugin/. Not sure how to address that, but at least with a few minutes of work, I can reduce the number of errors that we have.