### PR TITLE
fix: Poor contrast in <aside> content in light mode

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_documentation-article.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_documentation-article.scss
@@ -71,10 +71,6 @@
       color: $neutral-20;
     }
 
-    p {
-      color: $neutral-30;
-    }
-
     code:not([class]) {
       color: $neutral-20;
       background-color: #d9e2fe;


### PR DESCRIPTION
### NOW:

https://qdrant.tech/documentation/tutorials/neural-search/#:~:text=Use%20recreate_collection (SWITCH TO LIGHT MODE)
<img width="961" alt="Screenshot 2024-07-28 at 9 44 56 AM" src="https://github.com/user-attachments/assets/38c73761-e532-4866-a3d8-f2e33a373b2c">


## FIX:

https://deploy-preview-1057--condescending-goldwasser-91acf0.netlify.app/documentation/tutorials/neural-search/#upload-data-to-qdrant:~:text=Use%20recreate_collection

<img width="961" alt="Screenshot 2024-07-28 at 9 47 47 AM" src="https://github.com/user-attachments/assets/6041e995-a23c-466c-b778-8f5cfbf7433b">

