### PR TITLE
Segment Anonymous ID for Cloud UI Consumption

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -78,16 +78,10 @@ export function devLog(str) {
 }
 
 export const CROSS_SITE_URL_PARAM_KEY = 'qdrant-tech';
-export function tagCloudUILinksWithHash() {
+export function tagCloudUILinksWithAnonymousId() {
   const targetUrl = 'https://cloud.qdrant.io/';
-  
-  // Generate a random 32-character string
-  const generateRandomString = (length = 32) => {
-    const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
-    return Array.from({ length }, () => charset.charAt(Math.floor(Math.random() * charset.length))).join('');
-  };
 
-  const parameterValue = generateRandomString();
+  const anonymousId = analytics.user().anonymousId();
   
   // Function to add or update query parameter in the URL
   function addOrUpdateQueryParam(url, paramName, paramValue) {
@@ -101,6 +95,6 @@ export function tagCloudUILinksWithHash() {
 
   // Loop through all selected <a> elements and update their href
   links.forEach(link => {
-    link.href = addOrUpdateQueryParam(link.href, CROSS_SITE_URL_PARAM_KEY, parameterValue);
+    link.href = addOrUpdateQueryParam(link.href, CROSS_SITE_URL_PARAM_KEY, anonymousId);
   });
 }

--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -77,7 +77,7 @@ export function devLog(str) {
   }
 }
 
-export const CROSS_SITE_URL_PARAM_KEY = 'qdrant-tech';
+export const CROSS_SITE_URL_PARAM_KEY = 'ajs_anonymous_id';
 export function tagCloudUILinksWithAnonymousId() {
   const targetUrl = 'https://cloud.qdrant.io/';
 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -77,7 +77,7 @@ export function devLog(str) {
   }
 }
 
-export const CROSS_SITE_URL_PARAM_KEY = 'ajs_anonymous_id';
+const CROSS_SITE_URL_PARAM_KEY = 'ajs_anonymous_id';
 export function tagCloudUILinksWithAnonymousId() {
   const targetUrl = 'https://cloud.qdrant.io/';
 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -1,15 +1,12 @@
 import scrollHandler from './scroll-handler';
 import { XXL_BREAKPOINT } from './constants';
-import { initGoToTopButton, getCookie, tagCloudUILinksWithHash } from './helpers';
+import { initGoToTopButton, getCookie } from './helpers';
 import { loadSegment, createSegmentStoredPage, tagAllAnchors } from './segment-helpers'
 
 createSegmentStoredPage();
 
 // on document ready
 document.addEventListener('DOMContentLoaded', function () {
-  tagCloudUILinksWithHash();
-  tagAllAnchors();
-
   if (!window.analytics && getCookie('cookie-consent')) {
     loadSegment();
   }

--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -1,7 +1,7 @@
 import scrollHandler from './scroll-handler';
 import { XXL_BREAKPOINT } from './constants';
 import { initGoToTopButton, getCookie } from './helpers';
-import { loadSegment, createSegmentStoredPage, tagAllAnchors } from './segment-helpers'
+import { loadSegment, createSegmentStoredPage } from './segment-helpers'
 
 createSegmentStoredPage();
 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -1,4 +1,4 @@
-import { getCookie, devLog, CROSS_SITE_URL_PARAM_KEY } from './helpers';
+import { getCookie, devLog, tagCloudUILinksWithAnonymousId } from './helpers';
 
 const WRITE_KEY = 'segmentWriteKey';
 const PAGES_SESSION_STORAGE_KEY = 'segmentPages';
@@ -33,16 +33,11 @@ const nameMapper = (url) => { // Mapping names based on pathname for Segment
 /* DOM helpers */
 /***************/
 const handleClickInteraction = (event) => {
-  const url = new URL(event.target.href);
-  const searchParams = url.searchParams;
-  const qdrantTechHash = searchParams.get(CROSS_SITE_URL_PARAM_KEY);
-
   const payload = {
     ...PAYLOAD_BOILERPLATE,
     location: event.target.getAttribute('data-metric-loc') ?? '',
     label: event.target.getAttribute('data-metric-label') ?? event.target.innerText,
-    action: 'clicked',
-    qdrant_tech_hash: qdrantTechHash ?? null
+    action: 'clicked'
   };
 
   // If consented to tracking the track 
@@ -250,6 +245,11 @@ export function loadSegment() {
       analytics._writeKey = writeKey;
       analytics.SNIPPET_VERSION = "5.2.0";
       analytics.load(writeKey);
+
+      analytics.ready(function() {
+        tagCloudUILinksWithAnonymousId();
+        tagAllAnchors();
+      });
     }
   }
 

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -55,7 +55,7 @@ const handleClickInteraction = (event) => {
 
 // Gather all <a> elements that have been tagged 
 // for tracking via 'data-metric-loc' attribute
-export function tagAllAnchors() {
+function tagAllAnchors() {
   const allMetricsAnchors= document.querySelectorAll('a[data-metric-loc]');
 
   if (allMetricsAnchors) {

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/menu-mobile.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/menu-mobile.html
@@ -43,10 +43,10 @@
       {{ end }}
     </ul>
     <div class="menu-mobile__controls">
-      <a href="{{ .Params.logIn.url }}" class="button button_outlined button_lg menu-mobile__login"
+      <a data-metric-loc="mobile_nav" href="{{ .Params.logIn.url }}" class="button button_outlined button_lg menu-mobile__login"
         >{{ .Params.logIn.text }}</a
       >
-      <a href="{{ .Params.startFree.url }}" class="button button_contained button_lg">{{ .Params.startFree.text }}</a>
+      <a data-metric-loc="mobile_nav" href="{{ .Params.startFree.url }}" class="button button_contained button_lg">{{ .Params.startFree.text }}</a>
     </div>
   </div>
 {{ end }}


### PR DESCRIPTION
Spoke with Luis and Fabrizio. We've decided to pass the Segment anonymous generated ID via url params for cross domain tracking, instead of the pre-existing generate hash:
- custom generated ID swapped out for Segment Anonymous ID
- tagging on analytics load (instead of DOM load) as Segment must be loaded for the ID retrieved and passed
- adding mobile nav signup/login click tracking 