### PR TITLE
Added hide TOC param

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/table-of-contents.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/table-of-contents.html
@@ -1,3 +1,4 @@
+{{ if not .Params.hideTOC }}
 <div class="col-12 col-xl-2">
   {{ if gt (.TableOfContents | len) 34 }}
     <div class="table-of-contents">
@@ -24,3 +25,4 @@
     </div>
   {{ end }}
 </div>
+{{ end }}


### PR DESCRIPTION
`hideTOC: true` in the front matter of markdown file will hide TOC