### PR TITLE
Fix JSON example for distributed deployment

### DIFF
--- a/qdrant-landing/content/documentation/guides/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/guides/distributed_deployment.md
@@ -781,7 +781,7 @@ PUT /collections/{collection_name}
         "distance": "Cosine"
     },
     "shard_number": 6,
-    "replication_factor": 2,
+    "replication_factor": 2
 }
 ```
 
@@ -1048,7 +1048,7 @@ PUT /collections/{collection_name}
     },
     "shard_number": 6,
     "replication_factor": 2,
-    "write_consistency_factor": 2,
+    "write_consistency_factor": 2
 }
 ```
 


### PR DESCRIPTION
The JSON example for `replication_factor` and `write_consistency` had extra comma `,` at the end which makes the JSON invalid. This PR removes those commas.