### PR TITLE
Add proper indentation to operator-config

### DIFF
--- a/qdrant-landing/content/documentation/hybrid-cloud/operator-configuration.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/operator-configuration.md
@@ -77,8 +77,8 @@ qdrant:
     egress:
       - to:
         - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: kube-system
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
         ports:
         - protocol: UDP
           port: 53


### PR DESCRIPTION
### Description

We were missing indenting two lines to give the YAML code proper structure (found while working on the operator's config validation 😅 ) specifically on the `namespaceSelector` > `matchLabels`

### Screenshots

#### Before

<img width="941" alt="Screenshot 2024-06-06 at 8 46 10 AM" src="https://github.com/qdrant/landing_page/assets/5528266/f368db6d-3495-4204-a281-64bed2aedc74">

#### After
<img width="913" alt="Screenshot 2024-06-06 at 8 45 57 AM" src="https://github.com/qdrant/landing_page/assets/5528266/4c4d3f35-579e-4a03-abb8-9e00354fba45">
