### PR TITLE
use non-standart port for links checker

### DIFF
--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -31,7 +31,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          args: --max-redirects 0 --exclude '.*' --include 'http://localhost:1314/.*' --base http://localhost:1314/ qdrant-landing/public/
+          args: --max-redirects 0 --exclude '.*' --include 'http://localhost:1313/.*' --base http://localhost:1314/ qdrant-landing/public/
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -25,7 +25,7 @@ jobs:
           bash -x ./install-and-build.sh
           CURRENT_DIR=$(pwd)
           export PATH="${CURRENT_DIR}/dart-sass:${PATH}"
-          cd qdrant-landing && hugo --gc -b 'http://localhost:1314' && hugo serve &
+          cd qdrant-landing && hugo --gc -b 'http://localhost:1314' && hugo serve --port 1314 &
           sleep 5 # wait for server to start
       - name: Internal Links Check
         id: lychee

--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -25,13 +25,13 @@ jobs:
           bash -x ./install-and-build.sh
           CURRENT_DIR=$(pwd)
           export PATH="${CURRENT_DIR}/dart-sass:${PATH}"
-          cd qdrant-landing && hugo --gc -b 'http://localhost:1313' && hugo serve &
+          cd qdrant-landing && hugo --gc -b 'http://localhost:1314' && hugo serve &
           sleep 5 # wait for server to start
       - name: Internal Links Check
         id: lychee
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          args: --max-redirects 0 --exclude '.*' --include 'http://localhost:1313/.*' --base http://localhost:1313/ qdrant-landing/public/
+          args: --max-redirects 0 --exclude '.*' --include 'http://localhost:1314/.*' --base http://localhost:1314/ qdrant-landing/public/
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/qdrant-landing/content/articles/vector-search-resource-optimization.md
+++ b/qdrant-landing/content/articles/vector-search-resource-optimization.md
@@ -32,7 +32,7 @@ Let's take a look at some common goals and optimization strategies:
 
 | Intended Result                | Optimization Strategy        |
 |--------------------------------|------------------------------|
-| [**High Search Precision + Low Memory Expenditure**](/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)    | [**On-Disk Indexing**](/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)             |
+| [**High Search Precision + Low Memory Expenditure**](http://localhost:1313/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)    | [**On-Disk Indexing**](/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)             |
 | [**Low Memory Expenditure + Fast Search Speed**](/documentation/guides/quantization/)        | [**Quantization**](/documentation/guides/quantization/)                 |
 | [**High Search Precision + Fast Search Speed**](/documentation/guides/optimize/#3-high-precision-with-high-speed-search)    | [**RAM Storage + Quantization**](/documentation/guides/optimize/#3-high-precision-with-high-speed-search)   |
 | [**Balance Latency vs Throughput**](/documentation/guides/optimize/#balancing-latency-and-throughput)         | [**Segment Configuration**](/documentation/guides/optimize/#balancing-latency-and-throughput)        |

--- a/qdrant-landing/content/articles/vector-search-resource-optimization.md
+++ b/qdrant-landing/content/articles/vector-search-resource-optimization.md
@@ -32,7 +32,7 @@ Let's take a look at some common goals and optimization strategies:
 
 | Intended Result                | Optimization Strategy        |
 |--------------------------------|------------------------------|
-| [**High Search Precision + Low Memory Expenditure**](http://localhost:1313/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)    | [**On-Disk Indexing**](/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)             |
+| [**High Search Precision + Low Memory Expenditure**](/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)    | [**On-Disk Indexing**](/documentation/guides/optimize/#1-high-speed-search-with-low-memory-usage)             |
 | [**Low Memory Expenditure + Fast Search Speed**](/documentation/guides/quantization/)        | [**Quantization**](/documentation/guides/quantization/)                 |
 | [**High Search Precision + Fast Search Speed**](/documentation/guides/optimize/#3-high-precision-with-high-speed-search)    | [**RAM Storage + Quantization**](/documentation/guides/optimize/#3-high-precision-with-high-speed-search)   |
 | [**Balance Latency vs Throughput**](/documentation/guides/optimize/#balancing-latency-and-throughput)         | [**Segment Configuration**](/documentation/guides/optimize/#balancing-latency-and-throughput)        |


### PR DESCRIPTION
There is a corner-case in the link checker, that if we create a link with default base of localhost, link checker would think it is a valid one.
To prevent an obvious mistake, we can configure links checker to use base with non-standard port to make the accidental copy-paste of url less likely