### PR TITLE
docs: Re-organise API & SDKs, Web UI entries in the sidebar

### DIFF
--- a/qdrant-landing/content/documentation/fastembed/_index.md
+++ b/qdrant-landing/content/documentation/fastembed/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "FastEmbed" 
-weight: 6
+weight: 7
 partition: qdrant
 ---
 

--- a/qdrant-landing/content/documentation/interfaces.md
+++ b/qdrant-landing/content/documentation/interfaces.md
@@ -1,20 +1,20 @@
 ---
 title: API & SDKs
-weight: 6
+weight: 5
 partition: qdrant
-aliases:
-  - /documentation/interfaces/
+
 ---
 
 # Interfaces
 
-Qdrant supports these "official" clients. 
+Qdrant supports these "official" clients.
 
-> **Note:** If you are using a language that is not listed here, you can use the REST API directly or generate a client for your language 
+> **Note:** If you are using a language that is not listed here, you can use the REST API directly or generate a client for your language
 using [OpenAPI](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)
-or [protobuf](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/proto) definitions. 
+or [protobuf](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/proto) definitions.
 
 ## Client Libraries
+
 ||Client Repository|Installation|Version|
 |-|-|-|-|
 |[![python](/docs/misc/python.webp)](https://python-client.qdrant.tech/)|**[Python](https://github.com/qdrant/qdrant-client)** + **[(Client Docs)](https://python-client.qdrant.tech/)**|`pip install qdrant-client[fastembed]`|[Latest Release](https://github.com/qdrant/qdrant-client/releases)|
@@ -23,7 +23,6 @@ or [protobuf](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/prot
 |![golang](/docs/misc/go.webp)|**[Go](https://github.com/qdrant/go-client)**|`go get github.com/qdrant/go-client`|[Latest Release](https://github.com/qdrant/go-client)|
 |![.net](/docs/misc/dotnet.webp)|**[.NET](https://github.com/qdrant/qdrant-dotnet)**|`dotnet add package Qdrant.Client`|[Latest Release](https://github.com/qdrant/qdrant-dotnet/releases)|
 |![java](/docs/misc/java.webp)|**[Java](https://github.com/qdrant/java-client)**|[Available on Maven Central](https://central.sonatype.com/artifact/io.qdrant/client)|[Latest Release](https://github.com/qdrant/java-client/releases)|
-
 
 ## API Reference
 
@@ -44,8 +43,9 @@ As per the [configuration file](https://github.com/qdrant/qdrant/blob/master/con
 service:
   grpc_port: 6334
 ```
+
 <aside role="status">If you decide to use gRPC, you must expose the port when starting Qdrant.</aside>
- 
+
 Running the service inside of Docker will look like this:
 
 ```bash
@@ -55,7 +55,3 @@ docker run -p 6333:6333 -p 6334:6334 \
 ```
 
 **When to use gRPC:** The choice between gRPC and the REST API is a trade-off between convenience and speed. gRPC is a binary protocol and can be more challenging to debug. We recommend using gRPC if you are already familiar with Qdrant and are trying to optimize the performance of your application.
-
-
-
-

--- a/qdrant-landing/content/documentation/interfaces/api-reference.md
+++ b/qdrant-landing/content/documentation/interfaces/api-reference.md
@@ -1,7 +1,0 @@
----
-title: API Reference
-weight: 1
-type: external-link
-external_url: https://api.qdrant.tech/api-reference
-sitemapExclude: True
----

--- a/qdrant-landing/content/documentation/quickstart.md
+++ b/qdrant-landing/content/documentation/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Local Quickstart
-weight: 5
+weight: 4
 partition: qdrant
 aliases:
   - quick_start

--- a/qdrant-landing/content/documentation/web-ui.md
+++ b/qdrant-landing/content/documentation/web-ui.md
@@ -1,8 +1,10 @@
 ---
 title: Qdrant Web UI
-weight: 2
+weight: 6
+partition: qdrant
 aliases:
   - /documentation/web-ui/
+  - /documentation/interfaces/web-ui/
 ---
 
 # Qdrant Web UI


### PR DESCRIPTION
## [PREVIEW](https://deploy-preview-1308--condescending-goldwasser-91acf0.netlify.app/documentation/)

Currently, the `Qdrant Web UI` page is nested under the API & SDKs section. Which doesn't seem right.
Also, we're already pointing to the API reference in the nav bar. So no need to again in the API & SDKs section.

### CURRENTLY:
<img width="636" alt="Screenshot 2024-11-20 at 11 13 45 PM" src="https://github.com/user-attachments/assets/e11b3aa7-23c6-4430-9f98-a217c9f507d3">

### THIS PR:
<img width="636" alt="Screenshot 2024-11-20 at 11 10 51 PM" src="https://github.com/user-attachments/assets/76a4402c-788c-4ceb-b329-6d959e6bf261">
