### PR TITLE
new: provide local inference examples in colbert docs

### DIFF
--- a/qdrant-landing/content/documentation/fastembed/fastembed-colbert.md
+++ b/qdrant-landing/content/documentation/fastembed/fastembed-colbert.md
@@ -225,9 +225,9 @@ qdrant_client.upload_points(
         models.PointStruct(
             id=idx,
             payload=metadata[idx],
-            vector=description_documents[idx]
+            vector=description_document
         )
-        for idx, vector in enumerate(descriptions_embeddings)
+        for idx, description_document in enumerate(description_documents)
     ],
 )
 ```

--- a/qdrant-landing/content/documentation/fastembed/fastembed-colbert.md
+++ b/qdrant-landing/content/documentation/fastembed/fastembed-colbert.md
@@ -132,7 +132,7 @@ That means that for the first description, we have **48** vectors of lengths **1
 Install `qdrant-client`
 
 ```python
-pip install "qdrant-client>=1.14.0"
+pip install "qdrant-client>=1.14.2"
 ```
 
 Qdrant Client has a simple in-memory mode that allows you to experiment locally on small data volumes. 
@@ -193,9 +193,6 @@ metadata = [{"movie_name": "The Passion of Joan of Arc", "movie_watch_time_min":
 </details>
 
 ```python
-descriptions_embeddings = list(
-    embedding_model.embed(descriptions)
-)
 qdrant_client.upload_points(
     collection_name="movies",
     points=[


### PR DESCRIPTION
Qdrant-client v1.14 adds implicit local inference.

This PR is a draft which adds code snippets showcasing how to use it without explicit embedding computation.