### PR TITLE
Resharding requires cluster manager, only enabled on multi node clusters

### DIFF
--- a/qdrant-landing/content/documentation/cloud/cluster-scaling.md
+++ b/qdrant-landing/content/documentation/cloud/cluster-scaling.md
@@ -43,7 +43,7 @@ We will be glad to consult you on an optimal strategy for scaling.
 
 *Available as of Qdrant v1.13.0*
 
-<aside role="status">Resharding is exclusively available across our <a href="/documentation/cloud-intro/">cloud</a> offering, including <a href="/documentation/hybrid-cloud/">Hybrid</a> and <a href="/documentation/private-cloud/">Private</a> Cloud.</aside>
+<aside role="status">Resharding is exclusively available on multi-node clusters across our <a href="/documentation/cloud-intro/">cloud</a> offering, including <a href="/documentation/hybrid-cloud/">Hybrid</a> and <a href="/documentation/private-cloud/">Private</a> Cloud.</aside>
 
 When creating a collection, it has a specific number of shards. The ideal number of shards might change as your cluster evolves.
 


### PR DESCRIPTION
[Rendered](https://deploy-preview-1406--condescending-goldwasser-91acf0.netlify.app/documentation/cloud/cluster-scaling/#resharding)

It is expected to enable cluster manager on all clusters - even if running a single node - some time later.

This updates the warning banner to explicitly state that somewhere.

At least for now that means resharding cannot be used on single node clusters. If customers are looking for this, we can recommend them to scale up their cluster first after which resharding will become available.