### PR TITLE
Fix Sidebar + Add a New Section: "Send Data to Qdrant"

### DIFF
--- a/qdrant-landing/content/documentation/1-dl.md
+++ b/qdrant-landing/content/documentation/1-dl.md
@@ -2,6 +2,6 @@
 #Delimiter files are used to separate the list of documentation pages into sections.
 title: "User Manual"
 type: delimiter
-weight: 20 # Change this weight to change order of sections
+weight: 10 # Change this weight to change order of sections
 sitemapExclude: True
 ---

--- a/qdrant-landing/content/documentation/3-dl.md
+++ b/qdrant-landing/content/documentation/3-dl.md
@@ -1,7 +1,7 @@
 ---
 #Delimiter files are used to separate the list of documentation pages into sections.
-title: "Support"
+title: "Examples"
 type: delimiter
-weight: 40 # Change this weight to change order of sections
+weight: 17 # Change this weight to change order of sections
 sitemapExclude: True
 ---

--- a/qdrant-landing/content/documentation/4-dl.md
+++ b/qdrant-landing/content/documentation/4-dl.md
@@ -2,6 +2,6 @@
 #Delimiter files are used to separate the list of documentation pages into sections.
 title: "Managed Services"
 type: delimiter
-weight: 13 # Change this weight to change order of sections
+weight: 7 # Change this weight to change order of sections
 sitemapExclude: True
 ---

--- a/qdrant-landing/content/documentation/5-dl.md
+++ b/qdrant-landing/content/documentation/5-dl.md
@@ -1,7 +1,7 @@
 ---
 #Delimiter files are used to separate the list of documentation pages into sections.
-title: "Integrations"
+title: "Support"
 type: delimiter
-weight: 14 # Change this weight to change order of sections
+weight: 21 # Change this weight to change order of sections
 sitemapExclude: True
 ---

--- a/qdrant-landing/content/documentation/_index.md
+++ b/qdrant-landing/content/documentation/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Qdrant Documentation
-weight: 10
+title: Home
+weight: 2
 hideTOC: true
 ---
 # Documentation

--- a/qdrant-landing/content/documentation/cloud/_index.md
+++ b/qdrant-landing/content/documentation/cloud/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Managed Cloud
-weight: 14
+weight: 8
 aliases:
   - /documentation/overview/qdrant-alternatives/documentation/cloud/
 ---

--- a/qdrant-landing/content/documentation/community-links.md
+++ b/qdrant-landing/content/documentation/community-links.md
@@ -1,6 +1,7 @@
 ---
 title: Community links
 weight: 42
+draft: true
 ---
 
 # Community Contributions

--- a/qdrant-landing/content/documentation/concepts/_index.md
+++ b/qdrant-landing/content/documentation/concepts/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Concepts
-weight: 21
+weight: 11
 # If the index.md file is empty, the link to the section will be hidden from the sidebar
 ---
 

--- a/qdrant-landing/content/documentation/datasets.md
+++ b/qdrant-landing/content/documentation/datasets.md
@@ -1,6 +1,6 @@
 ---
 title: Practice Datasets
-weight: 41
+weight: 23
 ---
 
 # Common Datasets in Snapshot Format

--- a/qdrant-landing/content/documentation/embeddings/_index.md
+++ b/qdrant-landing/content/documentation/embeddings/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Embeddings
-weight: 34
+weight: 15
 ---
 
 | Embeddings Providers          |

--- a/qdrant-landing/content/documentation/examples/_index.md
+++ b/qdrant-landing/content/documentation/examples/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Examples
-weight: 35
+title: Build Prototypes
+weight: 19
 ---
 # Examples
 
@@ -16,8 +16,6 @@ weight: 35
 | [Hybrid Search on PDF Documents](../examples/hybrid-search-llamaindex-jinaai/)                                 | Develop a Hybrid Search System for Product PDF Manuals                | Qdrant, LlamaIndex, Jina AI   
 | [Blog-Reading RAG Chatbot](../examples/rag-chatbot-scaleway)                                 | Develop a RAG-based Chatbot on Scaleway and with LangChain                | Qdrant, LangChain, GPT-4o   
 | [Movie Recommendation System](../examples/recommendation-system-ovhcloud/)                                 | Build a Movie Recommendation System with LlamaIndex and With JinaAI             | Qdrant |   
-| [Qdrant on Databricks](../examples/databricks/)                                                                     | Learn how to use Qdrant on Databricks using the Spark connector     | Qdrant, Databricks, Apache Spark |
-| [Qdrant with Airflow and Astronomer](../examples/qdrant-airflow-astronomer/)                                        | Build a semantic querying system using Airflow and Astronomer       | Qdrant, Airflow, Astronomer      |
 
 
 ## Notebooks
