### PR TITLE
Open external links in a new tab

### DIFF
--- a/qdrant-landing/layouts/_default/_markup/render-link.html
+++ b/qdrant-landing/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener nofollow"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
Render links from markdown to HTML so that they would open in a new tab if they start with `https`.