### PR TITLE
Removed `list: never` build option from docs sidebar delimiters

### DIFF
--- a/qdrant-landing/content/documentation/0-dl.md
+++ b/qdrant-landing/content/documentation/0-dl.md
@@ -5,7 +5,6 @@ type: delimiter
 weight: 1 # Change this weight to change order of sections
 sitemapExclude: True
 _build:
-  list: never
   publishResources: false
   render: never
 ---

--- a/qdrant-landing/content/documentation/1-dl.md
+++ b/qdrant-landing/content/documentation/1-dl.md
@@ -5,7 +5,6 @@ type: delimiter
 weight: 10 # Change this weight to change order of sections
 sitemapExclude: True
 _build:
-  list: never
   publishResources: false
   render: never
 ---

--- a/qdrant-landing/content/documentation/2-dl.md
+++ b/qdrant-landing/content/documentation/2-dl.md
@@ -5,7 +5,6 @@ type: delimiter
 weight: 14 # Change this weight to change order of sections
 sitemapExclude: True
 _build:
-  list: never
   publishResources: false
   render: never
 ---

--- a/qdrant-landing/content/documentation/3-dl.md
+++ b/qdrant-landing/content/documentation/3-dl.md
@@ -5,7 +5,6 @@ type: delimiter
 weight: 17 # Change this weight to change order of sections
 sitemapExclude: True
 _build:
-  list: never
   publishResources: false
   render: never
 ---

--- a/qdrant-landing/content/documentation/4-dl.md
+++ b/qdrant-landing/content/documentation/4-dl.md
@@ -5,7 +5,6 @@ type: delimiter
 weight: 7 # Change this weight to change order of sections
 sitemapExclude: True
 _build:
-  list: never
   publishResources: false
   render: never
 ---

--- a/qdrant-landing/content/documentation/5-dl.md
+++ b/qdrant-landing/content/documentation/5-dl.md
@@ -5,7 +5,6 @@ type: delimiter
 weight: 21 # Change this weight to change order of sections
 sitemapExclude: True
 _build:
-  list: never
   publishResources: false
   render: never
 ---


### PR DESCRIPTION
Mistakenly excluded docs sidebar delimiters from listing, this PR fixes this