### PR TITLE
docs: List hardware/memory metrics in /guides/monitoring.md

### DIFF
--- a/qdrant-landing/content/documentation/guides/monitoring.md
+++ b/qdrant-landing/content/documentation/guides/monitoring.md
@@ -30,31 +30,31 @@ To scrape metrics from a Qdrant cluster running in Qdrant Cloud, note that an [A
 
 Each Qdrant server will expose the following metrics.
 
-| Name                                | Type    | Meaning                                                            |
-| ----------------------------------- | ------- | ------------------------------------------------------------------ |
-| app_info                            | gauge   | Information about Qdrant server                                    |
-| app_status_recovery_mode            | gauge   | If Qdrant is currently started in recovery mode                    |
-| collections_total                   | gauge   | Number of collections                                              |
-| collections_vector_total            | gauge   | Total number of vectors in all collections                         |
-| collections_full_total              | gauge   | Number of full collections                                         |
-| collections_aggregated_total        | gauge   | Number of aggregated collections                                   |
-| rest_responses_total                | counter | Total number of responses through REST API                         |
-| rest_responses_fail_total           | counter | Total number of failed responses through REST API                  |
-| rest_responses_avg_duration_seconds | gauge   | Average response duration in REST API                              |
-| rest_responses_min_duration_seconds | gauge   | Minimum response duration in REST API                              |
-| rest_responses_max_duration_seconds | gauge   | Maximum response duration in REST API                              |
-| grpc_responses_total                | counter | Total number of responses through gRPC API                         |
-| grpc_responses_fail_total           | counter | Total number of failed responses through REST API                  |
-| grpc_responses_avg_duration_seconds | gauge   | Average response duration in gRPC API                              |
-| grpc_responses_min_duration_seconds | gauge   | Minimum response duration in gRPC API                              |
-| grpc_responses_max_duration_seconds | gauge   | Maximum response duration in gRPC API                              |
-| cluster_enabled                     | gauge   | Whether the cluster support is enabled. 1 - YES                    |
+| Name                                | Type    | Meaning                                                                                                                            |
+| ----------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| app_info                            | gauge   | Information about Qdrant server                                                                                                    |
+| app_status_recovery_mode            | gauge   | If Qdrant is currently started in recovery mode                                                                                    |
+| collections_total                   | gauge   | Number of collections                                                                                                              |
+| collections_vector_total            | gauge   | Total number of vectors in all collections                                                                                         |
+| collections_full_total              | gauge   | Number of full collections                                                                                                         |
+| collections_aggregated_total        | gauge   | Number of aggregated collections                                                                                                   |
+| rest_responses_total                | counter | Total number of responses through REST API                                                                                         |
+| rest_responses_fail_total           | counter | Total number of failed responses through REST API                                                                                  |
+| rest_responses_avg_duration_seconds | gauge   | Average response duration in REST API                                                                                              |
+| rest_responses_min_duration_seconds | gauge   | Minimum response duration in REST API                                                                                              |
+| rest_responses_max_duration_seconds | gauge   | Maximum response duration in REST API                                                                                              |
+| grpc_responses_total                | counter | Total number of responses through gRPC API                                                                                         |
+| grpc_responses_fail_total           | counter | Total number of failed responses through REST API                                                                                  |
+| grpc_responses_avg_duration_seconds | gauge   | Average response duration in gRPC API                                                                                              |
+| grpc_responses_min_duration_seconds | gauge   | Minimum response duration in gRPC API                                                                                              |
+| grpc_responses_max_duration_seconds | gauge   | Maximum response duration in gRPC API                                                                                              |
+| cluster_enabled                     | gauge   | Whether the cluster support is enabled. 1 - YES                                                                                    |
 | memory_active_bytes                 | gauge   | Total number of bytes in active pages allocated by the application ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.active)) |
