### PR TITLE
Fix for the product schema

### DIFF
--- a/qdrant-landing/assets/schema/product-schema.json
+++ b/qdrant-landing/assets/schema/product-schema.json
@@ -12,8 +12,7 @@
   "image": "{{- if .Params.social_preview_image -}}{{- .Params.social_preview_image | absURL -}}{{- end -}}",
   "offers": {
     "@type": "AggregateOffer",
-    "highPrice": "on request",
-    "lowPrice": "free",
+    "lowPrice": "0",
     "offerCount": "3",
     "priceCurrency": "USD",
     "offers": [


### PR DESCRIPTION
Even though schema.org validated our updated structured data, google disagrees: using words to describe low and high prices is invalid.

So here the `lowPrice` is set to 0 and the `highPrice` field is removed (until we won't come up with a better solution).