@@ -34,10 +32,3 @@ Our Notebooks offer complex instructions that are supported with a throrough exp
 | [Extractive QA System](https://githubtocolab.com/qdrant/examples/blob/master/extractive_qa/extractive-question-answering.ipynb)                                                                                                       | Extract answers directly from context to generate highly relevant answers.                      | Qdrant                     | 
 | [Ecommerce Reverse Image Search](https://githubtocolab.com/qdrant/examples/blob/master/ecommerce_reverse_image_search/ecommerce-reverse-image-search.ipynb)                                                                           | Accept images as search queries to receive semantically appropriate answers.                    | Qdrant                     | 
 | [Basic RAG](https://githubtocolab.com/qdrant/examples/blob/master/rag-openai-qdrant/rag-openai-qdrant.ipynb)                                                                                                                          | Basic RAG pipeline with Qdrant and OpenAI SDKs.                                                  | OpenAI, Qdrant, FastEmbed  |
-
-## Data Transfer
-
-| Example                                                                   | Description                                                       | Stack                                       |   
-|---------------------------------------------------------------------------------|-------------------------------------------------------------------|---------------------------------------------|
-| [Pinecone to Qdrant Data Transfer](https://githubtocolab.com/qdrant/examples/blob/master/data-migration/from-pinecone-to-qdrant.ipynb)                                                                                                                          | Migrate your vector data from Pinecone to Qdrant.                                                 |  Qdrant, Vector-io  |
-| [Stream Data to Qdrant with Kafka](../examples/data-streaming-kafka-qdrant/)                                                                                                                          | Use Confluent to Stream Data to Qdrant via Managed Kafka.                                                 |  Qdrant, Kafka  |

--- a/qdrant-landing/content/documentation/faq/_index.md
+++ b/qdrant-landing/content/documentation/faq/_index.md
@@ -1,5 +1,5 @@
 ---
 title: FAQ
-weight: 41
+weight: 22
 is_empty: true
 ---

--- a/qdrant-landing/content/documentation/frameworks/_index.md
+++ b/qdrant-landing/content/documentation/frameworks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Frameworks 
-weight: 33
+weight: 15
 ---
 
 | Frameworks                            | Description                                                                                          |

--- a/qdrant-landing/content/documentation/frameworks/spark.md
+++ b/qdrant-landing/content/documentation/frameworks/spark.md
@@ -217,7 +217,7 @@ _Click each to expand._
 ## Databricks
 
 <aside role="status">
-    <p>Check out our <a href="/documentation/examples/databricks/" target="_blank">example</a> of using the Spark connector with Databricks.</p>
+    <p>Check out our <a href="/documentation/send-data/databricks/" target="_blank">example</a> of using the Spark connector with Databricks.</p>
 </aside>
 
 You can use the `qdrant-spark` connector as a library in [Databricks](https://www.databricks.com/).

--- a/qdrant-landing/content/documentation/guides/_index.md
+++ b/qdrant-landing/content/documentation/guides/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Guides
-weight: 22
+weight: 12
 # If the index.md file is empty, the link to the section will be hidden from the sidebar
 is_empty: true
 ---

--- a/qdrant-landing/content/documentation/hybrid-cloud/_index.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Hybrid Cloud
-weight: 15
+weight: 9
 ---
 
 # Qdrant Hybrid Cloud

--- a/qdrant-landing/content/documentation/interfaces/_index.md
+++ b/qdrant-landing/content/documentation/interfaces/_index.md
@@ -1,5 +1,5 @@
 ---
-title: API & SDK 
+title: API & SDKs
 weight: 6
 aliases:
   - /documentation/interfaces/

--- a/qdrant-landing/content/documentation/interfaces/_index.md
+++ b/qdrant-landing/content/documentation/interfaces/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Interfaces
-weight: 11
+title: API & SDK 
+weight: 6
 aliases:
   - /documentation/interfaces/
 ---

--- a/qdrant-landing/content/documentation/interfaces/api-reference.md
+++ b/qdrant-landing/content/documentation/interfaces/api-reference.md
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-weight: 12
+weight: 1
 type: external-link
 external_url: https://api.qdrant.tech/api-reference
 sitemapExclude: True

--- a/qdrant-landing/content/documentation/interfaces/web-ui.md
+++ b/qdrant-landing/content/documentation/interfaces/web-ui.md
@@ -1,6 +1,6 @@
 ---
 title: Qdrant Web UI
-weight: 1
+weight: 2
 aliases:
   - /documentation/web-ui/
 ---

--- a/qdrant-landing/content/documentation/overview/_index.md
+++ b/qdrant-landing/content/documentation/overview/_index.md
@@ -1,6 +1,6 @@
 ---
 title: What is Qdrant?
-weight: 2
+weight: 3
 aliases:
   - overview
 ---

--- a/qdrant-landing/content/documentation/quickstart-cloud.md
+++ b/qdrant-landing/content/documentation/quickstart-cloud.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Quickstart
-weight: 3
+weight: 4
 aliases:
   - quickstart-cloud
   - ../cloud-quick-start

--- a/qdrant-landing/content/documentation/quickstart.md
+++ b/qdrant-landing/content/documentation/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Local Quickstart
-weight: 4
+weight: 5
 aliases:
   - quick_start
   - quick-start

--- a/qdrant-landing/content/documentation/release-notes.md
+++ b/qdrant-landing/content/documentation/release-notes.md
@@ -1,6 +1,6 @@
 ---
-title: Release notes
-weight: 42
+title: Release Notes
+weight: 24
 type: external-link
 external_url: https://github.com/qdrant/qdrant/releases
 sitemapExclude: True

--- a/qdrant-landing/content/documentation/send-data/_index.md
+++ b/qdrant-landing/content/documentation/send-data/_index.md
@@ -1,0 +1,13 @@
+---
+title: Send Data to Qdrant
+weight: 18
+---
+
+## How to Send Your Data to a Qdrant Cluster
+
+| Example                                                                   | Description                                                       | Stack                                       |   
+|---------------------------------------------------------------------------------|-------------------------------------------------------------------|---------------------------------------------|
+| [Pinecone to Qdrant Data Transfer](https://githubtocolab.com/qdrant/examples/blob/master/data-migration/from-pinecone-to-qdrant.ipynb)                                                                                                                          | Migrate your vector data from Pinecone to Qdrant.                                                 |  Qdrant, Vector-io  |
+| [Stream Data to Qdrant with Kafka](../send-data/data-streaming-kafka-qdrant/)                                                                                                                          | Use Confluent to Stream Data to Qdrant via Managed Kafka.                                                 |  Qdrant, Kafka  |
+| [Qdrant on Databricks](../send-data/databricks/)                                                                     | Learn how to use Qdrant on Databricks using the Spark connector     | Qdrant, Databricks, Apache Spark |
+| [Qdrant with Airflow and Astronomer](../send-data/qdrant-airflow-astronomer/)                                        | Build a semantic querying system using Airflow and Astronomer       | Qdrant, Airflow, Astronomer      |

--- a/qdrant-landing/content/documentation/send-data/data-streaming-kafka-qdrant.md
+++ b/qdrant-landing/content/documentation/send-data/data-streaming-kafka-qdrant.md
@@ -1,6 +1,8 @@
 ---
 title: How to Setup Seamless Data Streaming with Kafka and Qdrant
 weight: 49
+aliases:
+  - /examples/data-streaming-kafka-qdrant/
 ---
 
 # Setup Data Streaming with Kafka via Confluent

--- a/qdrant-landing/content/documentation/send-data/databricks.md
+++ b/qdrant-landing/content/documentation/send-data/databricks.md
@@ -1,6 +1,8 @@
 ---
 title: Qdrant on Databricks
 weight: 36
+aliases:
+  - /examples/databricks/
 ---
 
 # Qdrant on Databricks

--- a/qdrant-landing/content/documentation/send-data/qdrant-airflow-astronomer.md
+++ b/qdrant-landing/content/documentation/send-data/qdrant-airflow-astronomer.md
@@ -1,6 +1,8 @@
 ---
 title: Semantic Querying with Airflow and Astronomer
 weight: 36
+aliases:
+  - /examples/qdrant-airflow-astronomer/
 ---
 
 # Semantic Querying with Airflow and Astronomer

--- a/qdrant-landing/content/documentation/tutorials/_index.md
+++ b/qdrant-landing/content/documentation/tutorials/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorials
-weight: 23
+weight: 13
 # If the index.md file is empty, the link to the section will be hidden from the sidebar
 is_empty: false
 aliases:


### PR DESCRIPTION
<img width="734" alt="Screenshot 2024-07-22 at 5 17 01 PM" src="https://github.com/user-attachments/assets/82cc8aa7-763a-4a42-882e-352417994781">


[PREVIEW](https://deploy-preview-1046--condescending-goldwasser-91acf0.netlify.app/documentation/send-data/)

- I fixed all the weights in each markdown file and left space for new sections
- I combined API + SDK in one section to save space
- I removed Community Contributions old page from Support
- Introduced a special examples section "Send Data to Qdrant". This will have examples on how to populate Qdrant OR migrate from other DBs
- Turned the old examples section into "Build Prototypes". I will further divide this into "Build Vector Search Apps" and "Build RAG apps"

- We need to separate the sections because visitors to the website won't browse through long tables. We need to make the headings immediately obvious to the reader. 