### PR TITLE
Fix: incorrect param usage in community hero

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/community-hero.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/community-hero.html
@@ -9,7 +9,7 @@
 <!--      {{ end }}-->
 <!--      <p class="community-hero__about">{{ .Params.about }}</p>-->
       <div class="text-center">
-        <a href="{{ .Params.button.link }}" class="button button_contained button_lg" target="_blank" role="button">{{ .Params.button.text }}</a>
+        <a href="{{ .Params.button.url }}" class="button button_contained button_lg" target="_blank" role="button">{{ .Params.button.text }}</a>
       </div>
       <img class="community-hero__image-mobile" src="{{ .Params.image.srcMobile }}" alt="{{ .Params.image.alt }}" />
     </div>


### PR DESCRIPTION
The "Join our Discord" button on the community page does not link properly to the Discord invite due to the wrong param being used. This PR fixes the theme to use `url`, instead of `link`, so it matches the param declared in Markdown.