### PR TITLE
new: replace .add and .query with local inference in fastembed semant…

### DIFF
--- a/qdrant-landing/content/documentation/fastembed/fastembed-semantic-search.md
+++ b/qdrant-landing/content/documentation/fastembed/fastembed-semantic-search.md
@@ -52,7 +52,7 @@ client.create_collection(
     vectors_config=models.VectorParams(
         size=client.get_embedding_size(model_name), 
         distance=models.Distance.COSINE
-    ),  # size and distance are model dependent, however, distance is almost always cosine
+    ),  # size and distance are model dependent
 )
 
 ```

--- a/qdrant-landing/content/documentation/fastembed/fastembed-semantic-search.md
+++ b/qdrant-landing/content/documentation/fastembed/fastembed-semantic-search.md
@@ -5,15 +5,9 @@ weight: 3
 
 # Using FastEmbed with Qdrant for Vector Search
 
-## Install Qdrant Client
+## Install Qdrant Client and FastEmbed
 ```python
-pip install "qdrant-client>1.14.0"
-```
-
-## Install FastEmbed
-Installing FastEmbed will let you quickly turn data to vectors, so that Qdrant can search over them.
-```python
-pip install fastembed
+pip install "qdrant-client[fastembed]>=1.14.2"
 ```
 
 ## Initialize the client

--- a/qdrant-landing/content/documentation/fastembed/fastembed-semantic-search.md
+++ b/qdrant-landing/content/documentation/fastembed/fastembed-semantic-search.md
@@ -28,12 +28,16 @@ client = QdrantClient(":memory:")  # Qdrant is running from RAM.
 Now you can add two sample documents, their associated metadata, and a point `id` for each. 
 
 ```python
-docs = ["Qdrant has a LangChain integration for chatbots.", "Qdrant has a LlamaIndex integration for agents."]
+docs = [
+    "Qdrant has a LangChain integration for chatbots.",
+    "Qdrant has a LlamaIndex integration for agents.",
+]
 metadata = [
     {"source": "langchain-docs"},
     {"source": "llamaindex-docs"},
 ]
 ids = [42, 2]
+
 ```
 ## Create a collection
 
@@ -42,10 +46,15 @@ Collection requires vector parameters to be set during creation.
 In this tutorial, we'll be using `BAAI/bge-small-en` to compute embeddings.
 
 ```python
+model_name = "BAAI/bge-small-en"
 client.create_collection(
     collection_name="test_collection",
-    vectors_config=models.VectorParams(size=384, distance=models.Distance.COSINE)  # size and distance are model dependent, however, distance is almost always cosine
+    vectors_config=models.VectorParams(
+        size=client.get_embedding_size(model_name), 
+        distance=models.Distance.COSINE
+    ),  # size and distance are model dependent, however, distance is almost always cosine
 )
+
 ```
 
 ## Upsert documents to the collection
@@ -54,7 +63,6 @@ Qdrant client can do inference implicitly within its methods via FastEmbed integ
 It requires wrapping your data in models, like `models.Document` (or `models.Image` if you're working with images)
 
 ```python
-model_name = "BAAI/bge-small-en"
 metadata_with_docs = [
     {"document": doc, "source": meta["source"]} for doc, meta in zip(docs, metadata)
 ]
@@ -72,7 +80,10 @@ Here, you will ask a dummy question that will allow you to retrieve a semantical
 ```python
 search_result = client.query_points(
     collection_name="test_collection",
-    query=models.Document(text="Which integration is best for agents?", model=model_name)
+    query=models.Document(
+        text="Which integration is best for agents?", 
+        model=model_name
+    )
 ).points
 print(search_result)
 ```


### PR DESCRIPTION
Qdrant-client v1.14 adds implicit local inference, methods `.add` and `.query` will become deprecated.

This PR is a draft which updates the related code snippets, however, the descriptions have also been updated, but should still be polished. (Other than polishing, PR is ready)