### PR TITLE
Docs: Score boosting

### DIFF
--- a/qdrant-landing/content/documentation/concepts/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/concepts/hybrid-queries.md
@@ -152,12 +152,13 @@ There are multiple expressions available, check the [API docs for specific detai
 - **geo distance** - Haversine distance between two geographic points. Values need to be `{ "lat": 0.0, "lon": 0.0 }` objects.
 - **decay** - Apply a decay function to an expression, which clamps the output between 0 and 1. Available decay functions are **linear**, **exponential**, and **gaussian**. [See more](#boost-points-closer-to-user).
 - **datetime** - Parse a datetime string (see formats [here](/documentation/concepts/payload/#datetime)), and use it as a POSIX timestamp, in seconds.
+- **datetime key** - Specify that a payload key contains a datetime string to be parsed into POSIX seconds.
 
 It is possible to define a default for when the variable (either from payload or prefetch score) is not found. This is given in the form of a mapping from variable to value.
 If there is no variable, and no defined default, a default value of `0.0` is used.
 
 <aside role="status">
-    
+
 **Considerations when using formula queries:**
 
 - Formula queries can only be used as a rescoring step.

--- a/qdrant-landing/content/documentation/concepts/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/concepts/hybrid-queries.md
@@ -113,24 +113,7 @@ Query API can rescore points with custom formulas. They can be based on:
 To express the formula, the syntax uses objects to identify each element.
 Taking the documentation example, the request would look like this:
 
-```http
-POST /collections/{collection_name}/points/query
-{
-    "prefetch": {
-        "query": [0.2, 0.8, ...],  // <-- dense vector
-        "limit": 50
-    }
-    "query": {
-        "formula": {
-            "sum": [
-                "$score,
-                { "mult": [ 0.5, { "key": "tag", "match": { "any": ["h1", "h2", "h3", "h4"] } } ] },
-                { "mult": [ 0.25, { "key": "tag", "match": { "any": ["p", "li"] } } ] }
-            ]
-        }
-    }
-}
-```
+{{< code-snippet path="/documentation/headless/snippets/query-points/score-boost-tags/" >}}
 
 TODO: add all clients
 
@@ -170,7 +153,7 @@ If there is no variable, and no defined default, a default value of `0.0` is use
 </aside>
 
 ### Boost points closer to user
-Another example. Combine the score with how close the result is to a user. 
+Another example. Combine the score with how close the result is to a user.
 
 Considering each point has an associated geo location, we can calculate the distance between the point and the request's location.
 
@@ -180,31 +163,7 @@ Assuming we have cosine scores in the prefetch, we can use a helper function to 
 
 In this case we use a **gauss_decay** function.
 
-```http
-POST /collections/{collection_name}/points/query
-{
-    "prefetch": { "query": [0.2, 0.8, ...], "limit": 50 },
-    "query": {
-        "formula": {
-            "sum": [
-                "$score",
-                { 
-                    "gauss_decay": {
-                        "scale": 5000, // 5km
-                        "x": {
-                            "geo_distance": {
-                                "origin": { "lat": 52.504043, "lon": 13.393236 } // Berlin
-                                "to": "geo.location"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        "defaults": { "geo.location": {"lat": 48.137154, "lon": 11.576124} } // Munich
-    }
-}
-```
+{{< code-snippet path="/documentation/headless/snippets/query-points/score-boost-closer-to-user/" >}}
 
 For all decay functions, there are these parameters available
 
@@ -232,114 +191,6 @@ It is possible to group results by a certain field. This is useful when you have
 
 REST API ([Schema](https://api.qdrant.tech/master/api-reference/search/query-points-groups)):
 
-```http
-POST /collections/{collection_name}/points/query/groups
-{
-    "query": [0.01, 0.45, 0.67],
-    group_by="document_id",  # Path of the field to group by
-    limit=4,  # Max amount of groups
-    group_size=2,  # Max amount of points per group
-}
-```
-
-```python
-from qdrant_client import QdrantClient, models
-
-client = QdrantClient(url="http://localhost:6333")
-
-client.query_points_groups(
-    collection_name="{collection_name}",
-    query=[0.01, 0.45, 0.67],
-    group_by="document_id",
-    limit=4,
-    group_size=2,
-)
-```
-
-```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
-client.queryGroups("{collection_name}", {
-    query: [0.01, 0.45, 0.67],
-    group_by: "document_id",
-    limit: 4,
-    group_size: 2,
-});
-```
-
-```rust
-use qdrant_client::Qdrant;
-use qdrant_client::qdrant::{Query, QueryPointsBuilder};
-
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
-client.query_groups(
-    QueryPointGroupsBuilder::new("{collection_name}", "document_id")
-        .query(Query::from(vec![0.01, 0.45, 0.67]))
-        .limit(4u64)
-        .group_size(2u64)
-).await?;
-```
-
-```java
-import static io.qdrant.client.QueryFactory.nearest;
-
-import io.qdrant.client.QdrantClient;
-import io.qdrant.client.QdrantGrpcClient;
-import io.qdrant.client.grpc.Points.QueryPointGroups;
-
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
-client
-    .queryGroupsAsync(
-        QueryPointGroups.newBuilder()
-            .setCollectionName("{collection_name}")
-            .setGroupBy("document_id")
-            .setQuery(nearest(0.01f, 0.45f, 0.67f))
-            .setLimit(4)
-            .setGroupSize(2)
-            .build())
-    .get();
-```
-
-```csharp
-using Qdrant.Client;
-using Qdrant.Client.Grpc;
-
-var client = new QdrantClient("localhost", 6334);
-
-await client.QueryGroupsAsync(
-  collectionName: "{collection_name}",
-  groupBy: "document_id",
-  query: new float[] {
-    0.01f, 0.45f, 0.67f
-  },
-  limit: 4,
-  groupSize: 2
-);
-```
-
-```go
-import (
-	"context"
-
-	"github.com/qdrant/go-client/qdrant"
-)
-
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
-client.QueryGroups(context.Background(), &qdrant.QueryPointGroups{
-	CollectionName: "{collection_name}",
-	Query:          qdrant.NewQuery(0.01, 0.45, 0.67),
-	GroupBy:        "document_id",
-	GroupSize:      qdrant.PtrOf(uint64(2)),
-})
-```
+{{< code-snippet path="/documentation/headless/snippets/query-groups/basic/" >}}
 
 For more information on the `grouping` capabilities refer to the reference documentation for search with [grouping](/documentation/concepts/search/#search-groups) and [lookup](/documentation/concepts/search/#lookup-in-groups).

--- a/qdrant-landing/content/documentation/concepts/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/concepts/hybrid-queries.md
@@ -219,10 +219,10 @@ The formulas for each decay function are as follows:
 <iframe src="https://www.desmos.com/calculator/idv5hknwb1?embed" width="600" height="400" style="border: 1px solid #ccc" frameborder=0></iframe>
 
 | Decay Function | Formula | Range |
-| --- | --- | --- | 
-| Linear (green) | $ \max\left(0,\ -\frac{\left(1-m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)+1\right) $ | $[0, 1]$ |
-| Exponential (red) | $ \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)\right) $ | $(0, 1]$ |
-| Gaussian (purple) | $ \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}^{2}}\cdot {abs}\left(x-t_{arget}\right)^{2}\right) $ | $(0, 1]$ |
+| --- | --- | --- |
+| `lin_decay` (green) | $ \max\left(0,\ -\frac{\left(1-m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)+1\right) $ | $[0, 1]$ |
+| `exp_decay` (red) | $ \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)\right) $ | $(0, 1]$ |
+| `gauss_decay` (purple) | $ \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}^{2}}\cdot \left(x-t_{arget}\right)^{2}\right) $ | $(0, 1]$ |
 
 ## Grouping
 

