### PR TITLE
For a grey collection status, hint to use the trigger optimizers button

### DIFF
--- a/qdrant-landing/content/documentation/concepts/collections.md
+++ b/qdrant-landing/content/documentation/concepts/collections.md
@@ -1471,6 +1471,9 @@ client.UpdateCollection(context.Background(), &qdrant.UpdateCollection{
 })
 ```
 
+Alternatively you may use the `Trigger Optimizers` button in the [Qdrant Web UI](/documentation/web-ui/).
+It is shown next to the grey collection status on the collection info page.
+
 ### Approximate point and vector counts
 
 You may be interested in the count attributes:


### PR DESCRIPTION
[Rendered](https://deploy-preview-1355--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/collections/#grey-collection-status)

Tell users they may use the `Trigger Optimizers` button in the web UI to resolve a grey collection status. It's easier than manually sending a request.

I did not include an image in the documentation as I don't think it's necessary, but here is what I'm referring to and what it looks like:

![image](https://github.com/user-attachments/assets/a5d4717b-c270-4636-a7d6-248296eda643)
