### PR TITLE
docs: fix extra colon in documentation

### DIFF
--- a/qdrant-landing/content/documentation/search-precision/reranking-semantic-search.md
+++ b/qdrant-landing/content/documentation/search-precision/reranking-semantic-search.md
@@ -158,7 +158,7 @@ co = cohere.Client("<API-KEY>")
 
 ### Creating a Collection
 
-A collection is basically a named group of points (vectors with data) that you can search through. All the vectors in a collection need to have the same size and be compared using one distance metric. Here’s how to create one::
+A collection is basically a named group of points (vectors with data) that you can search through. All the vectors in a collection need to have the same size and be compared using one distance metric. Here’s how to create one:
 
 ```jsx
 client.create_collection(


### PR DESCRIPTION
Remove an extra colon in the documentation line.
![image](https://github.com/user-attachments/assets/b2108a9f-975a-480a-af56-21101834ed93)
