### PR TITLE
Replacing deprecated `search` with `query_points`

### DIFF
--- a/qdrant-landing/content/documentation/embeddings/cohere.md
+++ b/qdrant-landing/content/documentation/embeddings/cohere.md
@@ -73,9 +73,9 @@ client.upsert(
 Once the documents are indexed, you can search for the most relevant documents using the Embed v3 model:
 
 ```python
-client.search(
+client.query_points(
     collection_name="MyCollection",
-    query_vector=cohere_client.embed(
+    query=cohere_client.embed(
         model="embed-english-v3.0",  # New Embed v3 model
         input_type="search_query",  # Input type for search queries
         texts=["The best vector database"],


### PR DESCRIPTION
The original documentation page is using `client.search` which gives the warning
```bash
/var/folders/yq/g_nknqvs6tz0_nv06j3b5cth0000gn/T/ipykernel_17665/1253820733.py:1: DeprecationWarning: `search` method is deprecated and will be removed in the future. Use `query_points` instead.
  client.search(
```
It's replaced with `client.query_points`