### PR TITLE
[Docs] Fix broken link to scroll-points in API reference

### DIFF
--- a/qdrant-landing/content/documentation/concepts/points.md
+++ b/qdrant-landing/content/documentation/concepts/points.md
@@ -1716,7 +1716,7 @@ Python client:
 
 Sometimes it might be necessary to get all stored points without knowing ids, or iterate over points that correspond to a filter.
 
-REST API ([Schema](https://api.qdrant.tech/master/api-reference/search/scroll-points)):
+REST API ([Schema](https://api.qdrant.tech/master/api-reference/points/scroll-points)):
 
 ```http
 POST /collections/{collection_name}/points/scroll


### PR DESCRIPTION
Fixed a broken link. Updated the link to point to the correct `scroll-points` schema in the API reference.