### PR TITLE
Prevent empty pages rendering

### DIFF
--- a/qdrant-landing/archetypes/delimiter.md
+++ b/qdrant-landing/archetypes/delimiter.md
@@ -4,4 +4,8 @@ title: "{{ replace .Name "-" " " | title }}"
 type: delimiter
 weight: 0 # Change this weight to change order of sections
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
 ---

--- a/qdrant-landing/content/documentation/0-dl.md
+++ b/qdrant-landing/content/documentation/0-dl.md
@@ -4,4 +4,8 @@ title: "Getting Started"
 type: delimiter
 weight: 1 # Change this weight to change order of sections
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
 ---

--- a/qdrant-landing/content/documentation/1-dl.md
+++ b/qdrant-landing/content/documentation/1-dl.md
@@ -4,4 +4,8 @@ title: "User Manual"
 type: delimiter
 weight: 10 # Change this weight to change order of sections
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
 ---

--- a/qdrant-landing/content/documentation/2-dl.md
+++ b/qdrant-landing/content/documentation/2-dl.md
@@ -4,4 +4,8 @@ title: "Integrations"
 type: delimiter
 weight: 14 # Change this weight to change order of sections
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
 ---

--- a/qdrant-landing/content/documentation/3-dl.md
+++ b/qdrant-landing/content/documentation/3-dl.md
@@ -4,4 +4,8 @@ title: "Examples"
 type: delimiter
 weight: 17 # Change this weight to change order of sections
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
 ---

--- a/qdrant-landing/content/documentation/4-dl.md
+++ b/qdrant-landing/content/documentation/4-dl.md
@@ -4,4 +4,8 @@ title: "Managed Services"
 type: delimiter
 weight: 7 # Change this weight to change order of sections
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
 ---

--- a/qdrant-landing/content/documentation/5-dl.md
+++ b/qdrant-landing/content/documentation/5-dl.md
@@ -4,4 +4,8 @@ title: "Support"
 type: delimiter
 weight: 21 # Change this weight to change order of sections
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
 ---

--- a/qdrant-landing/content/features/_index.md
+++ b/qdrant-landing/content/features/_index.md
@@ -2,6 +2,15 @@
 title: "Make the most of your Unstructured Data"
 icon: 
 sitemapExclude: True
+_build:
+  render: never
+  list: never
+  publishResources: false
+cascade:
+  _build:
+    render: never
+    list: never
+    publishResources: false
 ---
 
 Qdrant is a vector database & vector similarity search engine.

--- a/qdrant-landing/content/legal/_index.html
+++ b/qdrant-landing/content/legal/_index.html
@@ -1,4 +1,0 @@
----
-title: Legal
-sitemapExclude: True
----

--- a/qdrant-landing/content/legal/_index.md
+++ b/qdrant-landing/content/legal/_index.md
@@ -1,0 +1,9 @@
+---
+title: Legal
+sitemapExclude: True
+_build:
+  render: never
+cascade:
+  - build:
+    render: always
+---

--- a/qdrant-landing/content/marketing/_index.md
+++ b/qdrant-landing/content/marketing/_index.md
@@ -1,5 +1,15 @@
 ---
 _build:
-    render: never
-    list: never
+  list: never
+  publishResources: false
+  render: never
+# child pages won't be rendered if lines below are not removed
+# currently we don't have a template for this section
+# remove or comment out the lines below to render the section
+# only if you have a template for it!
+cascade:
+  _build:
+      list: never
+      publishResources: false
+      render: never
 ---

--- a/qdrant-landing/content/stack/_index.md
+++ b/qdrant-landing/content/stack/_index.md
@@ -2,4 +2,13 @@
 title: Trusted by developers worldwide
 subtitle: Qdrant is powering thousands of innovative AI solutions at leading companies. Engineers are choosing Qdrant for its top performance, high scalability, ease of use, and flexible cost and resource-saving options
 sitemapExclude: True
+_build:
+  list: never
+  publishResources: false
+  render: never
+cascade:
+    _build:
+      list: never
+      publishResources: false
+      render: never
 ---


### PR DESCRIPTION
We have some markdown files that are not intended to be displayed as site pages. Although they are excluded from the site map, they can still be accessed through a link. This pull request adds Hugo parameters to these files to prevent them from being built.