### PR TITLE
Update hybrid cloud docs for operator v2

### DIFF
--- a/qdrant-landing/content/documentation/cloud/cluster-scaling.md
+++ b/qdrant-landing/content/documentation/cloud/cluster-scaling.md
@@ -17,7 +17,7 @@ Vertical scaling is the process of increasing the capacity of a cluster by addin
 
 You can start with a minimal cluster configuration of 2GB of RAM and resize it up to 64GB of RAM (or even more if desired) over the time step by step with the growing amount of data in your application. If your cluster consists of several nodes each node will need to be scaled to the same size. Please note that vertical cluster scaling will require a short downtime period to restart your cluster.  In order to avoid a downtime you can make use of data replication, which can be configured on the collection level.  Vertical scaling can be initiated on the cluster detail page via the button "scale".
 
-If you want to scale your cluster down, the new, smaller memory size must be still sufficient to store all the data in the cluster. Otherwise, the database cluster could run out of memory and crash. Therefore, the new memory size must be at least as large as the current memory usage of the database cluster including a bit of buffer. Qdrant Cloud will automatically prevent you from scaling down the Qdrant datab ase cluster with a too small memory size.
+If you want to scale your cluster down, the new, smaller memory size must be still sufficient to store all the data in the cluster. Otherwise, the database cluster could run out of memory and crash. Therefore, the new memory size must be at least as large as the current memory usage of the database cluster including a bit of buffer. Qdrant Cloud will automatically prevent you from scaling down the Qdrant database cluster with a too small memory size.
 
 Note, that it is not possible to scale down the disk space of the cluster due to technical limitations of the underlying cloud providers.
 

--- a/qdrant-landing/content/documentation/hybrid-cloud/hybrid-cloud-setup.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/hybrid-cloud-setup.md
@@ -96,7 +96,6 @@ Container images:
 
 - `registry.cloud.qdrant.io/qdrant/qdrant`
 - `registry.cloud.qdrant.io/qdrant/qdrant-cloud-agent`
-- `registry.cloud.qdrant.io/qdrant/qdrant-operator`
 - `registry.cloud.qdrant.io/qdrant/operator`
 - `registry.cloud.qdrant.io/qdrant/cluster-manager`
 - `registry.cloud.qdrant.io/qdrant/prometheus`
@@ -106,7 +105,6 @@ Container images:
 Open Containers Initiative (OCI) Helm charts:
 
 - `registry.cloud.qdrant.io/qdrant-charts/qdrant-cloud-agent`
-- `registry.cloud.qdrant.io/qdrant-charts/qdrant-operator`
 - `registry.cloud.qdrant.io/qdrant-charts/operator`
 - `registry.cloud.qdrant.io/qdrant-charts/qdrant-cluster-manager`
 - `registry.cloud.qdrant.io/qdrant-charts/prometheus`
@@ -155,7 +153,6 @@ skopeo login your-registry.example.com
 To sync all container images:
 
 ```shell
-skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant/qdrant-operator your-registry.example.com/qdrant/qdrant-operator
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant/operator your-registry.example.com/qdrant/operator
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant/qdrant-cloud-agent your-registry.example.com/qdrant/qdrant-cloud-agent
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant/prometheus your-registry.example.com/qdrant/prometheus
@@ -171,7 +168,6 @@ To sync all helm charts:
 ```shell
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant-charts/prometheus your-registry.example.com/qdrant-charts/prometheus
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant-charts/operator your-registry.example.com/qdrant-charts/operator
-skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant-charts/qdrant-operator your-registry.example.com/qdrant-charts/qdrant-operator
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant-charts/qdrant-kubernetes-api your-registry.example.com/qdrant-charts/qdrant-kubernetes-api
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant-charts/qdrant-cloud-agent your-registry.example.com/qdrant-charts/qdrant-cloud-agent
 skopeo sync --all --src docker --dest docker registry.cloud.qdrant.io/qdrant-charts/operator your-registry.example.com/qdrant-charts/operator

