### PR TITLE
Adding GA4 properties to Segment analytics events

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -98,3 +98,9 @@ export function tagCloudUILinksWithAnonymousId() {
     link.href = addOrUpdateQueryParam(link.href, CROSS_SITE_URL_PARAM_KEY, anonymousId);
   });
 }
+
+export function addGA4Properties(properties) {
+  const gaMeasurementId = getCookie('ga_measurement_id')?.replace('G-', '');
+  properties.ga_session_id = getCookie('_ga_' + gaMeasurementId)?.replace('GS1.1.','').split('.')[0];
+  properties.ga_client_id = getCookie('_ga')?.replace('GA1.1.','');
+}

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -1,4 +1,4 @@
-import { getCookie, devLog, tagCloudUILinksWithAnonymousId } from './helpers';
+import { addGA4Properties, getCookie, devLog, tagCloudUILinksWithAnonymousId } from './helpers';
 
 const WRITE_KEY = 'segmentWriteKey';
 const PAGES_SESSION_STORAGE_KEY = 'segmentPages';
@@ -125,6 +125,8 @@ const trackStoredPageViews = () => {
     const originalTimestamp = properties.storedEvent ? properties.storedTimestamp : null;
     delete properties['storedTimestamp'];
 
+    addGA4Properties(properties);
+
     if(window.analytics) {
       window.analytics.page(
         category,
@@ -150,6 +152,8 @@ const trackStoredInteractions = () => {
 const trackEvent = (name, properties = {}) => {
   const originalTimestamp = properties.storedEvent ? properties.storedTimestamp : null;
   delete properties['storedTimestamp'];
+
+  addGA4Properties(properties);
 
   if(window.analytics) {
     window.analytics.track({

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-setup.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-setup.js
@@ -1,6 +1,11 @@
 import * as params from '@params';
+import { setCookie } from './helpers';
 import { setSegmentWriteKey } from './segment-helpers';
 
 if (params.segmentWriteKey) {
     setSegmentWriteKey(params.segmentWriteKey);
+}
+
+if (params.gaMeasurementId) {
+    setCookie('ga_measurement_id', params.gaMeasurementId, 365);
 }

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/js-head.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/js-head.html
@@ -38,6 +38,6 @@
 
 <!--Segment-->
 {{ if .Site.Params.segmentWriteKey }}
-  {{ $segmentJs := resources.Get "js/segment-setup.js" | js.Build (dict "params" (dict "segmentWriteKey" .Site.Params.segmentWriteKey)) | minify | resources.Fingerprint "sha512" }}
+  {{ $segmentJs := resources.Get "js/segment-setup.js" | js.Build (dict "params" (dict "segmentWriteKey" .Site.Params.segmentWriteKey "gaMeasurementId" .Site.GoogleAnalytics)) | minify | resources.Fingerprint "sha512" }}
   <script src="{{ $segmentJs.RelPermalink }}"></script>
 {{ end }}


### PR DESCRIPTION
Storing and leveraging the Google Measurement ID for conversion analytics for the marketing team. Requested by JDM (consulting agency for our marketing) for use with Google Ads.