### PR TITLE
fix: prepend Cloud API KEY with apikey

### DIFF
--- a/qdrant-landing/content/documentation/qdrant-cloud-api.md
+++ b/qdrant-landing/content/documentation/qdrant-cloud-api.md
@@ -28,7 +28,7 @@ Here's an example of a basic request to **list all clusters** in your Qdrant Clo
 curl -X 'GET' \
   'https://cloud.qdrant.io/pa/v1/accounts/<YOUR_ACCOUNT_ID>/clusters' \
   -H 'accept: application/json' \
-  -H 'Authorization: <YOUR_API_KEY>'
+  -H 'Authorization: apikey <YOUR_API_KEY>'
 ```
 
 This request will return a list of clusters associated with your account in JSON format.


### PR DESCRIPTION
Example API request lacks `apikey` in header

```
  -H 'Authorization: <YOUR_API_KEY>'
```

amended to 
```
  -H 'Authorization: apikey <YOUR_API_KEY>'
```

I tested and this works