### PR TITLE
Corrects contributors link

### DIFF
--- a/qdrant-landing/content/community/community-features.md
+++ b/qdrant-landing/content/community/community-features.md
@@ -55,7 +55,7 @@ features:
   description: Whatever your strengths are, we got you covered. Learn more about how to contribute to Qdrant.
   link:
     text: Learn More
-    url: https://github.com/qdrant/qdrant/blob/master/CONTRIBUTING.md
+    url: https://github.com/qdrant/qdrant/blob/master/docs/CONTRIBUTING.md 
 - id: 2
   icon:
     src: /icons/outline/handshake-blue.svg


### PR DESCRIPTION
As per [this issue](https://github.com/qdrant/qdrant/issues/5730), the contributors guide was moved to the `docs` repo [in July 2024](https://github.com/qdrant/qdrant/pull/4678).