--- a/qdrant-landing/content/documentation/concepts/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/concepts/hybrid-queries.md
@@ -115,8 +115,6 @@ Taking the documentation example, the request would look like this:
 
 {{< code-snippet path="/documentation/headless/snippets/query-points/score-boost-tags/" >}}
 
-TODO: add all clients
-
 There are multiple expressions available, check the [API docs for specific details](https://api.qdrant.tech/v-1-13-x/api-reference/search/query-points#request.body.query.Query%20Interface.Query.Formula%20Query.formula).
 - **constant** - A floating point number. e.g. `0.5`.
 - `"$score"` - Reference to the score of the point in the prefetch. This is the same as `"$score[0]"`.
@@ -176,13 +174,25 @@ For all decay functions, there are these parameters available
 | `midpoint` | 0.5 | Output is `midpoint` when `x` equals `scale`. Must be in the range (0.0, 1.0), exclusive |
 
 The formulas for each decay function are as follows:
-<iframe src="https://www.desmos.com/calculator/idv5hknwb1?embed" width="600" height="400" style="border: 1px solid #ccc" frameborder=0></iframe>
 
-| Decay Function | Formula | Range |
-| --- | --- | --- |
-| `lin_decay` (green) | $ \max\left(0,\ -\frac{\left(1-m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)+1\right) $ | $[0, 1]$ |
-| `exp_decay` (red) | $ \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)\right) $ | $(0, 1]$ |
-| `gauss_decay` (purple) | $ \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}^{2}}\cdot \left(x-t_{arget}\right)^{2}\right) $ | $(0, 1]$ |
+
+<iframe src="https://www.desmos.com/calculator/idv5hknwb1?embed" width="600" height="400" style="border: 1px solid #ccc" frameborder=0 class="mx-auto d-block"></iframe>
+
+
+#### Decay functions
+
+
+**`lin_decay`** (green), range: `[0, 1]`
+
+$$ \text{lin_decay}(x) = \max\left(0,\ -\frac{\left(1-m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)+1\right) $$
+
+**`exp_decay`** (red), range: `(0, 1]`
+
+$$ \text{exp_decay}(x) = \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}}\cdot {abs}\left(x-t_{arget}\right)\right) $$
+
+**`gauss_decay`** (purple), range: `(0, 1]`
+
+$$ \text{gauss_decay}(x) = \exp\left(\frac{\ln\left(m_{idpoint}\right)}{s_{cale}^{2}}\cdot \left(x-t_{arget}\right)^{2}\right) $$
 
 ## Grouping
 

