### PR TITLE
Fix invalid sparse vector indices in HTTP example

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/sparse-vectors/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/sparse-vectors/http.md
@@ -15,7 +15,7 @@ PUT /collections/{collection_name}/points
             "id": 2,
             "vector": {
                 "text": {
-                    "indices": [1, 1, 2, 3, 4, 5],
+                    "indices": [1, 2, 3, 4, 5],
                     "values": [0.1, 0.2, 0.3, 0.4, 0.5]
                 }
             }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/landing_page/issues/1583>