### PR TITLE
fix: Use .Site.Config.Services.GoogleAnalytics.ID instead.

### DIFF
--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -3,7 +3,6 @@ languageCode = "en-us"
 title = "Qdrant - Vector Database"
 theme = "qdrant-2024"
 
-googleAnalytics = "G-NZYW2651NE"
 enableRobotsTXT = true
 canonifyURLs = true
 
@@ -117,4 +116,6 @@ disableKinds = ["taxonomy", "term"]
     environment = '{production}'
     path = '{**.skip,**.skip/*}'
 
-
+[services]
+  [services.googleAnalytics]
+    id = 'G-NZYW2651NE'

--- a/qdrant-landing/package-lock.json
+++ b/qdrant-landing/package-lock.json
@@ -2378,10 +2378,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/js-head.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/js-head.html
@@ -1,11 +1,11 @@
 {{ if hugo.IsProduction }}
-  {{ if .Site.GoogleAnalytics }}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
+  {{ if .Site.Config.Services.GoogleAnalytics.ID }}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Config.Services.GoogleAnalytics.ID }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments)};
   gtag('js', new Date());
-  gtag('config', '{{ .Site.GoogleAnalytics }}');
+  gtag('config', '{{ .Site.Config.Services.GoogleAnalytics.ID }}');
 </script>
   {{ end }}
 
@@ -38,6 +38,6 @@
 
 <!--Segment-->
 {{ if .Site.Params.segmentWriteKey }}
-  {{ $segmentJs := resources.Get "js/segment-setup.js" | js.Build (dict "params" (dict "segmentWriteKey" .Site.Params.segmentWriteKey "gaMeasurementId" .Site.GoogleAnalytics)) | minify | resources.Fingerprint "sha512" }}
+  {{ $segmentJs := resources.Get "js/segment-setup.js" | js.Build (dict "params" (dict "segmentWriteKey" .Site.Params.segmentWriteKey "gaMeasurementId" .Site.Config.Services.GoogleAnalytics.ID)) | minify | resources.Fingerprint "sha512" }}
   <script src="{{ $segmentJs.RelPermalink }}?v=eu"></script>
 {{ end }}

--- a/qdrant-landing/themes/qdrant/layouts/partials/head.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/head.html
@@ -36,13 +36,13 @@
 
     {{ if hugo.IsProduction }}
 
-    {{ if .Site.GoogleAnalytics }}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
+    {{ if .Site.Config.Services.GoogleAnalytics.ID }}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Config.Services.GoogleAnalytics.ID }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments)};
       gtag('js', new Date());
-      gtag('config', '{{ .Site.GoogleAnalytics }}');
+      gtag('config', '{{ .Site.Config.Services.GoogleAnalytics.ID }}');
     </script>
     {{ end }}
 

--- a/qdrant-landing/themes/qdrant/layouts/partials/table_of_content.html
+++ b/qdrant-landing/themes/qdrant/layouts/partials/table_of_content.html
@@ -21,7 +21,7 @@
         </ul>
         <div class="divider pt-2 mb-3"></div>
 
-        {{ if (and (not .Params.hide_feedback) (.Site.Params.feedback.enable) (.Site.GoogleAnalytics)) }}
+        {{ if (and (not .Params.hide_feedback) (.Site.Params.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) }}
             {{ partial "feedback.html" . -}}
         {{ end }}
     </div>


### PR DESCRIPTION
- Fixes:

```console
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.
```

- I've also run: `npm audit fix`