### PR TITLE
[Docs] Add "Related Content" section in concept docs

### DIFF
--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -5,8 +5,6 @@ aliases:
   - ../filtering
 ---
 
-
-
 # Filtering
 
 With Qdrant, you can set conditions when searching or retrieving points.

--- a/qdrant-landing/content/documentation/concepts/filtering.md
+++ b/qdrant-landing/content/documentation/concepts/filtering.md
@@ -5,6 +5,8 @@ aliases:
   - ../filtering
 ---
 
+
+
 # Filtering
 
 With Qdrant, you can set conditions when searching or retrieving points.
@@ -12,6 +14,10 @@ For example, you can impose conditions on both the [payload](../payload/) and th
 
 Setting additional conditions is important when it is impossible to express all the features of the object in the embedding.
 Examples include a variety of business requirements: stock availability, user location, or desired price range.
+
+## Related Content
+|[A Complete Guide to Filtering in Vector Search](/articles/vector-search-filtering/)|Developer advice on proper usage and advanced practices.|
+|-|-|
 
 ## Filtering clauses
 


### PR DESCRIPTION
[PREVIEW](https://deploy-preview-1180--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/filtering/)

We are finding documentation is some of the most popular content on the site.
Specifically, filtering is a top 10 visited page. However, for people to discover related filtering tips, they have to manually explore the site.

By referencing directly related content, such as more formal guides (not blogs or casual articles), we aim to give more depth to the user journey on the docsite. 

<img width="905" alt="Screenshot 2024-09-16 at 2 34 58 PM" src="https://github.com/user-attachments/assets/d0473767-b1f2-46b8-8488-dd6a9621915a">
