### PR TITLE
Removed `sitemapExclude` params from places where we don't need it anymore

### DIFF
--- a/qdrant-landing/content/blog/cohere-embedding-v3.md
+++ b/qdrant-landing/content/blog/cohere-embedding-v3.md
@@ -1,7 +1,6 @@
 ---
 draft: false
 preview_image: /blog/from_cms/nils-thumbnail.png
-sitemapExclude: true
 title: "From Content Quality to Compression: The Evolution of Embedding Models
   at Cohere with Nils Reimers"
 slug: cohere-embedding-v3

--- a/qdrant-landing/content/blog/vector-search-and-applications-by-andrey-vasnetsov-cto-at-qdrant.md
+++ b/qdrant-landing/content/blog/vector-search-and-applications-by-andrey-vasnetsov-cto-at-qdrant.md
@@ -2,7 +2,6 @@
 draft: false
 title: '"Vector search and applications" by Andrey Vasnetsov, CTO at Qdrant'
 preview_image: /blog/from_cms/ramsri-podcast-preview.png
-sitemapExclude: true
 slug: vector-search-and-applications-record
 short_description: Andrey Vasnetsov, Co-founder and CTO at Qdrant has shared
   about vector search and applications with Learn NLP Academy. 

--- a/qdrant-landing/content/demo/_index.md
+++ b/qdrant-landing/content/demo/_index.md
@@ -38,5 +38,4 @@ cards:
     link:
       text: View Demo
       url: https://code-search.qdrant.tech/
-sitemapExclude: true
 ---

--- a/qdrant-landing/content/subscribe/_index.md
+++ b/qdrant-landing/content/subscribe/_index.md
@@ -24,5 +24,4 @@ footer:
   impressumLink:
     url: /legal/impressum/
     text: Impressum
-sitemapExclude: true
 ---


### PR DESCRIPTION
Removed `sitemapExclude` parameters from associated files as the next pages need to be indexed by search engines now:

- https://qdrant.tech/blog/cohere-embedding-v3/
- https://qdrant.tech/demo/
- https://qdrant.tech/blog/vector-search-and-applications-record/
- https://qdrant.tech/subscribe/