--- a/qdrant-landing/content/documentation/hybrid-cloud/operator-configuration.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/operator-configuration.md
@@ -10,68 +10,216 @@ The Qdrant Operator has several configuration options, which can be configured i
 The following YAML shows all configuration options with their default values:
 
 ```yaml
-# Retention for the backup history of Qdrant clusters
-backupHistoryRetentionDays: 2
-# Timeout configuration for the Qdrant operator operations
-operationTimeout: 7200 # 2 hours
-handlerTimeout: 21600 # 6 hours
-backupTimeout: 12600 # 3.5 hours
-# Incremental backoff configuration for the Qdrant operator operations
-backOff:
-  minDelay: 5
-  maxDelay: 300
-  increment: 5
-#  node_selector: {}
-#  tolerations: []
-# Default ingress configuration for a Qdrant cluster
-ingress:
+# Additional pod annotations
+podAnnotations: {}
+
+# Configuration for the Qdrant operator service monitor to scrape metrics
+serviceMonitor:
   enabled: false
-  provider: KubernetesIngress # or NginxIngress
-#  kubernetesIngress:
-#  ingressClassName: ""
-# Default storage configuration for a Qdrant cluster
-#storage:
-# Default VolumeSnapshotClass for a Qdrant cluster
-#  snapshot_class: "csi-snapclass"
-# Default StorageClass for a Qdrant cluster, uses cluster default StorageClass if not set
-#  default_storage_class_names:
-# StorageClass for DB volumes
-#    db: ""
-# StorageClass for snapshot volumes
-#    snapshots: ""
-# Default scheduling configuration for a Qdrant cluster
-#scheduling:
-#  default_topology_spread_constraints: []
-#  default_pod_disruption_budget: {}
-qdrant:
-# Default security context for Qdrant cluster
-#  securityContext:
-#    enabled: false
-#    user: ""
-#    fsGroup: ""
-#    group: ""
-# Default Qdrant image configuration
-#  image:
-#    pull_secret: ""
-#    pull_policy: IfNotPresent
-#    repository: qdrant/qdrant
-# Default Qdrant log_level
-#  log_level: INFO
-# Default network policies to create for a qdrant cluster
-  networkPolicies:
-    ingress:
-      - ports:
-        - protocol: TCP
-          port: 6333
-        - protocol: TCP
-          port: 6334
-# Allow DNS resolution from qdrant pods at Kubernetes internal DNS server
-    egress:
-      - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-        ports:
-        - protocol: UDP
-          port: 53
+
+# Resource requests and limits for the Qdrant operator
+resources: {}
+
+# Node selector for the Qdrant operator
+nodeSelector: {}
+
+# Tolerations for the Qdrant operator
+tolerations: []
+
+# Affinity configuration for the Qdrant operator
+affinity: {}
+
+# Configuration for the Qdrant operator (v2)
+settings:
+  # The log level for the operator
+  # Available options: DEBUG | INFO | WARN | ERROR
+  logLevel: INFO 
+  # Controller related settings
+  controller:
+    # The period a forced recync is done by the controller (if watches are missed / nothing happened)
+    forceResyncPeriod: 10h
+    # QPS indicates the maximum QPS to the master from this client.
+    # Default is 200
+    qps: 200
+    # Maximum burst for throttle.
+    # Default is 500.
+    burst: 500
+  # Features contains the settings for enabling / disabling the individual features of the operator
+  features:
+    # ClusterManagement contains the settings for qdrant (database) cluster management
+    clusterManagement:
+      # Whether or not the Qdrant cluster features are enabled.
+      # If disabled, all other properties in this struct are disregarded. Otherwise, the individual features will be inspected.
+      # Default is true.
+      enable: true
+      # The StorageClass used to make database and snapshot PVCs.
+      # Default is nil, meaning the default storage class of Kubernetes.
+      storageClass: 
+        # The StorageClass used to make database PVCs.
+        # Default is nil, meaning the default storage class of Kubernetes.
+        #database: 
+        # The StorageClass used to make snapshot PVCs.
+        # Default is nil, meaning the default storage class of Kubernetes.
+        #snapshot:
+      # Qdrant config contains settings specific for the database
+      qdrant:
+        # The config where to find the image for qdrant
+        image: 
+          # The repository where to find the image for qdrant
+          # Default is "qdrant/qdrant"
+          repository: qdrant/qdrant
+          # Docker image pull policy
+          # Default "IfNotPresent", unless the tag is dev, master or latest. Then "Always"
+          #pullPolicy:
+          # Docker image pull secret name
+          # This secret should be available in the namespace where the cluster is running
+          # Default not set
+          #pullSecretName:
+        # storage contains the settings for the storage of the Qdrant cluster
+        storage:
+          performance:
+            # CPU budget, how many CPUs (threads) to allocate for an optimization job.
+            # If 0 - auto selection, keep 1 or more CPUs unallocated depending on CPU size
+            # If negative - subtract this number of CPUs from the available CPUs.
+            # If positive - use this exact number of CPUs.
+            optimizerCpuBudget: 0
+            # Enable async scorer which uses io_uring when rescoring.
+            # Only supported on Linux, must be enabled in your kernel.
+            # See: <https://qdrant.tech/articles/io_uring/#and-what-about-qdrant>
+            asyncScorer: false
+        # Qdrant DB log level
+        # Available options: DEBUG | INFO | WARN | ERROR 
+        # Default is "INFO"
+        logLevel: INFO
+        # Default Qdrant security context configuration
+        securityContext:
+          # Enable default security context
+          # Default is false
+          enabled: false
+          # Default user for qdrant container
+          # Default not set
+          #user: 1000
+          # Default fsGroup for qdrant container
+          # Default not set
+          #fsUser: 2000
+          # Default group for qdrant container
+          # Default not set
+          #group: 3000
+        # Network policies configuration for the Qdrant databases
+        networkPolicies:
+          ingress:
+            - ports:
+                - protocol: TCP
+                  port: 6333
+                - protocol: TCP
+                  port: 6334
+          # Allow DNS resolution from qdrant pods at Kubernetes internal DNS server
+          egress:
+            - ports:
+                - protocol: UDP
+                  port: 53
+      # Scheduling config contains the settings specific for scheduling
+      scheduling:
+        # Default topology spread constraints (list from type corev1.TopologySpreadConstraint)
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: "kubernetes.io/hostname"
+            whenUnsatisfiable: "ScheduleAnyway"
+        # Default pod disruption budget (object from type policyv1.PodDisruptionBudgetSpec)
+        podDisruptionBudget:
+          maxUnavailable: 1
+      # ClusterManager config contains the settings specific for cluster manager
+      clusterManager:
+        # Whether or not the cluster manager (on operator level).
+        # If disabled, all other properties in this struct are disregarded. Otherwise, the individual features will be inspected.
+        # Default is false.
+        enable: true
+        # The endpoint address the cluster manager could be reached
+        # If set, this should be a full URL like: http://cluster-manager.qdrant-cloud-ns.svc.cluster.local:7333
+        endpointAddress: http://qdrant-cluster-manager:80
+        # InvocationInterval is the interval between calls (started after the previous call is retured)
+        # Default is 10 seconds
+        invocationInterval: 10s
+        # Timeout is the duration a single call to the cluster manager is allowed to take.
+        # Default is 30 seconds
+        timeout: 30s
+        # Specifies overrides for the manage rules
+        manageRulesOverrides:
+          #dry_run: 
+          #max_transfers:
+          #max_transfers_per_collection:
+          #rebalance:
+          #replicate:
+      # Ingress config contains the settings specific for ingress
+      ingress:
+        # Whether or not the Ingress feature is enabled.
+        # Default is true.
+        enable: false
+        # Which specific ingress provider should be used
+        # Default is KubernetesIngress
+        provider: KubernetesIngress
+        # The specific settings when the Provider is QdrantCloudTraefik
+        qdrantCloudTraefik:
+          # Enable tls
+          # Default is false
+          tls: false
+          # Secret with TLS certificate
+          # Default is None
+          secretName: ""
+          # List of Traefik middlewares to apply
+          # Default is an empty list
+          middlewares: []
+          # IP Allowlist Strategy for Traefik
+          # Default is None
+          ipAllowlistStrategy:
+          # Enable body validator plugin and matching ingressroute rules
+          # Default is false
+          enableBodyValidatorPlugin: false
+        # The specific settings when the Provider is KubernetesIngress
+        kubernetesIngress:
+          # Name of the ingress class
+          # Default is None
+          #ingressClassName:
+      # TelemetryTimeout is the duration a single call to the cluster telemetry endpoint is allowed to take.
+      # Default is 3 seconds
+      telemetryTimeout: 3s
+      # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run. Defaults to 20.
+      maxConcurrentReconciles: 20  
+      # VolumeExpansionMode specifies the expansion mode, which can be online or offline (e.g. in case of Azure).
+      # Available options: Online, Offline
+      # Default is Online
+      volumeExpansionMode: Online
+    # BackupManagementConfig contains the settings for backup management
+    backupManagement:
+      # Whether or not the backup features are enabled.
+      # If disabled, all other properties in this struct are disregarded. Otherwise, the individual features will be inspected.
+      # Default is true.
+      enable: true
+      # Snapshots contains the settings for snapshots as part of backup management.
+      snapshots:
+        # Whether or not the Snapshot feature is enabled.
+        # Default is true.
+        enable: true
+        # The VolumeSnapshotClass used to make VolumeSnapshots.
+        # Default is "csi-snapclass".
+        volumeSnapshotClass: "csi-snapclass"
+        # The duration a snapshot is retained when the phase becomes Failed or Skipped
+        # Default is 72h (3d).
+        retainUnsuccessful: 72h
+        # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run. Defaults to 1.
+        maxConcurrentReconciles: 1
+      # ScheduledSnapshots contains the settings for scheduled snapshot as part of backup management.
+      scheduledSnapshots:
+        # Whether or not the ScheduledSnapshot feature is enabled.
+        # Default is true.
+        enable: true
+        # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run. Defaults to 1.
+        maxConcurrentReconciles: 1
+      # Restores contains the settings for restoring (a snapshot) as part of backup management.
+      restores:
+        # Whether or not the Restore feature is enabled.
+        # Default is true.
+        enable:  true
+        # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run. Defaults to 1.
+        maxConcurrentReconciles: 1
 ```

