### PR TITLE
Fix typo in multiple-partitions documentation

### DIFF
--- a/qdrant-landing/content/documentation/guides/multiple-partitions.md
+++ b/qdrant-landing/content/documentation/guides/multiple-partitions.md
@@ -512,7 +512,7 @@ client.create_payload_index(
     collection_name="{collection_name}",
     field_name="group_id",
     field_schema=models.KeywordIndexParams(
-        type="keywprd",
+        type="keyword",
         is_tenant=True,
     ),
 )


### PR DESCRIPTION
Typo is present in python example for creating payload index.
`keywprd` vs `keyword`