### PR TITLE
Fix quickstart for Python due to fetching payload by default

### DIFF
--- a/qdrant-landing/content/documentation/quickstart.md
+++ b/qdrant-landing/content/documentation/quickstart.md
@@ -363,7 +363,10 @@ Let's ask a basic question - Which of our stored vectors are most similar to the
 
 ```python
 search_result = client.query_points(
-    collection_name="test_collection", query=[0.2, 0.1, 0.9, 0.7], limit=3
+    collection_name="test_collection",
+    query=[0.2, 0.1, 0.9, 0.7],
+    with_payload=False,
+    limit=3
 ).points
 
 print(search_result)


### PR DESCRIPTION
A python user was confused on Discord when following the quickstart to get a different result.

This is because the Python client fetches payload by default.

Regarding other clients, I just checked the Rust one and it does not request payload by default.