### PR TITLE
Use proper units (gigabytes and megabytes, not gigabits and megabits)

### DIFF
--- a/qdrant-landing/content/articles/bm42.md
+++ b/qdrant-landing/content/articles/bm42.md
@@ -340,7 +340,7 @@ As you can see, it has pretty short texts, there are not much of the statistics 
 
 After encoding with BM42, the average vector size is only **5.6 elements per document**.
 
-With `datatype: uint8` available in Qdrant, the total size of the sparse vector index is about **13Mb** for ~530k documents.
+With `datatype: uint8` available in Qdrant, the total size of the sparse vector index is about **13MB** for ~530k documents.
 
 As a reference point, we use:
 

--- a/qdrant-landing/content/articles/dedicated-service.md
+++ b/qdrant-landing/content/articles/dedicated-service.md
@@ -99,7 +99,7 @@ Assume we have a database with 1 million records.
 This is a small database by modern standards of any relational database.
 You can probably use the smallest free tier of any cloud provider to host it.
 
-But if we want to use this database for vector search, 1 million OpenAI `text-embedding-ada-002` embeddings will take **~6Gb of RAM** (sic!).
+But if we want to use this database for vector search, 1 million OpenAI `text-embedding-ada-002` embeddings will take **~6GB of RAM** (sic!).
 As you can see, the vector search use case completely overwhelmed the main database resource requirements.
 In practice, this means that your main database becomes burdened with high memory requirements and can not scale efficiently, limited by the size of a single machine.
 

--- a/qdrant-landing/content/articles/memory-consumption.md
+++ b/qdrant-landing/content/articles/memory-consumption.md
@@ -29,7 +29,7 @@ Introduction:
     2. Process may not free deallocated memory.
     3. Process might be forked and memory is shared between processes.
     3. Process may use disk cache.
-3. As a result, if you see `10Gb` memory consumption in `htop`, it doesn't mean that your process actually needs `10Gb` of RAM to work.
+3. As a result, if you see `10GB` memory consumption in `htop`, it doesn't mean that your process actually needs `10GB` of RAM to work.
 -->
 
 # Mastering RAM Measurement and Memory Optimization in Qdrant: A Comprehensive Guide
@@ -120,7 +120,7 @@ All in memory:
 1152mb - out of memory
 1200mb - 794.72it/s
 
-Conclusion: about 1.2Gb is needed to serve ~1 million vectors, no speed degradation with limiting memory above 1.2Gb
+Conclusion: about 1.2GB is needed to serve ~1 million vectors, no speed degradation with limiting memory above 1.2GB
 
 MMAP for vectors:
 
@@ -164,8 +164,8 @@ We tried using different amounts of memory, ranging from 1512mb to 1024mb, and m
 | 1024mb | out of memory |
 
 
-We found that 1152Mb memory limit resulted in our system running out of memory, but using 1512mb, 1256mb, and 1200mb of memory resulted in our system being able to handle around 780 RPS.
-This suggests that about 1.2Gb of memory is needed to serve around 1 million vectors, and there is no speed degradation when limiting memory usage above 1.2Gb.
+We found that 1152MB memory limit resulted in our system running out of memory, but using 1512mb, 1256mb, and 1200mb of memory resulted in our system being able to handle around 780 RPS.
+This suggests that about 1.2GB of memory is needed to serve around 1 million vectors, and there is no speed degradation when limiting memory usage above 1.2GB.
 
 ### Vectors stored using MMAP
 

--- a/qdrant-landing/content/articles/scalar-quantization.md
+++ b/qdrant-landing/content/articles/scalar-quantization.md
@@ -268,16 +268,16 @@ We used a machine with a very slow network-mounted disk and tested the following
 
 | Setup                       | RPS  | Precision |
 |-----------------------------|------|-----------|
-| 4.5Gb memory                | 600  | 0.99      |
-| 4.5Gb memory + SQ + rescore | 1000 | 0.989     |
+| 4.5GB memory                | 600  | 0.99      |
+| 4.5GB memory + SQ + rescore | 1000 | 0.989     |
 
 And another group with more strict memory limits:
 
 | Setup                        | RPS  | Precision |
 |------------------------------|------|-----------|
-| 2Gb memory                   | 2    | 0.99      |
-| 2Gb memory + SQ + rescore    | 30   | 0.989     |
-| 2Gb memory + SQ + no rescore | 1200 | 0.974     |
+| 2GB memory                   | 2    | 0.99      |
+| 2GB memory + SQ + rescore    | 30   | 0.989     |
+| 2GB memory + SQ + no rescore | 1200 | 0.974     |
 
 In those experiments, throughput was mainly defined by the number of disk reads, and quantization efficiently reduces it by allowing more vectors in RAM.
 Read more about on-disk storage in Qdrant and how we measure its performance in our article: [Minimal RAM you need to serve a million vectors


### PR DESCRIPTION
As reported in #1048, some articles used the wrong units (*bits, not *bytes). This PR fixes that.