### PR TITLE
Improve headers and fix redirect for analytics iframe

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,10 +19,10 @@ HUGO_ENV = "staging"
 HUGO_PARAMS_segmentWriteKey = "DZ49RYXkFEV0pY6DG4i0RyxyobSovIlU"
 
 [[headers]]
-  for = "/get_anonymous_id"
+  for = "/get_anonymous_id/"
   [headers.values]
-    Content-Security-Policy = "frame-ancestors https://staging-cloud.qdrant.io https://cloud.qdrant.io;"
-    X-Frame-Options = "ALLOW-FROM https://staging-cloud.qdrant.io https://cloud.qdrant.io"
+    Content-Security-Policy = "frame-ancestors https://development-cloud.qdrant.io https://staging-cloud.qdrant.io https://cloud.qdrant.io"
+    X-Frame-Options = "ALLOW-FROM https://development-cloud.qdrant.io https://staging-cloud.qdrant.io https://cloud.qdrant.io"
 
     
 [[headers]]

--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -118,3 +118,10 @@ disableKinds = ["taxonomy", "term"]
 [services]
   [services.googleAnalytics]
     id = 'G-NZYW2651NE'
+
+[server]
+  [server.headers]
+    for = '/get_anonymous_id/**'
+    [[server.headers.values]]
+      Content-Security-Policy = 'frame-ancestors https://localhost:3000'
+      X-Frame-Options = 'ALLOW-FROM https://localhost:3000'

--- a/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/get_anonymous_id/baseof.html
@@ -1,13 +1,11 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta name="robots" content="noindex, nofollow">
-
+    <meta name="robots" content="noindex, nofollow" />
     <script>
       const writeKey = "{{ .Site.Params.segmentWriteKey }}";
       const isProduction = "{{ hugo.IsProduction }}" === "true";
-
-      if(!isProduction) { // not production ∴ no cdn
+      if (!isProduction) { // not production ∴ no cdn
         !function(){
           var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey=writeKey;;analytics.SNIPPET_VERSION="5.2.0";
           analytics.load(writeKey);
@@ -22,22 +20,18 @@
           analytics.load(writeKey);
         }}();
       }
-
-      window.onload = function() {
-        window.addEventListener('message', (cloudUIEvent) => {
-          analytics.ready(() => {
-            const isQdrantOrigin = ['https://cloud.qdrant.io', 'https://staging-cloud.qdrant.io'].includes(cloudUIEvent.origin);
-            const isLocal = !isProduction && cloudUIEvent.origin === 'https://localhost:3000';
-            const originPass = isQdrantOrigin || isLocal;
-
-            if (originPass && cloudUIEvent.data === 'getAnonymousId') {
-              const anonymousId = analytics.user().anonymousId();
-              cloudUIEvent.source.postMessage(anonymousId, cloudUIEvent.origin);
-            }
-          });
-        });
-      };
     </script>
   </head>
-  <body></body>
+  <body>
+    <script>
+      window.addEventListener('message', (event) => {
+        analytics.ready(() => {
+          if (event.data === 'getAnonymousId') {
+            const anonymousId = analytics.user().anonymousId();
+            event.source.postMessage(anonymousId, event.origin);
+          }
+        });
+      });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
- The iframe was loading with 301, because it was missing the trailing slash
- Added localhost:3000 to Hugo's HTTP headers for path
- Remove domain checks, since we have CSP headers for protection
- Added development domain to headers, alongside staging and prod.