### PR TITLE
fix: Broken cloud quickstart link in welcome letter

### DIFF
--- a/qdrant-landing/content/documentation/frameworks/airflow.md
+++ b/qdrant-landing/content/documentation/frameworks/airflow.md
@@ -21,7 +21,7 @@ Before configuring Airflow, you need:
 
 You can install the Qdrant provider by running `pip install apache-airflow-providers-qdrant` in your Airflow shell.
 
-**NOTE**: You'll have to restart your Airlfow session for the provider to be available.
+**NOTE**: You'll have to restart your Airflow session for the provider to be available.
 
 ## Setting up a connection
 

--- a/qdrant-landing/content/documentation/quickstart-cloud.md
+++ b/qdrant-landing/content/documentation/quickstart-cloud.md
@@ -6,6 +6,7 @@ aliases:
   - ../cloud-quick-start
   - cloud-quick-start
   - cloud-quickstart
+  - cloud/quickstart-cloud/
 ---
 # How to Get Started With Qdrant Cloud
 


### PR DESCRIPTION
## Description

<img width="541" alt="Screenshot 2024-07-31 at 12 16 19 AM" src="https://github.com/user-attachments/assets/e7b37186-9f65-42f7-9314-c3a9339dd8d7">

Fixes the broken highlighted link.
Leads to https://qdrant.tech/documentation/cloud/quickstart-cloud.