--- a/qdrant-landing/content/documentation/concepts/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/concepts/hybrid-queries.md
@@ -151,6 +151,7 @@ There are multiple expressions available, check the [API docs for specific detai
 - **exp** - Exponential function of an expression (`e^x`).
 - **geo distance** - Haversine distance between two geographic points. Values need to be `{ "lat": 0.0, "lon": 0.0 }` objects.
 - **decay** - Apply a decay function to an expression, which clamps the output between 0 and 1. Available decay functions are **linear**, **exponential**, and **gaussian**. [See more](#boost-points-closer-to-user).
+- **datetime** - Parse a datetime string (see formats [here](/documentation/concepts/payload/#datetime)), and use it as a POSIX timestamp, in seconds.
 
 It is possible to define a default for when the variable (either from payload or prefetch score) is not found. This is given in the form of a mapping from variable to value.
 If there is no variable, and no defined default, a default value of `0.0` is used.
@@ -161,7 +162,9 @@ If there is no variable, and no defined default, a default value of `0.0` is use
 
 - Formula queries can only be used as a rescoring step.
 - Formula results are always sorted in descending order (bigger is better). **For euclidean scores, make sure to negate them** to sort closest to farthest.
-- If a score or variable is not available, and there is no default value, it will be evaluated as 0.
+- If a score or variable is not available, and there is no default value, it will return an error.
+- If a value is not a number (or the expected type), it will return an error.
+- To leverage payload indices, single-value arrays are considered the same as the inner value. For example: `[0.2]` is the same as `0.2`, but `[0.2, 0.7]` will be interpreted as `[0.2, 0.7]`
 - Multiplication and division are lazily evaluated, meaning that if a 0 is encountered, the rest of operations don't execute (e.g. `0.0 * condition` won't check the condition).
 </aside>
 

--- a/qdrant-landing/content/documentation/concepts/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/concepts/hybrid-queries.md
@@ -150,6 +150,7 @@ If there is no variable, and no defined default, a default value of `0.0` is use
 - If a value is not a number (or the expected type), it will return an error.
 - To leverage payload indices, single-value arrays are considered the same as the inner value. For example: `[0.2]` is the same as `0.2`, but `[0.2, 0.7]` will be interpreted as `[0.2, 0.7]`
 - Multiplication and division are lazily evaluated, meaning that if a 0 is encountered, the rest of operations don't execute (e.g. `0.0 * condition` won't check the condition).
+- Payload variables used within the formula also benefit from having payload indices. Please try to always have a payload index set up for the variables used in the formula for better performance.
 </aside>
 
 ### Boost points closer to user

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/_description.md
@@ -1,1 +1,1 @@
-The snippet demonstrates how to use decay functions and geo distance functions to boost the score of points closer to a user.
+The snippet demonstrates how to use decay functions and geo distance functions to boost the score of points closer to a user. Function will boost the scores of points, that are closer to specified location `x`. Point locations is taken from the `geo.location` field. If the field is not present, the `defaults` parameter can be used to fill in the missing values. Scale parameter is used to control the decay rate.

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/_description.md
@@ -1,0 +1,1 @@
+The snippet demonstrates how to use decay functions and geo distance functions to boost the score of points closer to a user.

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
@@ -6,39 +6,39 @@ using static Qdrant.Client.Grpc.Expression;
 var client = new QdrantClient("localhost", 6334);
 
 await client.QueryAsync(
-	collectionName: "{collection_name}",
-	prefetch:
-	[
-		new PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },
-	],
-	query: new Formula
-	{
-		Expression = new SumExpression
-		{
-			Sum =
-			{
-				"$score",
-				FromExpDecay(
-					new()
-					{
-						X = new GeoDistance
-						{
-							Origin = new GeoPoint { Lat = 52.504043, Lon = 13.393236 },
-							To = "geo.location",
-						},
-						Scale = 5000,
-					}
-				),
-			},
-		},
-		Defaults =
-		{
-			["geo.location"] = new Dictionary<string, Value>
-			{
-				["lat"] = 48.137154,
-				["lon"] = 11.576124,
-			},
-		},
-	}
+    collectionName: "{collection_name}",
+    prefetch:
+    [
+        new PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },
+    ],
+    query: new Formula
+    {
+        Expression = new SumExpression
+        {
+            Sum =
+            {
+                "$score",
+                FromExpDecay(
+                    new()
+                    {
+                        X = new GeoDistance
+                        {
+                            Origin = new GeoPoint { Lat = 52.504043, Lon = 13.393236 },
+                            To = "geo.location",
+                        },
+                        Scale = 5000,
+                    }
+                ),
+            },
+        },
+        Defaults =
+        {
+            ["geo.location"] = new Dictionary<string, Value>
+            {
+                ["lat"] = 48.137154,
+                ["lon"] = 11.576124,
+            },
+        },
+    }
 );
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
@@ -31,7 +31,14 @@ await client.QueryAsync(
 				),
 			},
 		},
