### PR TITLE
Qdrant 1.10.0: update configuration

### DIFF
--- a/qdrant-landing/content/headless/stats.md
+++ b/qdrant-landing/content/headless/stats.md
@@ -1,6 +1,6 @@
 ---
 stats:
   githubStars: 18.7k
-  discordMembers: 5.9k
+  discordMembers: 6.0k
   twitterFollowers: 7.5k
 ---


### PR DESCRIPTION
Update the configuration to match the Qdrant 1.10.0 release.

This removes the more elaborate S3 configuration example, but I'll move it into a different place in a [separate PR](https://github.com/qdrant/landing_page/pull/994).