### PR TITLE
Cloud UI Outbound Link URL Param

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -77,9 +77,9 @@ export function devLog(str) {
   }
 }
 
+export const CROSS_SITE_URL_PARAM_KEY = 'qdrant-tech';
 export function tagCloudUILinksWithHash() {
   const targetUrl = 'https://cloud.qdrant.io/';
-  const parameterName = 'qdrant-tech';
   
   // Generate a random 32-character string
   const generateRandomString = (length = 32) => {
@@ -101,6 +101,6 @@ export function tagCloudUILinksWithHash() {
 
   // Loop through all selected <a> elements and update their href
   links.forEach(link => {
-    link.href = addOrUpdateQueryParam(link.href, parameterName, parameterValue);
+    link.href = addOrUpdateQueryParam(link.href, CROSS_SITE_URL_PARAM_KEY, parameterValue);
   });
 }

--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -76,3 +76,31 @@ export function devLog(str) {
     console.log(str)
   }
 }
+
+export function tagCloudUILinksWithHash() {
+  const targetUrl = 'https://cloud.qdrant.io/';
+  const parameterName = 'qdrant-tech';
+  
+  // Generate a random 32-character string
+  const generateRandomString = (length = 32) => {
+    const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+    return Array.from({ length }, () => charset.charAt(Math.floor(Math.random() * charset.length))).join('');
+  };
+
+  const parameterValue = generateRandomString();
+  
+  // Function to add or update query parameter in the URL
+  function addOrUpdateQueryParam(url, paramName, paramValue) {
+    const urlObj = new URL(url, window.location.origin); // Ensures URL is absolute
+    urlObj.searchParams.set(paramName, paramValue);
+    return urlObj.toString();
+  }
+
+  // Select all <a> elements with href exactly containing targetUrl
+  const links = document.querySelectorAll(`a[href*="${targetUrl}"]`);
+
+  // Loop through all selected <a> elements and update their href
+  links.forEach(link => {
+    link.href = addOrUpdateQueryParam(link.href, parameterName, parameterValue);
+  });
+}

--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -1,12 +1,13 @@
 import scrollHandler from './scroll-handler';
 import { XXL_BREAKPOINT } from './constants';
 import { initGoToTopButton, getCookie } from './helpers';
-import { loadSegment, createSegmentStoredPage, tagAllAnchors } from './segment-helpers'
+import { loadSegment, createSegmentStoredPage, tagAllAnchors, tagCloudUILinksWithHash } from './segment-helpers'
 
 createSegmentStoredPage();
 
 // on document ready
 document.addEventListener('DOMContentLoaded', function () {
+  tagCloudUILinksWithHash();
   tagAllAnchors();
 
   if (!window.analytics && getCookie('cookie-consent')) {

--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -1,7 +1,7 @@
 import scrollHandler from './scroll-handler';
 import { XXL_BREAKPOINT } from './constants';
-import { initGoToTopButton, getCookie } from './helpers';
-import { loadSegment, createSegmentStoredPage, tagAllAnchors, tagCloudUILinksWithHash } from './segment-helpers'
+import { initGoToTopButton, getCookie, tagCloudUILinksWithHash } from './helpers';
+import { loadSegment, createSegmentStoredPage, tagAllAnchors } from './segment-helpers'
 
 createSegmentStoredPage();
 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -33,11 +33,16 @@ const nameMapper = (url) => { // Mapping names based on pathname for Segment
 /* DOM helpers */
 /***************/
 const handleClickInteraction = (event) => {
+  const url = new URL(event.target.href);
+  const searchParams = url.searchParams;
+  const qdrantTechValue = searchParams.get('qdrant-techs');
+
   const payload = {
     ...PAYLOAD_BOILERPLATE,
     location: event.target.getAttribute('data-metric-loc') ?? '',
     label: event.target.getAttribute('data-metric-label') ?? event.target.innerText,
-    action: 'clicked'
+    action: 'clicked',
+    qdrant_tech_hash: qdrantTechValue ?? null
   };
 
   // If consented to tracking the track 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -1,4 +1,4 @@
-import { getCookie, devLog, tagCloudUILinksWithHash } from './helpers';
+import { getCookie, devLog } from './helpers';
 
 const WRITE_KEY = 'segmentWriteKey';
 const PAGES_SESSION_STORAGE_KEY = 'segmentPages';
@@ -7,8 +7,6 @@ const PAYLOAD_BOILERPLATE = {
   url: window.location.href,
   title: document.title,
 };
-
-tagCloudUILinksWithHash();
 
 /*******************/
 /* General helpers */

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -8,6 +8,7 @@ const PAYLOAD_BOILERPLATE = {
   title: document.title,
 };
 
+tagCloudUILinksWithHash();
 
 /*******************/
 /* General helpers */
@@ -181,8 +182,6 @@ export function handleConsent() {
 /* Loading Segment */
 /*******************/
 export function loadSegment() {
-  tagCloudUILinksWithHash();
-
   const writeKey = getSegmentWriteKey();
   if (!writeKey) return; // Fail silently?
 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -1,4 +1,4 @@
-import { getCookie, devLog } from './helpers';
+import { getCookie, devLog, tagCloudUILinksWithHash } from './helpers';
 
 const WRITE_KEY = 'segmentWriteKey';
 const PAGES_SESSION_STORAGE_KEY = 'segmentPages';
@@ -181,6 +181,8 @@ export function handleConsent() {
 /* Loading Segment */
 /*******************/
 export function loadSegment() {
+  tagCloudUILinksWithHash();
+
   const writeKey = getSegmentWriteKey();
   if (!writeKey) return; // Fail silently?
 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -1,4 +1,4 @@
-import { getCookie, devLog } from './helpers';
+import { getCookie, devLog, CROSS_SITE_URL_PARAM_KEY } from './helpers';
 
 const WRITE_KEY = 'segmentWriteKey';
 const PAGES_SESSION_STORAGE_KEY = 'segmentPages';
@@ -35,14 +35,14 @@ const nameMapper = (url) => { // Mapping names based on pathname for Segment
 const handleClickInteraction = (event) => {
   const url = new URL(event.target.href);
   const searchParams = url.searchParams;
-  const qdrantTechValue = searchParams.get('qdrant-techs');
+  const qdrantTechHash = searchParams.get(CROSS_SITE_URL_PARAM_KEY);
 
   const payload = {
     ...PAYLOAD_BOILERPLATE,
     location: event.target.getAttribute('data-metric-loc') ?? '',
     label: event.target.getAttribute('data-metric-label') ?? event.target.innerText,
     action: 'clicked',
-    qdrant_tech_hash: qdrantTechValue ?? null
+    qdrant_tech_hash: qdrantTechHash ?? null
   };
 
   // If consented to tracking the track 


### PR DESCRIPTION
## Context
Marketing needs to track a user's journey across our 2 domains: `qdrant.tech` and `cloud.qdrant.io`. To do this without exposing user PII all outbound links to Cloud UI will get a url parameter called `qdrant-tech` with a randomly generated 32 character string. This will allow us to tie together a user's journey across domains via the link href and the referrer parameters within Cloud UI events.

## Approach
- Wait for DOM Content Loaded
- Update cloud.qdrant.io links with `qdrant-tech` url param
- add new key/value pair to interaction event called `qdrant_tech_hash`

@fabriziobonavita 