-| memory_allocated_bytes              | gauge   | Total number of bytes allocated by the application ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.allocated))                 |
-| memory_metadata_bytes               | gauge   | Total number of bytes dedicated to allocator metadata ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.metadata))                        |
-| memory_resident_bytes               | gauge   | Maximum number of bytes in physically resident data pages mapped ([resident](https://jemalloc.net/jemalloc.3.html#stats.resident))   |
-| memory_retained_bytes               | gauge   | Total number of bytes in virtual memory mappings ([retained](https://jemalloc.net/jemalloc.3.html#stats.retained))                  |
-| collection_hardware_metric_cpu      | gauge   | CPU measurements of a collection                                   |
+| memory_allocated_bytes              | gauge   | Total number of bytes allocated by the application ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.allocated))              |
+| memory_metadata_bytes               | gauge   | Total number of bytes dedicated to allocator metadata ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.metadata))            |
+| memory_resident_bytes               | gauge   | Maximum number of bytes in physically resident data pages mapped ([resident](https://jemalloc.net/jemalloc.3.html#stats.resident)) |
+| memory_retained_bytes               | gauge   | Total number of bytes in virtual memory mappings ([retained](https://jemalloc.net/jemalloc.3.html#stats.retained))                 |
+| collection_hardware_metric_cpu      | gauge   | CPU measurements of a collection                                                                                                   |
 
 ### Cluster-related metrics
 

--- a/qdrant-landing/content/documentation/guides/monitoring.md
+++ b/qdrant-landing/content/documentation/guides/monitoring.md
@@ -30,25 +30,31 @@ To scrape metrics from a Qdrant cluster running in Qdrant Cloud, note that an [A
 
 Each Qdrant server will expose the following metrics.
 
-| Name                                | Type    | Meaning                                           |
-|-------------------------------------|---------|---------------------------------------------------|
-| app_info                            | gauge   | Information about Qdrant server                   |
-| app_status_recovery_mode            | gauge   | If Qdrant is currently started in recovery mode   |
-| collections_total                   | gauge   | Number of collections                             |
-| collections_vector_total            | gauge   | Total number of vectors in all collections        |
-| collections_full_total              | gauge   | Number of full collections                        |
-| collections_aggregated_total        | gauge   | Number of aggregated collections                  |
-| rest_responses_total                | counter | Total number of responses through REST API        |
-| rest_responses_fail_total           | counter | Total number of failed responses through REST API |
-| rest_responses_avg_duration_seconds | gauge   | Average response duration in REST API             |
-| rest_responses_min_duration_seconds | gauge   | Minimum response duration in REST API             |
-| rest_responses_max_duration_seconds | gauge   | Maximum response duration in REST API             |
-| grpc_responses_total                | counter | Total number of responses through gRPC API        |
-| grpc_responses_fail_total           | counter | Total number of failed responses through REST API |
-| grpc_responses_avg_duration_seconds | gauge   | Average response duration in gRPC API             |
-| grpc_responses_min_duration_seconds | gauge   | Minimum response duration in gRPC API             |
-| grpc_responses_max_duration_seconds | gauge   | Maximum response duration in gRPC API             |
-| cluster_enabled                     | gauge   | Whether the cluster support is enabled. 1 - YES   |
+| Name                                | Type    | Meaning                                                            |
+| ----------------------------------- | ------- | ------------------------------------------------------------------ |
+| app_info                            | gauge   | Information about Qdrant server                                    |
+| app_status_recovery_mode            | gauge   | If Qdrant is currently started in recovery mode                    |
+| collections_total                   | gauge   | Number of collections                                              |
+| collections_vector_total            | gauge   | Total number of vectors in all collections                         |
+| collections_full_total              | gauge   | Number of full collections                                         |
+| collections_aggregated_total        | gauge   | Number of aggregated collections                                   |
+| rest_responses_total                | counter | Total number of responses through REST API                         |
+| rest_responses_fail_total           | counter | Total number of failed responses through REST API                  |
+| rest_responses_avg_duration_seconds | gauge   | Average response duration in REST API                              |
+| rest_responses_min_duration_seconds | gauge   | Minimum response duration in REST API                              |
+| rest_responses_max_duration_seconds | gauge   | Maximum response duration in REST API                              |
+| grpc_responses_total                | counter | Total number of responses through gRPC API                         |
+| grpc_responses_fail_total           | counter | Total number of failed responses through REST API                  |
+| grpc_responses_avg_duration_seconds | gauge   | Average response duration in gRPC API                              |
+| grpc_responses_min_duration_seconds | gauge   | Minimum response duration in gRPC API                              |
+| grpc_responses_max_duration_seconds | gauge   | Maximum response duration in gRPC API                              |
+| cluster_enabled                     | gauge   | Whether the cluster support is enabled. 1 - YES                    |
+| memory_active_bytes                 | gauge   | Total number of bytes in active pages allocated by the application |
+| memory_allocated_bytes              | gauge   | Total number of bytes allocated by the application                 |
+| memory_metadata_bytes               | gauge   | Total number of bytes dedicated to metadata                        |
+| memory_resident_bytes               | gauge   | Maximum number of bytes in physically resident data pages mapped"  |
+| memory_retained_bytes               | gauge   | Total number of bytes in virtual memory mappings                   |
+| collection_hardware_metric_cpu      | gauge   | CPU measurements of a collection                                   |
 
 ### Cluster-related metrics
 

--- a/qdrant-landing/content/documentation/guides/monitoring.md
+++ b/qdrant-landing/content/documentation/guides/monitoring.md
@@ -52,7 +52,7 @@ Each Qdrant server will expose the following metrics.
 | memory_active_bytes                 | gauge   | Total number of bytes in active pages allocated by the application |
 | memory_allocated_bytes              | gauge   | Total number of bytes allocated by the application                 |
 | memory_metadata_bytes               | gauge   | Total number of bytes dedicated to metadata                        |
-| memory_resident_bytes               | gauge   | Maximum number of bytes in physically resident data pages mapped"  |
+| memory_resident_bytes               | gauge   | Maximum number of bytes in physically resident data pages mapped   |
 | memory_retained_bytes               | gauge   | Total number of bytes in virtual memory mappings                   |
 | collection_hardware_metric_cpu      | gauge   | CPU measurements of a collection                                   |
 

--- a/qdrant-landing/content/documentation/guides/monitoring.md
+++ b/qdrant-landing/content/documentation/guides/monitoring.md
@@ -49,11 +49,11 @@ Each Qdrant server will expose the following metrics.
 | grpc_responses_min_duration_seconds | gauge   | Minimum response duration in gRPC API                              |
 | grpc_responses_max_duration_seconds | gauge   | Maximum response duration in gRPC API                              |
 | cluster_enabled                     | gauge   | Whether the cluster support is enabled. 1 - YES                    |
-| memory_active_bytes                 | gauge   | Total number of bytes in active pages allocated by the application |
-| memory_allocated_bytes              | gauge   | Total number of bytes allocated by the application                 |
-| memory_metadata_bytes               | gauge   | Total number of bytes dedicated to metadata                        |
-| memory_resident_bytes               | gauge   | Maximum number of bytes in physically resident data pages mapped   |
-| memory_retained_bytes               | gauge   | Total number of bytes in virtual memory mappings                   |
+| memory_active_bytes                 | gauge   | Total number of bytes in active pages allocated by the application ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.active)) |
+| memory_allocated_bytes              | gauge   | Total number of bytes allocated by the application ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.allocated))                 |
+| memory_metadata_bytes               | gauge   | Total number of bytes dedicated to allocator metadata ([jemalloc](https://jemalloc.net/jemalloc.3.html#stats.metadata))                        |
+| memory_resident_bytes               | gauge   | Maximum number of bytes in physically resident data pages mapped ([resident](https://jemalloc.net/jemalloc.3.html#stats.resident))   |
+| memory_retained_bytes               | gauge   | Total number of bytes in virtual memory mappings ([retained](https://jemalloc.net/jemalloc.3.html#stats.retained))                  |
 | collection_hardware_metric_cpu      | gauge   | CPU measurements of a collection                                   |
 
 ### Cluster-related metrics


### PR DESCRIPTION
While updating the Datadog integration with the new metrics, I found this page was not up-to-date.

## [PREVIEW](https://deploy-preview-1353--condescending-goldwasser-91acf0.netlify.app/documentation/guides/monitoring/)