### PR TITLE
Typo fix in _index.md

### DIFF
--- a/qdrant-landing/content/documentation/overview/_index.md
+++ b/qdrant-landing/content/documentation/overview/_index.md
@@ -52,7 +52,7 @@ system, each vector could represent a song, and elements of the vector would cap
 such as tempo, genre, lyrics, and so on.
 
 Vector databases are optimized for **storing** and **querying** these high-dimensional vectors 
-efficiently, and they often using specialized data structures and indexing techniques such as 
+efficiently, and they often use specialized data structures and indexing techniques such as 
 Hierarchical Navigable Small World (HNSW) -- which is used to implement Approximate Nearest 
 Neighbors -- and Product Quantization, among others. These databases enable fast similarity 
 and semantic search while allowing users to find vectors that are the closest to a given query 


### PR DESCRIPTION
This pull request includes a minor correction to the documentation in the `qdrant-landing/content/documentation/overview/_index.md` file. The grammatical error "often using" was corrected to "often use" for improved readability and accuracy.

* [`qdrant-landing/content/documentation/overview/_index.md`](diffhunk://#diff-ce5b2e075462bfdbcfe5d0de4a281020cb168b46ebe16de7a5bba71c6978f4eaL55-R55): Fixed a grammatical error in the description of vector database optimizations.