### PR TITLE
Fix bad links, issue #729

### DIFF
--- a/qdrant-landing/content/articles/chatgpt-plugin.md
+++ b/qdrant-landing/content/articles/chatgpt-plugin.md
@@ -167,8 +167,8 @@ deploy the app. There are various properties we need to fill in:
 | `description_for_model` | Description of the purpose of the plugin, so ChatGPT knows in what cases it should be using it to answer a question. | *Plugin for searching through the Qdrant documentation to find answers to questions and retrieve relevant information. Use it whenever a user asks something that might be related to Qdrant vector database or semantic vector search* |
 | `description_for_human` | Short description of the plugin, also to be displayed in the ChatGPT UI.                                             | *Search through Qdrant docs*                                                                                                                                                                                                            |
 | `auth`                  | Authorization scheme used by the application. By default, the bearer token has to be configured.                     | ```{"type": "user_http", "authorization_type": "bearer"}```                                                                                                                                                                             |
-| `api.url`               | Link to the OpenAPI schema definition. Please adjust based on your application URL.                                  | *https://your-application-name.fly.dev/.well-known/openapi.yaml*                                                                                                                                                                        |
-| `logo_url`              | Link to the application logo. Please adjust based on your application URL.                                           | *https://your-application-name.fly.dev/.well-known/logo.png*                                                                                                                                                                            |
+| `api.url`               | Link to the OpenAPI schema definition. Please adjust based on your application URL.                                  | `https://your-application-name.fly.dev/.well-known/openapi.yaml`                                                                                                                                                                        |
+| `logo_url`              | Link to the application logo. Please adjust based on your application URL.                                           | `https://your-application-name.fly.dev/.well-known/logo.png`                                                                                                                                                                            |
 
 A complete file may look as follows:
 
@@ -263,7 +263,7 @@ Finally, we need to provide the Bearer token again:
 
 Our plugin is now ready to be tested. Since there is no data inside the knowledge base, 
 extracting any facts is impossible, but we’re going to put some data using the Swagger UI 
-exposed by our service at https://your-application-name.fly.dev/docs. We need to authorize 
+exposed by our service at `https://your-application-name.fly.dev/docs`. We need to authorize 
 first, and then call the upsert method with some docs. For the demo purposes, we can just 
 put a single document extracted from the Qdrant documentation to see whether integration 
 works properly:

--- a/qdrant-landing/content/documentation/web-ui.md
+++ b/qdrant-landing/content/documentation/web-ui.md
@@ -11,7 +11,7 @@ If you've set up a deployment locally with the Qdrant [Quickstart](/documentatio
 navigate to http://localhost:6333/dashboard.
 
 If you've set up a deployment in a cloud cluster, find your Cluster URL in your
-cloud dashboard, at https://cloud.qudrant.io. Add `:6333/dashboard` to the end
+cloud dashboard, at https://cloud.qdrant.io. Add `:6333/dashboard` to the end
 of the URL. 
 
 ## Access the Web UI


### PR DESCRIPTION
From https://github.com/qdrant/landing_page/issues/729

The issue identifies 5 bad links. I've neutralized 3 with backquotes (``), corrected the spelling of 1, and have contacted the owner of a blog post that is hopefully temporarily down.