--- a/qdrant-landing/content/documentation/private-cloud/configuration.md
+++ b/qdrant-landing/content/documentation/private-cloud/configuration.md
@@ -110,9 +110,6 @@ operator:
       # Maximum burst for throttle.
       # Default is 500.
       burst: 500
-      # If set to true, the operator reconciles all watched CRs,
-      # fully ignoring operator.qdrant.com/version annotation on them
-      disableOperatorVersionCheck: true
     # Features contains the settings for enabling / disabling the individual features of the operator
     features:
       # ClusterManagement contains the settings for qdrant (database) cluster management
@@ -280,10 +277,6 @@ operator:
           # Whether or not the ScheduledSnapshot feature is enabled.
           # Default is true.
           enable: true
-          # RemoveCronJobs can be enabled when the previous [Python] operator (qdrant-operator) has been run and this
-          # operator should remove the cron jobs it created (not used by this operator anymore).
-          # Default is true.
-          removeCronJobs: true
           # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run. Defaults to 1.
           maxConcurrentReconciles: 1
         # Restores contains the settings for restoring (a snapshot) as part of backup management.


### PR DESCRIPTION
Only merge, once operator v2 is the default for new environments for Hybrid Cloud.

Fixes https://github.com/qdrant/cloud-pm/issues/2097