### PR TITLE
Adding documentation for specifying writing log files to disk.

### DIFF
--- a/qdrant-landing/content/documentation/guides/configuration.md
+++ b/qdrant-landing/content/documentation/guides/configuration.md
@@ -91,12 +91,9 @@ QDRANT__SERVICE__HTTP_PORT=1234 ./qdrant
 ```yaml
 log_level: INFO
 
-# Logging to disk
-# By default, Qdrant logs to stdout. You can write logs to disk by specifying a log file. 
-# This parameter can be specified in the configuration file 
-# or by updating the current configuration with `POST /logger`.
-# If both the top-level `log_level` and the `logger.log_level` directives are specified, 
-# the `logger.log_level` directive will take priority.
+# Logging configuration
+# Qdrant logs to stdout. You may configure to also write logs to a file on disk.
+# Be aware that this file may grow indefinitely.
 # logger:
 #   on_disk:
 #     enabled: true

--- a/qdrant-landing/content/documentation/guides/configuration.md
+++ b/qdrant-landing/content/documentation/guides/configuration.md
@@ -92,7 +92,7 @@ QDRANT__SERVICE__HTTP_PORT=1234 ./qdrant
 log_level: INFO
 
 # Logging to disk
-# You can write logs to disk by specifying a log file. 
+# By default, Qdrant logs to stdout. You can write logs to disk by specifying a log file. 
 # This parameter can be specified in the configuration file 
 # or by updating the current configuration with `POST /logger`.
 # If both the top-level `log_level` and the `logger.log_level` directives are specified, 

--- a/qdrant-landing/content/documentation/guides/configuration.md
+++ b/qdrant-landing/content/documentation/guides/configuration.md
@@ -91,6 +91,18 @@ QDRANT__SERVICE__HTTP_PORT=1234 ./qdrant
 ```yaml
 log_level: INFO
 
+# Logging to disk
+# You can write logs to disk by specifying a log file. 
+# This parameter can be specified in the configuration file 
+# or by updating the current configuration with `POST /logger`.
+# If both the top-level `log_level` and the `logger.log_level` directives are specified, 
+# the `logger.log_level` directive will take priority.
+# logger:
+#   on_disk:
+#     enabled: true
+#     log_file: path/to/log/file.log
+#     log_level: INFO
+
 storage:
   # Where to store all the data
   storage_path: ./storage

--- a/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
@@ -48,7 +48,7 @@ kubectl -n qdrant-namespace logs -l app=qdrant,cluster-id=9a9f48c7-bb90-4fb2-816
 
 **Writing logs to disk:** You can write logs to disk by specifying a log file. This parameter can be specified in the configuration file or by updating the current configuration with `POST /logger`.
 
-```
+```yaml
 logger:
   on_disk:
     enabled: true

--- a/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
@@ -46,9 +46,7 @@ kubectl -n qdrant-namespace logs -l app=qdrant,cluster-id=9a9f48c7-bb90-4fb2-816
 
 **Configuring log levels:** You can configure log levels for the databases individually in the configuration section of the Qdrant Cluster detail page. The log level for the **Qdrant Cloud Agent** and **Operator** can be set in the [Hybrid Cloud Environment configuration](/documentation/hybrid-cloud/operator-configuration/).
 
-**Writing logs to disk** 
-
-You can write logs to disk by specifying a log file. This parameter can be specified in the configuration file or by updating the current configuration with `POST /logger`.
+**Writing logs to disk:** You can write logs to disk by specifying a log file. This parameter can be specified in the configuration file or by updating the current configuration with `POST /logger`.
 
 ```
 logger:

--- a/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
@@ -46,16 +46,6 @@ kubectl -n qdrant-namespace logs -l app=qdrant,cluster-id=9a9f48c7-bb90-4fb2-816
 
 **Configuring log levels:** You can configure log levels for the databases individually in the configuration section of the Qdrant Cluster detail page. The log level for the **Qdrant Cloud Agent** and **Operator** can be set in the [Hybrid Cloud Environment configuration](/documentation/hybrid-cloud/operator-configuration/).
 
-**Writing logs to disk:** You can write logs to disk by specifying a log file. This parameter can be specified in the configuration file or by updating the current configuration with `POST /logger`.
-
-```yaml
-logger:
-  on_disk:
-    enabled: true
-    log_file: path/to/log/file.log
-    log_level: debug
-```
-
 ## Monitoring
 
 The Qdrant Cloud console gives you access to basic metrics about CPU, memory and disk usage of your Qdrant clusters. You can also access Prometheus metrics endpoint of your Qdrant databases. Finally, you can use a Kubernetes workload monitoring tool of your choice to monitor your Qdrant clusters.

--- a/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/networking-logging-monitoring.md
@@ -46,6 +46,18 @@ kubectl -n qdrant-namespace logs -l app=qdrant,cluster-id=9a9f48c7-bb90-4fb2-816
 
 **Configuring log levels:** You can configure log levels for the databases individually in the configuration section of the Qdrant Cluster detail page. The log level for the **Qdrant Cloud Agent** and **Operator** can be set in the [Hybrid Cloud Environment configuration](/documentation/hybrid-cloud/operator-configuration/).
 
+**Writing logs to disk** 
+
+You can write logs to disk by specifying a log file. This parameter can be specified in the configuration file or by updating the current configuration with `POST /logger`.
+
+```
+logger:
+  on_disk:
+    enabled: true
+    log_file: path/to/log/file.log
+    log_level: debug
+```
+
 ## Monitoring
 
 The Qdrant Cloud console gives you access to basic metrics about CPU, memory and disk usage of your Qdrant clusters. You can also access Prometheus metrics endpoint of your Qdrant databases. Finally, you can use a Kubernetes workload monitoring tool of your choice to monitor your Qdrant clusters.


### PR DESCRIPTION
This PR resolves: https://github.com/qdrant/landing_page/issues/1125

Provides documentation around writing Qdrant log files to disk.

I tried to build the project locally to verify but saw the following when I ran `hugo serve -D`:

```
ERROR TOCSS-DART: failed to transform "/css/main.scss" (text/x-scss): "/Users/justin/Development/Projects/landing_page/qdrant-landing/themes/qdrant-2024/assets/css/_bootstrap-custom.scss:2:8": Can't find stylesheet to import.
Built in 1744 ms
Error: error building site: TOCSS-DART: failed to transform "/css/vendor/splide.scss" (text/x-scss): "/Users/justin/Development/Projects/landing_page/qdrant-landing/themes/qdrant-2024/assets/css/vendor/splide.scss:1:8": Can't find stylesheet to import.
```