### PR TITLE
Single page default layout, article content partial, table

### DIFF
--- a/qdrant-landing/content/headless/footer.md
+++ b/qdrant-landing/content/headless/footer.md
@@ -110,7 +110,7 @@ menuItems:
 copyright: © 2024 Qdrant. All Rights Reserved
 termsLink:
   text: Terms
-  url: /legal/terms-and-conditions/
+  url: /legal/terms_and_conditions/
 privacyLink:
   text: Privacy Policy
   url: /legal/privacy-policy/

--- a/qdrant-landing/themes/qdrant-2024/layouts/_default/baseof.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/_default/baseof.html
@@ -3,6 +3,9 @@
   {{- partial "head.html" . -}}
   <body>
     <main>
+      {{ if (eq .Params.type "external-link") }}
+        Redirecting to <a href="{{ .Params.external_url }}">external page</a>...
+      {{ end }}
       {{ block "main" . }}{{ end }}
     </main>
     {{ partial "footer" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/_default/single.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/_default/single.html
@@ -7,9 +7,9 @@
 
   <div class="container my-5">
     <div class="qdrant-post">
-      <div class="qdrant-post__content">
+      <article class="qdrant-post__content">
         {{ partial "article-content" . }}
-      </div>
+      </article>
     </div>
   </div>
 {{ end }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/_default/single.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/_default/single.html
@@ -1,1 +1,15 @@
-{{ define "main" }}{{ end }}
+{{ define "main" }}
+  <header class="main-header">
+    {{ partial "top-banner" . }}
+    {{ partial "menu" . }}
+    {{ partial "menu-mobile" . }}
+  </header>
+
+  <div class="container my-5">
+    <div class="qdrant-post">
+      <div class="qdrant-post__content">
+        {{ partial "article-content" . }}
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/article-content.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/article-content.html
@@ -1,0 +1,9 @@
+{{ $reAltTitleIn := "<img src=\"([^\"]+)\" alt=\"([^\"]*)\" title=\"([^\"]+)\">" }}
+{{ $reAltTitleOut := "<figure><img src=\"$1\" alt=\"$2\" title=\"$3\"><figcaption>$3</figcaption></figure>" }}
+{{ $contentWithImgCaptures := .Content | replaceRE $reAltTitleIn $reAltTitleOut | safeHTML }}
+
+{{ $wrappedTable := printf "<div class=table-responsive> ${1} </div>" }}
+{{ $contentWithWrappedTables := $contentWithImgCaptures | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
+{{ $old := "<table>" }}
+{{ $new := printf "<table class=\"%s\">"  "table mb-5" }}
+{{ $contentWithWrappedTables | replaceRE $old $new | safeHTML }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/head.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/head.html
@@ -17,6 +17,10 @@
   <meta name="msapplication-config" content="/favicon/browserconfig.xml" />
   <meta name="theme-color" content="#ffffff" />
 
+  {{ if (eq .Params.type "external-link") }}
+    <meta http-equiv="refresh" content="0; url={{ .Params.external_url }}" />
+  {{ end }}
+
   {{ partial "css" . }}
 
   {{ partial "seo_schema" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
@@ -1,5 +1,5 @@
 <section class="qdrant-post">
-  <div class="container">
+  <article class="container">
     <div class="qdrant-post__header">
       <h2 class="qdrant-post__title">{{ .Params.title }}</h2>
       <div class="qdrant-post__about">
@@ -16,7 +16,7 @@
     </div>
 
     <div class="qdrant-post__body">
-      <div class="qdrant-post__social">
+      <section class="qdrant-post__social">
         <p class="qdrant-post__social-title">Share</p>
         <div class="qdrant-post__social-links">
           <a href="/">
@@ -45,11 +45,11 @@
             </svg>
           </a>
         </div>
-      </div>
+      </section>
 
       <div class="qdrant-post__content">
         {{ partial "article-content" . }}
       </div>
     </div>
-  </div>
+  </article>
 </section>

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
@@ -48,12 +48,7 @@
       </div>
 
       <div class="qdrant-post__content">
-        {{ $reAltTitleIn := "<img src=\"([^\"]+)\" alt=\"([^\"]*)\" title=\"([^\"]+)\">" }}
-        {{ $reAltTitleOut := "<figure><img src=\"$1\" alt=\"$2\" title=\"$3\"><figcaption>$3</figcaption></figure>" }}
-        {{ $contentWithImgCaptures := .Content | replaceRE $reAltTitleIn $reAltTitleOut | safeHTML }}
-
-        {{ $wrappedTable := printf "<div class=table-responsive> ${1} </div>" }}
-        {{ $contentWithImgCaptures | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
+        {{ partial "article-content" . }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Added a default single page layout (which means terms, privacy policy, etc pages work now), moved an article content in the separate partial to reuse, fixed table inside posts.