### PR TITLE
Add CPU requirements, 32-bit is not supported

### DIFF
--- a/qdrant-landing/assets/jsconfig.json
+++ b/qdrant-landing/assets/jsconfig.json
@@ -1,0 +1,10 @@
+{
+ "compilerOptions": {
+  "baseUrl": ".",
+  "paths": {
+   "*": [
+    "../themes/qdrant-2024/assets/*"
+   ]
+  }
+ }
+}

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -12,9 +12,12 @@ The following sections describe the requirements for deploying Qdrant.
 
 ### CPU and memory
 
-Your CPU must meet the following requirements:
-
-- x86_64/amd64 or AArch64/arm64, 32-bit systems are not supported
+CPU architectures:
+- 64-bit system 
+  - x86_64/amd64 
+  - AArch64/arm64
+- 32-bit system
+  - Not supported
 
 The preferred size of your CPU and RAM depends on:
 

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -12,7 +12,11 @@ The following sections describe the requirements for deploying Qdrant.
 
 ### CPU and memory
 
-The CPU and RAM that you need depends on:
+Your CPU must meet the following requirements:
+
+- x86_64/amd64 or AArch64/arm64, 32-bit systems are not supported
+
+The preferred size of your CPU and RAM depends on:
 
 - Number of vectors
 - Vector dimensions

--- a/qdrant-landing/content/documentation/guides/installation.md
+++ b/qdrant-landing/content/documentation/guides/installation.md
@@ -6,18 +6,11 @@ aliases:
   - ../installation
 ---
 
-## Installation requirements
+# Installation requirements
 
 The following sections describe the requirements for deploying Qdrant.
 
-### CPU and memory
-
-CPU architectures:
-- 64-bit system 
-  - x86_64/amd64 
-  - AArch64/arm64
-- 32-bit system
-  - Not supported
+## CPU and memory
 
 The preferred size of your CPU and RAM depends on:
 
@@ -29,6 +22,15 @@ The preferred size of your CPU and RAM depends on:
 - How you configure quantization
 
 Our [Cloud Pricing Calculator](https://cloud.qdrant.io/calculator) can help you estimate required resources without payload or index data.
+
+### Supported CPU architectures:
+
+**64-bit system:**
+- x86_64/amd64 
+- AArch64/arm64
+
+**32-bit system:**
+- Not supported
 
 ### Storage
 


### PR DESCRIPTION
[Rendered](https://deploy-preview-1182--condescending-goldwasser-91acf0.netlify.app/documentation/guides/installation/#cpu-and-memory)

Update the listed requirements in the installation guide. We do not support 32-bit systems.