### PR TITLE
get_anonymous_id 'page'

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@ HUGO_PARAMS_segmentWriteKey = "eQYi1nZE2zQSmnHuxjMRlDd2uLl65oHe"
 
 [context.deploy-preview.environment]
 HUGO_ENV = "staging"
-HUGO_PARAMS_segmentWriteKey = "PVpuTLKGJveLivvc1r3ZyzFutWgtzkvQ"
+HUGO_PARAMS_segmentWriteKey = "DZ49RYXkFEV0pY6DG4i0RyxyobSovIlU"
 
 [[headers]]
     for = "/*"

--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -78,7 +78,7 @@ disableKinds = ["taxonomy", "term"]
   docVersion = "v1.9.x"
   cloudDocVersion = "v0.1.x"
 
-  segmentWriteKey = "noKey"
+  segmentWriteKey = "UOgPyE2GbtD4lletUP2uWfBGQQSfkzf1"
 
 [params.author]
   name = "Andrey Vasnetsov"

--- a/qdrant-landing/content/get_anonymous_id/_index.md
+++ b/qdrant-landing/content/get_anonymous_id/_index.md
@@ -1,0 +1,4 @@
+---
+title: Anonymous ID
+---
+

--- a/qdrant-landing/content/get_anonymous_id/_index.md
+++ b/qdrant-landing/content/get_anonymous_id/_index.md
@@ -1,4 +1,0 @@
----
-title: Anonymous ID
----
-

--- a/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
@@ -23,21 +23,16 @@
         }}();
       }
 
-      const msgEvent = {
-        origin: isProduction ? 'https://cloud.qdrant.io' : 'https://localhost:3000',
-        data: 'getAnonymousId'
-      }
-
       window.onload = function() {
         window.addEventListener('message', (cloudUIEvent) => {
           analytics.ready(() => {
-            if (cloudUIEvent.origin === msgEvent.origin && cloudUIEvent.data === msgEvent.data) {
-              const anonymousId = analytics.user().anonymousId();
+            const isQdrantOrigin = ['https://cloud.qdrant.io', 'https://staging-cloud.qdrant.io'].includes(cloudUIEvent.origin);
+            const isLocal = !isProduction && cloudUIEvent.origin === 'https://localhost:3000';
+            const originPass = isQdrantOrigin || isLocal;
 
-              cloudUIEvent.source.postMessage({
-                anonymousId,
-                consent: {  analytics: true }
-              }, cloudUIEvent.origin);
+            if (originPass && cloudUIEvent.data === 'getAnonymousId') {
+              const anonymousId = analytics.user().anonymousId();
+              cloudUIEvent.source.postMessage({ anonymousId }, cloudUIEvent.origin);
             }
           });
         });
@@ -46,9 +41,9 @@
   </head>
   <body></body>
   
-<!--Cookies banner-->
-{{ $cookit := resources.Get "/js/cookit.js" | js.Build | minify | resources.Fingerprint "sha512" }}
-<script src="{{ $cookit.RelPermalink }}"></script>
-{{ with (.Site.GetPage "/headless/cookies") }}
-{{ end }}
+  <!--Cookies banner-->
+  {{ $cookit := resources.Get "/js/cookit.js" | js.Build | minify | resources.Fingerprint "sha512" }}
+  <script src="{{ $cookit.RelPermalink }}"></script>
+  {{ with (.Site.GetPage "/headless/cookies") }}
+  {{ end }}
 </html>

--- a/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
@@ -40,10 +40,4 @@
     </script>
   </head>
   <body></body>
-  
-  <!--Cookies banner-->
-  {{ $cookit := resources.Get "/js/cookit.js" | js.Build | minify | resources.Fingerprint "sha512" }}
-  <script src="{{ $cookit.RelPermalink }}"></script>
-  {{ with (.Site.GetPage "/headless/cookies") }}
-  {{ end }}
 </html>

--- a/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
@@ -14,8 +14,7 @@
 
           // Can ensure this is working in (not to be used in production, see below):
           // https://eu1.app.segment.com/qdrant-eu/sources/dev_marketing_site_events/debugger
-          analytics.page(); 
-          console.log('writeKey', writeKey)
+          analytics.page();
         }}();
       } else { // production
         !function(){

--- a/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="robots" content="noindex, nofollow">
+
+    <script>
+      const writeKey = "{{ .Site.Params.segmentWriteKey }}";
+      const isProduction = "{{ hugo.IsProduction }}" === "true";
+
+      if(!isProduction) { // not production ∴ no cdn
+        !function(){
+          var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey=writeKey;;analytics.SNIPPET_VERSION="5.2.0";
+          analytics.load(writeKey);
+
+          // Can ensure this is working in (not to be used in production, see below):
+          // https://eu1.app.segment.com/qdrant-eu/sources/dev_marketing_site_events/debugger
+          analytics.page(); 
+          console.log('writeKey', writeKey)
+        }}();
+      } else { // production
+        !function(){
+          var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://evs.analytics.qdrant.tech/5caWuitPgcGFN5Q7HMpTaj/vEkmzjuRSqeXGbhGAFTWex.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey=writeKey;analytics._cdn = "https://evs.analytics.qdrant.tech";analytics.SNIPPET_VERSION="5.2.0";
+          analytics.load(writeKey);
+        }}();
+      }
+
+      const msgEvent = {
+        origin: isProduction ? 'https://cloud.qdrant.io' : 'https://localhost:3000',
+        data: 'getAnonymousId'
+      }
+
+      window.onload = function() {
+        window.addEventListener('message', (cloudUIEvent) => {
+          analytics.ready(() => {
+            if (cloudUIEvent.origin === msgEvent.origin && cloudUIEvent.data === msgEvent.data) {
+              const anonymousId = analytics.user().anonymousId();
+
+              cloudUIEvent.source.postMessage({
+                anonymousId,
+                consent: {  analytics: true }
+              }, cloudUIEvent.origin);
+            }
+          });
+        });
+      };
+    </script>
+  </head>
+  <body></body>
+  
+<!--Cookies banner-->
+{{ $cookit := resources.Get "/js/cookit.js" | js.Build | minify | resources.Fingerprint "sha512" }}
+<script src="{{ $cookit.RelPermalink }}"></script>
+{{ with (.Site.GetPage "/headless/cookies") }}
+{{ end }}
+</html>


### PR DESCRIPTION
Going to be use this standalone page to allow cross-site passing of `ajs_anonymous_id` from parent (landing_page) to child (cloud ui). This is the first step in the process. Returning an `ajs_anonymous_id` if it exists. Only allowed from Cloud UI staging and production origins.

This path `/get_anonymous_id` will be used within the iframe in Cloud UI.

https://www.teamsimmer.com/2023/05/02/how-do-i-use-the-postmessage-method-with-cross-site-iframes/

*Also updating staging segmentWriteKey with most recent value as well as the development value which was not previously set.
