### PR TITLE
top banner mobile style fix

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_top-banner.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_top-banner.scss
@@ -2,12 +2,13 @@
 
 .top-banner {
   display: flex;
-  height: pxToRem(40);
   justify-content: center;
   align-items: center;
   gap: $spacer * 1.5;
   border-bottom: 1px solid $neutral-20;
   background: $neutral-10;
+  padding: 0.5 * $spacer $spacer;
+  line-height: 1.2;
 
   &__text {
     color: $neutral-94;


### PR DESCRIPTION
Small style fix for mobiles:
|**Before**| **After**|
|--|--|
|![Screenshot 2024-11-05 at 16 01 41](https://github.com/user-attachments/assets/19bf0385-57e3-4462-8aef-934bfaedbc73)| ![Screenshot 2024-11-05 at 16 01 49](https://github.com/user-attachments/assets/b42efd51-bfde-4cd5-8a27-776891e7892b)|