-		Defaults = { ["lat"] = 48.137154, ["lon"] = 11.576124 },
+		Defaults =
+		{
+			["geo.location"] = new Dictionary<string, Value>
+			{
+				["lat"] = 48.137154,
+				["lon"] = 11.576124,
+			},
+		},
 	}
 );
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
@@ -18,7 +18,7 @@ await client.QueryAsync(
 			Sum =
 			{
 				"$score",
-				WithExpDecay(
+				FromExpDecay(
 					new()
 					{
 						X = new GeoDistance

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/csharp.md
@@ -1,0 +1,37 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using static Qdrant.Client.Grpc.Expression;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.QueryAsync(
+	collectionName: "{collection_name}",
+	prefetch:
+	[
+		new PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },
+	],
+	query: new Formula
+	{
+		Expression = new SumExpression
+		{
+			Sum =
+			{
+				"$score",
+				WithExpDecay(
+					new()
+					{
+						X = new GeoDistance
+						{
+							Origin = new GeoPoint { Lat = 52.504043, Lon = 13.393236 },
+							To = "geo.location",
+						},
+						Scale = 5000,
+					}
+				),
+			},
+		},
+		Defaults = { ["lat"] = 48.137154, ["lon"] = 11.576124 },
+	}
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/go.md
@@ -1,0 +1,41 @@
+```go
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+	Host: "localhost",
+	Port: 6334,
+})
+
+client.Query(context.Background(), &qdrant.QueryPoints{
+	CollectionName: "{collection_name}",
+	Prefetch: []*qdrant.PrefetchQuery{
+		{
+			Query: qdrant.NewQuery(0.2, 0.8),
+		},
+	},
+	Query: qdrant.NewQueryFormula(&qdrant.Formula{
+		Expression: qdrant.NewExpressionSum(&qdrant.SumExpression{
+			Sum: []*qdrant.Expression{
+				qdrant.NewExpressionVariable("$score"),
+				qdrant.NewExpressionExpDecay(&qdrant.DecayParamsExpression{
+					X: qdrant.NewExpressionGeoDistance(&qdrant.GeoDistance{
+						Origin: &qdrant.GeoPoint{
+							Lat: 52.504043,
+							Lon: 13.393236,
+						},
+						To: "geo.location",
+					}),
+				}),
+			},
+		}),
+		Defaults: qdrant.NewValueMap(map[string]any{
+			"lat": 48.137154,
+			"lon": 11.576124,
+		}),
+	}),
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/go.md
@@ -33,8 +33,10 @@ client.Query(context.Background(), &qdrant.QueryPoints{
 			},
 		}),
 		Defaults: qdrant.NewValueMap(map[string]any{
-			"lat": 48.137154,
-			"lon": 11.576124,
+			"geo.location": map[string]any{
+				"lat": 48.137154,
+				"lon": 11.576124,
+			},
 		}),
 	}),
 })

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/go.md
@@ -1,43 +1,43 @@
 ```go
 import (
-	"context"
+    "context"
 
-	"github.com/qdrant/go-client/qdrant"
+    "github.com/qdrant/go-client/qdrant"
 )
 
 client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
+    Host: "localhost",
+    Port: 6334,
 })
 
 client.Query(context.Background(), &qdrant.QueryPoints{
-	CollectionName: "{collection_name}",
-	Prefetch: []*qdrant.PrefetchQuery{
-		{
-			Query: qdrant.NewQuery(0.2, 0.8),
-		},
-	},
-	Query: qdrant.NewQueryFormula(&qdrant.Formula{
-		Expression: qdrant.NewExpressionSum(&qdrant.SumExpression{
-			Sum: []*qdrant.Expression{
-				qdrant.NewExpressionVariable("$score"),
-				qdrant.NewExpressionExpDecay(&qdrant.DecayParamsExpression{
-					X: qdrant.NewExpressionGeoDistance(&qdrant.GeoDistance{
-						Origin: &qdrant.GeoPoint{
-							Lat: 52.504043,
-							Lon: 13.393236,
-						},
-						To: "geo.location",
-					}),
-				}),
-			},
-		}),
-		Defaults: qdrant.NewValueMap(map[string]any{
-			"geo.location": map[string]any{
-				"lat": 48.137154,
-				"lon": 11.576124,
-			},
-		}),
-	}),
+    CollectionName: "{collection_name}",
+    Prefetch: []*qdrant.PrefetchQuery{
+        {
+            Query: qdrant.NewQuery(0.2, 0.8),
+        },
+    },
+    Query: qdrant.NewQueryFormula(&qdrant.Formula{
+        Expression: qdrant.NewExpressionSum(&qdrant.SumExpression{
+            Sum: []*qdrant.Expression{
+                qdrant.NewExpressionVariable("$score"),
+                qdrant.NewExpressionExpDecay(&qdrant.DecayParamsExpression{
+                    X: qdrant.NewExpressionGeoDistance(&qdrant.GeoDistance{
+                        Origin: &qdrant.GeoPoint{
+                            Lat: 52.504043,
+                            Lon: 13.393236,
+                        },
+                        To: "geo.location",
+                    }),
+                }),
+            },
+        }),
+        Defaults: qdrant.NewValueMap(map[string]any{
+            "geo.location": map[string]any{
+                "lat": 48.137154,
+                "lon": 11.576124,
+            },
+        }),
+    }),
 })
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/http.md
@@ -8,13 +8,13 @@ POST /collections/{collection_name}/points/query
                 "$score",
                 {
                     "gauss_decay": {
-                        "scale": 5000, // 5km
                         "x": {
                             "geo_distance": {
                                 "origin": { "lat": 52.504043, "lon": 13.393236 } // Berlin
                                 "to": "geo.location"
                             }
-                        }
+                        },
+                        "scale": 5000 // 5km
                     }
                 }
             ]

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/http.md
@@ -1,0 +1,25 @@
+```http
+POST /collections/{collection_name}/points/query
+{
+    "prefetch": { "query": [0.2, 0.8, ...], "limit": 50 },
+    "query": {
+        "formula": {
+            "sum": [
+                "$score",
+                {
+                    "gauss_decay": {
+                        "scale": 5000, // 5km
+                        "x": {
+                            "geo_distance": {
+                                "origin": { "lat": 52.504043, "lon": 13.393236 } // Berlin
+                                "to": "geo.location"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "defaults": { "geo.location": {"lat": 48.137154, "lon": 11.576124} } // Munich
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/http.md
@@ -10,7 +10,7 @@ POST /collections/{collection_name}/points/query
                     "gauss_decay": {
                         "x": {
                             "geo_distance": {
-                                "origin": { "lat": 52.504043, "lon": 13.393236 } // Berlin
+                                "origin": { "lat": 52.504043, "lon": 13.393236 }
                                 "to": "geo.location"
                             }
                         },
@@ -19,7 +19,7 @@ POST /collections/{collection_name}/points/query
                 }
             ]
         },
-        "defaults": { "geo.location": {"lat": 48.137154, "lon": 11.576124} } // Munich
+        "defaults": { "geo.location": {"lat": 48.137154, "lon": 11.576124} }
     }
 }
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/java.md
@@ -1,0 +1,65 @@
+```java
+import static io.qdrant.client.ExpressionFactory.expDecay;
+import static io.qdrant.client.ExpressionFactory.geoDistance;
+import static io.qdrant.client.ExpressionFactory.sum;
+import static io.qdrant.client.ExpressionFactory.variable;
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.QueryFactory.formula;
+import static io.qdrant.client.QueryFactory.nearest;
+import static io.qdrant.client.ValueFactory.value;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Points.DecayParamsExpression;
+import io.qdrant.client.grpc.Points.Formula;
+import io.qdrant.client.grpc.Points.GeoDistance;
+import io.qdrant.client.grpc.Points.GeoPoint;
+import io.qdrant.client.grpc.Points.PrefetchQuery;
+import io.qdrant.client.grpc.Points.QueryPoints;
+import io.qdrant.client.grpc.Points.SumExpression;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .queryAsync(
+        QueryPoints.newBuilder()
+            .setCollectionName("{collection_name}")
+            .addPrefetch(
+                PrefetchQuery.newBuilder()
+                    .setQuery(nearest(0.01f, 0.45f, 0.67f))
+                    .setLimit(100)
+                    .build())
+            .setQuery(
+                formula(
+                    Formula.newBuilder()
+                        .setExpression(
+                            sum(
+                                SumExpression.newBuilder()
+                                    .addSum(variable("$score"))
+                                    .addSum(
+                                        expDecay(
+                                            DecayParamsExpression.newBuilder()
+                                                .setX(
+                                                    geoDistance(
+                                                        GeoDistance.newBuilder()
+                                                            .setOrigin(
+                                                                GeoPoint.newBuilder()
+                                                                    .setLat(52.504043)
+                                                                    .setLon(13.393236)
+                                                                    .build())
+                                                            .setTo("geo.location")
+                                                            .build()))
+                                                .setScale(5000)
+                                                .build()))
+                                    .build()))
+                        .putDefaults(
+                            "geo.location",
+                            value(
+                                Map.of(
+                                    "lat", value(48.137154),
+                                    "lon", value(11.576124))))
+                        .build()))
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/java.md
@@ -19,47 +19,47 @@ import io.qdrant.client.grpc.Points.QueryPoints;
 import io.qdrant.client.grpc.Points.SumExpression;
 
 QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+  new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
 
 client
-    .queryAsync(
-        QueryPoints.newBuilder()
-            .setCollectionName("{collection_name}")
-            .addPrefetch(
-                PrefetchQuery.newBuilder()
-                    .setQuery(nearest(0.01f, 0.45f, 0.67f))
-                    .setLimit(100)
-                    .build())
-            .setQuery(
-                formula(
-                    Formula.newBuilder()
-                        .setExpression(
-                            sum(
-                                SumExpression.newBuilder()
-                                    .addSum(variable("$score"))
-                                    .addSum(
-                                        expDecay(
-                                            DecayParamsExpression.newBuilder()
-                                                .setX(
-                                                    geoDistance(
-                                                        GeoDistance.newBuilder()
-                                                            .setOrigin(
-                                                                GeoPoint.newBuilder()
-                                                                    .setLat(52.504043)
-                                                                    .setLon(13.393236)
-                                                                    .build())
-                                                            .setTo("geo.location")
-                                                            .build()))
-                                                .setScale(5000)
-                                                .build()))
-                                    .build()))
-                        .putDefaults(
-                            "geo.location",
-                            value(
-                                Map.of(
-                                    "lat", value(48.137154),
-                                    "lon", value(11.576124))))
+  .queryAsync(
+    QueryPoints.newBuilder()
+      .setCollectionName("{collection_name}")
+      .addPrefetch(
+        PrefetchQuery.newBuilder()
+          .setQuery(nearest(0.01f, 0.45f, 0.67f))
+          .setLimit(100)
+          .build())
+      .setQuery(
+        formula(
+          Formula.newBuilder()
+            .setExpression(
+              sum(
+                SumExpression.newBuilder()
+                  .addSum(variable("$score"))
+                  .addSum(
+                    expDecay(
+                      DecayParamsExpression.newBuilder()
+                        .setX(
+                          geoDistance(
+                            GeoDistance.newBuilder()
+                              .setOrigin(
+                                GeoPoint.newBuilder()
+                                  .setLat(52.504043)
+                                  .setLon(13.393236)
+                                  .build())
+                              .setTo("geo.location")
+                              .build()))
+                        .setScale(5000)
                         .build()))
-            .build())
-    .get();
+                  .build()))
+            .putDefaults(
+              "geo.location",
+              value(
+                Map.of(
+                  "lat", value(48.137154),
+                  "lon", value(11.576124))))
+            .build()))
+      .build())
+  .get();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/python.md
@@ -1,24 +1,29 @@
 ```python
 from qdrant_client import models
 
-boosted = client.query_points(
+
+geo_boosted = client.query_points(
     collection_name="{collection_name}",
-    prefetch=models.PrefetchRequest(
+    prefetch=models.Prefetch(
         query=[0.2, 0.8, ...],  # <-- dense vector
         limit=50
     ),
-    query=models.Formula(
+    query=models.FormulaQuery(
         formula=models.SumExpression(sum=[
             "$score",
             models.GaussDecayExpression(
-                x=models.GeoDistanceExpression(
-                    origin=models.GeoPoint(
-                        lat=52.504043,
-                        lon=13.393236
-                    ),  # Berlin
-                    to="geo.location"
-                ),
-                scale=5000  # 5km
+                gauss_decay=models.DecayParamsExpression(
+                    x=models.GeoDistance(
+                        geo_distance=models.GeoDistanceParams(
+                            origin=models.GeoPoint(
+                                lat=52.504043,
+                                lon=13.393236
+                            ),  # Berlin
+                            to="geo.location"
+                        )
+                    ),
+                    scale=5000  # 5km
+                )
             )
         ]),
         defaults={"geo.location": models.GeoPoint(lat=48.137154, lon=11.576124)}  # Munich

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/python.md
@@ -1,0 +1,27 @@
+```python
+from qdrant_client import models
+
+boosted = client.query_points(
+    collection_name="{collection_name}",
+    prefetch=models.PrefetchRequest(
+        query=[0.2, 0.8, ...],  # <-- dense vector
+        limit=50
+    ),
+    query=models.Formula(
+        formula=models.SumExpression(sum=[
+            "$score",
+            models.GaussDecayExpression(
+                x=models.GeoDistanceExpression(
+                    origin=models.GeoPoint(
+                        lat=52.504043,
+                        lon=13.393236
+                    ),  # Berlin
+                    to="geo.location"
+                ),
+                scale=5000  # 5km
+            )
+        ]),
+        defaults={"geo.location": models.GeoPoint(lat=48.137154, lon=11.576124)}  # Munich
+    )
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/rust.md
@@ -1,0 +1,37 @@
+```rust
+use qdrant_client::qdrant::{
+    GeoPoint,  DecayParamsExpressionBuilder, Expression, FormulaBuilder, PrefetchQueryBuilder, QueryPointsBuilder,
+};
+use qdrant_client::Qdrant;
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .query(
+        QueryPointsBuilder::new("{collection_name}")
+            .add_prefetch(
+                PrefetchQueryBuilder::default()
+                    .query(vec![0.01, 0.45, 0.67])
+                    .limit(100u64),
+            )
+            .query(
+                FormulaBuilder::new(Expression::sum_with([
+                    Expression::variable("$score"),
+                    Expression::exp_decay(
+                        DecayParamsExpressionBuilder::new(Expression::geo_distance_with(
+                            GeoPoint {
+                                lat: 52.504043,
+                                lon: 13.393236,
+                            }, // Berlin
+                            "geo.location",
+                        ))
+                        .scale(5_000.0),
+                    ),
+                ]))
+                // Munich
+                .add_default("geo.location", GeoPoint { lat: 48.137154, lon: 11.576124 }),
+            )
+            .limit(10),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/rust.md
@@ -6,9 +6,8 @@ use qdrant_client::Qdrant;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;
 
-client
-    .query(
-        QueryPointsBuilder::new("{collection_name}")
+let _geo_boosted = client.query(
+    QueryPointsBuilder::new("{collection_name}")
             .add_prefetch(
                 PrefetchQueryBuilder::default()
                     .query(vec![0.01, 0.45, 0.67])
@@ -19,10 +18,8 @@ client
                     Expression::variable("$score"),
                     Expression::exp_decay(
                         DecayParamsExpressionBuilder::new(Expression::geo_distance_with(
-                            GeoPoint {
-                                lat: 52.504043,
-                                lon: 13.393236,
-                            }, // Berlin
+                            // Berlin
+                            GeoPoint { lat: 52.504043, lon: 13.393236 },
                             "geo.location",
                         ))
                         .scale(5_000.0),

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/rust.md
@@ -15,7 +15,7 @@ let _geo_boosted = client.query(
             )
             .query(
                 FormulaBuilder::new(Expression::sum_with([
-                    Expression::variable("$score"),
+                    Expression::score(),
                     Expression::exp_decay(
                         DecayParamsExpressionBuilder::new(Expression::geo_distance_with(
                             // Berlin

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-closer-to-user/typescript.md
@@ -1,0 +1,32 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+const distance_boosted = await client.query(collectionName, {
+  prefetch: {
+    query: [0.2, 0.8, ...],
+    limit: 50
+  },
+  query: {
+    formula: {
+      sum: [
+        "$score",
+        {
+          gauss_decay: {
+            x: {
+              geo_distance: {
+                origin: { lat: 52.504043, lon: 13.393236 }, // Berlin
+                to: "geo.location"
+              }
+            },
+            scale: 5000 // 5km
+          }
+        }
+      ]
+    },
+    defaults: { "geo.location": { lat: 48.137154, lon: 11.576124 } } // Munich
+  }
+});
+
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/_description.md
@@ -1,1 +1,1 @@
-The snippet demonstrating how to boost the score of points based on their tag field.
+The snippet demonstrates how to boost the score of points based on their tag field. If the tag field is one of the headers, it will be more relevant to the query. Tags are located in the payload and included in the boost formula as a filtering condition.

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/_description.md
@@ -1,0 +1,1 @@
+The snippet demonstrating how to boost the score of points based on their tag field.

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/csharp.md
@@ -6,26 +6,26 @@ using static Qdrant.Client.Grpc.Conditions;
 var client = new QdrantClient("localhost", 6334);
 
 await client.QueryAsync(
-	collectionName: "{collection_name}",
-	prefetch:
-	[
-		new PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },
-	],
-	query: new Formula
-	{
-		Expression = new SumExpression
-		{
-			Sum =
-			{
-				"$score",
-				new MultExpression
-				{
-					Mult = { 0.5f, Match("tag", ["h1", "h2", "h3", "h4"]) },
-				},
-				new MultExpression { Mult = { 0.25f, Match("tag", ["p", "li"]) } },
-			},
-		},
-	},
-	limit: 10
+  collectionName: "{collection_name}",
+  prefetch:
+  [
+    new PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },
+  ],
+  query: new Formula
+  {
+    Expression = new SumExpression
+    {
+      Sum =
+      {
+        "$score",
+        new MultExpression
+        {
+          Mult = { 0.5f, Match("tag", ["h1", "h2", "h3", "h4"]) },
+        },
+        new MultExpression { Mult = { 0.25f, Match("tag", ["p", "li"]) } },
+      },
+    },
+  },
+  limit: 10
 );
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/csharp.md
@@ -1,0 +1,31 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using static Qdrant.Client.Grpc.Conditions;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.QueryAsync(
+	collectionName: "{collection_name}",
+	prefetch:
+	[
+		new PrefetchQuery { Query = new float[] { 0.01f, 0.45f, 0.67f }, Limit = 100 },
+	],
+	query: new Formula
+	{
+		Expression = new SumExpression
+		{
+			Sum =
+			{
+				"$score",
+				new MultExpression
+				{
+					Mult = { 0.5f, Match("tag", ["h1", "h2", "h3", "h4"]) },
+				},
+				new MultExpression { Mult = { 0.25f, Match("tag", ["p", "li"]) } },
+			},
+		},
+	},
+	limit: 10
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/go.md
@@ -1,0 +1,40 @@
+```go
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+	Host: "localhost",
+	Port: 6334,
+})
+
+client.Query(context.Background(), &qdrant.QueryPoints{
+	CollectionName: "{collection_name}",
+	Prefetch: []*qdrant.PrefetchQuery{
+		{
+			Query: qdrant.NewQuery(0.01, 0.45, 0.67),
+		},
+	},
+	Query: qdrant.NewQueryFormula(&qdrant.Formula{
+		Expression: qdrant.NewExpressionSum(&qdrant.SumExpression{
+			Sum: []*qdrant.Expression{
+				qdrant.NewExpressionVariable("$score"),
+				qdrant.NewExpressionMult(&qdrant.MultExpression{
+					Mult: []*qdrant.Expression{
+						qdrant.NewExpressionConstant(0.5),
+						qdrant.NewExpressionCondition(qdrant.NewMatchKeywords("tag", "h1", "h2", "h3", "h4")),
+					},
+				}),
+				qdrant.NewExpressionMult(&qdrant.MultExpression{
+					Mult: []*qdrant.Expression{
+						qdrant.NewExpressionConstant(0.25),
+						qdrant.NewExpressionCondition(qdrant.NewMatchKeywords("tag", "p", "li")),
+					},
+				}),
+			},
+		}),
+	}),
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/go.md
@@ -1,40 +1,40 @@
 ```go
 import (
-	"context"
+    "context"
 
-	"github.com/qdrant/go-client/qdrant"
+    "github.com/qdrant/go-client/qdrant"
 )
 
 client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
+    Host: "localhost",
+    Port: 6334,
 })
 
 client.Query(context.Background(), &qdrant.QueryPoints{
-	CollectionName: "{collection_name}",
-	Prefetch: []*qdrant.PrefetchQuery{
-		{
-			Query: qdrant.NewQuery(0.01, 0.45, 0.67),
-		},
-	},
-	Query: qdrant.NewQueryFormula(&qdrant.Formula{
-		Expression: qdrant.NewExpressionSum(&qdrant.SumExpression{
-			Sum: []*qdrant.Expression{
-				qdrant.NewExpressionVariable("$score"),
-				qdrant.NewExpressionMult(&qdrant.MultExpression{
-					Mult: []*qdrant.Expression{
-						qdrant.NewExpressionConstant(0.5),
-						qdrant.NewExpressionCondition(qdrant.NewMatchKeywords("tag", "h1", "h2", "h3", "h4")),
-					},
-				}),
-				qdrant.NewExpressionMult(&qdrant.MultExpression{
-					Mult: []*qdrant.Expression{
-						qdrant.NewExpressionConstant(0.25),
-						qdrant.NewExpressionCondition(qdrant.NewMatchKeywords("tag", "p", "li")),
-					},
-				}),
-			},
-		}),
-	}),
+    CollectionName: "{collection_name}",
+    Prefetch: []*qdrant.PrefetchQuery{
+        {
+            Query: qdrant.NewQuery(0.01, 0.45, 0.67),
+        },
+    },
+    Query: qdrant.NewQueryFormula(&qdrant.Formula{
+        Expression: qdrant.NewExpressionSum(&qdrant.SumExpression{
+            Sum: []*qdrant.Expression{
+                qdrant.NewExpressionVariable("$score"),
+                qdrant.NewExpressionMult(&qdrant.MultExpression{
+                    Mult: []*qdrant.Expression{
+                        qdrant.NewExpressionConstant(0.5),
+                        qdrant.NewExpressionCondition(qdrant.NewMatchKeywords("tag", "h1", "h2", "h3", "h4")),
+                    },
+                }),
+                qdrant.NewExpressionMult(&qdrant.MultExpression{
+                    Mult: []*qdrant.Expression{
+                        qdrant.NewExpressionConstant(0.25),
+                        qdrant.NewExpressionCondition(qdrant.NewMatchKeywords("tag", "p", "li")),
+                    },
+                }),
+            },
+        }),
+    }),
 })
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/http.md
@@ -1,0 +1,18 @@
+```http
+POST /collections/{collection_name}/points/query
+{
+    "prefetch": {
+        "query": [0.2, 0.8, ...],  // <-- dense vector
+        "limit": 50
+    }
+    "query": {
+        "formula": {
+            "sum": [
+                "$score,
+                { "mult": [ 0.5, { "key": "tag", "match": { "any": ["h1", "h2", "h3", "h4"] } } ] },
+                { "mult": [ 0.25, { "key": "tag", "match": { "any": ["p", "li"] } } ] }
+            ]
+        }
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/http.md
@@ -9,8 +9,23 @@ POST /collections/{collection_name}/points/query
         "formula": {
             "sum": [
                 "$score,
-                { "mult": [ 0.5, { "key": "tag", "match": { "any": ["h1", "h2", "h3", "h4"] } } ] },
-                { "mult": [ 0.25, { "key": "tag", "match": { "any": ["p", "li"] } } ] }
+                { 
+                    "mult": [ 
+                        0.5,
+                        { 
+                            "key": "tag",
+                            "match": { "any": ["h1", "h2", "h3", "h4"] } } 
+                    ]
+                },
+                {
+                    "mult": [
+                        0.25,
+                        { 
+                            "key": "tag",
+                            "match": { "any": ["p", "li"] } 
+                        }
+                    ]
+                }
             ]
         }
     }

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/java.md
@@ -20,44 +20,44 @@ import io.qdrant.client.grpc.Points.QueryPoints;
 import io.qdrant.client.grpc.Points.SumExpression;
 
 QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+  new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
 
 client
-    .queryAsync(
-        QueryPoints.newBuilder()
-            .setCollectionName("{collection_name}")
-            .addPrefetch(
-                PrefetchQuery.newBuilder()
-                    .setQuery(nearest(0.01f, 0.45f, 0.67f))
-                    .setLimit(100)
-                    .build())
-            .setQuery(
-                formula(
-                    Formula.newBuilder()
-                        .setExpression(
-                            sum(
-                                SumExpression.newBuilder()
-                                    .addSum(variable("$score"))
-                                    .addSum(
-                                        mult(
-                                            MultExpression.newBuilder()
-                                                .addMult(constant(0.5f))
-                                                .addMult(
-                                                    condition(
-                                                        matchKeywords(
-                                                            "tag",
-                                                            List.of("h1", "h2", "h3", "h4"))))
-                                                .build()))
-                                    .addSum(mult(MultExpression.newBuilder()
-                                    .addMult(constant(0.25f))
-                                    .addMult(
-                                        condition(
-                                            matchKeywords(
-                                                "tag",
-                                                List.of("p", "li"))))
-                                    .build()))
-                                    .build()))
+  .queryAsync(
+    QueryPoints.newBuilder()
+      .setCollectionName("{collection_name}")
+      .addPrefetch(
+        PrefetchQuery.newBuilder()
+          .setQuery(nearest(0.01f, 0.45f, 0.67f))
+          .setLimit(100)
+          .build())
+      .setQuery(
+        formula(
+          Formula.newBuilder()
+            .setExpression(
+              sum(
+                SumExpression.newBuilder()
+                  .addSum(variable("$score"))
+                  .addSum(
+                    mult(
+                      MultExpression.newBuilder()
+                        .addMult(constant(0.5f))
+                        .addMult(
+                          condition(
+                            matchKeywords(
+                              "tag",
+                              List.of("h1", "h2", "h3", "h4"))))
                         .build()))
-            .build())
-    .get();
+                  .addSum(mult(MultExpression.newBuilder()
+                  .addMult(constant(0.25f))
+                  .addMult(
+                    condition(
+                      matchKeywords(
+                        "tag",
+                        List.of("p", "li"))))
+                  .build()))
+                  .build()))
+            .build()))
+      .build())
+  .get();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/java.md
@@ -1,0 +1,63 @@
+```java
+import java.util.List;
+
+import static io.qdrant.client.ConditionFactory.matchKeywords;
+import static io.qdrant.client.ExpressionFactory.condition;
+import static io.qdrant.client.ExpressionFactory.constant;
+import static io.qdrant.client.ExpressionFactory.mult;
+import static io.qdrant.client.ExpressionFactory.sum;
+import static io.qdrant.client.ExpressionFactory.variable;
+import static io.qdrant.client.QueryFactory.formula;
+import static io.qdrant.client.QueryFactory.nearest;
+
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Points.Formula;
+import io.qdrant.client.grpc.Points.MultExpression;
+import io.qdrant.client.grpc.Points.PrefetchQuery;
+import io.qdrant.client.grpc.Points.QueryPoints;
+import io.qdrant.client.grpc.Points.SumExpression;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .queryAsync(
+        QueryPoints.newBuilder()
+            .setCollectionName("{collection_name}")
+            .addPrefetch(
+                PrefetchQuery.newBuilder()
+                    .setQuery(nearest(0.01f, 0.45f, 0.67f))
+                    .setLimit(100)
+                    .build())
+            .setQuery(
+                formula(
+                    Formula.newBuilder()
+                        .setExpression(
+                            sum(
+                                SumExpression.newBuilder()
+                                    .addSum(variable("$score"))
+                                    .addSum(
+                                        mult(
+                                            MultExpression.newBuilder()
+                                                .addMult(constant(0.5f))
+                                                .addMult(
+                                                    condition(
+                                                        matchKeywords(
+                                                            "tag",
+                                                            List.of("h1", "h2", "h3", "h4"))))
+                                                .build()))
+                                    .addSum(mult(MultExpression.newBuilder()
+                                    .addMult(constant(0.25f))
+                                    .addMult(
+                                        condition(
+                                            matchKeywords(
+                                                "tag",
+                                                List.of("p", "li"))))
+                                    .build()))
+                                    .build()))
+                        .build()))
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/python.md
@@ -1,0 +1,18 @@
+```python
+from qdrant_client import models
+
+boosted = client.query_points(
+    collection_name="{collection_name}",
+    prefetch=models.PrefetchRequest(
+        query=[0.2, 0.8, ...],  # <-- dense vector
+        limit=50
+    ),
+    query=models.Formula(formula=models.SumExpression(
+        sum=[
+            "$score",
+            models.MultExpression(mult=[0.5, models.FieldCondition(key="tag", match=models.MatchAny(any=["h1", "h2", "h3", "h4"]))]),
+            models.MultExpression(mult=[0.25, models.FieldCondition(key="tag", match=models.MatchAny(any=["p", "li"]))])
+        ]
+    ))
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/python.md
@@ -1,14 +1,15 @@
 ```python
 from qdrant_client import models
 
-boosted = client.query_points(
+
+tag_boosted = client.query_points(
     collection_name="{collection_name}",
-    prefetch=models.PrefetchRequest(
+    prefetch=models.Prefetch(
         query=[0.2, 0.8, ...],  # <-- dense vector
         limit=50
     ),
-    query=models.Formula(formula=models.SumExpression(
-        sum=[
+    query=models.FormulaQuery(
+        formula=models.SumExpression(sum=[
             "$score",
             models.MultExpression(mult=[0.5, models.FieldCondition(key="tag", match=models.MatchAny(any=["h1", "h2", "h3", "h4"]))]),
             models.MultExpression(mult=[0.25, models.FieldCondition(key="tag", match=models.MatchAny(any=["p", "li"]))])

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/rust.md
@@ -1,0 +1,28 @@
+```rust
+use qdrant_client::qdrant::{
+    Condition, Expression, FormulaBuilder, PrefetchQueryBuilder, QueryPointsBuilder,
+};
+use qdrant_client::Qdrant;
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client.query(
+    QueryPointsBuilder::new("{collection_name}")
+        .add_prefetch(PrefetchQueryBuilder::default()
+            .query(vec![0.01, 0.45, 0.67])
+            .limit(100u64)
+        )
+        .query(FormulaBuilder::new(Expression::sum_with([
+            Expression::variable("$score"),
+            Expression::mult_with([
+                Expression::constant(0.5),
+                Expression::condition(Condition::matches("tag", ["h1", "h2", "h3", "h4"])),
+            ]),
+            Expression::mult_with([
+                Expression::constant(0.25),
+                Expression::condition(Condition::matches("tag", ["p", "li"])),
+            ]),
+        ])))
+        .limit(10)
+).await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/rust.md
@@ -13,7 +13,7 @@ let _tag_boosted = client.query(
             .limit(100u64)
         )
         .query(FormulaBuilder::new(Expression::sum_with([
-            Expression::variable("$score"),
+            Expression::score(),
             Expression::mult_with([
                 Expression::constant(0.5),
                 Expression::condition(Condition::matches("tag", ["h1", "h2", "h3", "h4"])),

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/rust.md
@@ -6,7 +6,7 @@ use qdrant_client::Qdrant;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;
 
-client.query(
+let _tag_boosted = client.query(
     QueryPointsBuilder::new("{collection_name}")
         .add_prefetch(PrefetchQueryBuilder::default()
             .query(vec![0.01, 0.45, 0.67])
@@ -24,5 +24,5 @@ client.query(
             ]),
         ])))
         .limit(10)
-).await?;
+    ).await?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/score-boost-tags/typescript.md
@@ -1,0 +1,26 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+const tag_boosted = await client.query(collectionName, {
+  prefetch: {
+    query: [0.2, 0.8, 0.1, 0.9],
+    limit: 50
+  },
+  query: {
+    formula: {
+      sum: [
+        "$score",
+        {
+          mult: [ 0.5, { key: "tag", match: { any: ["h1", "h2", "h3", "h4"] }} ]
+        },
+        {
+          mult: [ 0.25, { key: "tag", match: { any: ["p", "li"] }} ]
+        }
+      ]
+    }
+  }
+});
+```
+


### PR DESCRIPTION
For v1.14 release

- Adds documentation for formula queries
- Removes `Re-ranking with payload values` section since formula queries can do the same thing, but more versatile.

[Rendered](https://deploy-preview-1506--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/hybrid-queries/#score-boosting)

TODO:
- [x] Add example which uses defaults for payloads or scores
- [x] Add snippets for other langs
  - [x] http
  - [x] Rust
  - [x] Python
  - [x] Java
  - [x] Go
  - [x] C#
  - [x] JS