### PR TITLE
isFirstPageView for Marketing Traffic Source Attribution

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -105,7 +105,7 @@ export function addGA4Properties(properties) {
   properties.ga_client_id = getCookie('_ga')?.replace('GA1.1.','');
 }
 
-export function addUTMToLinks() {
+export function getUTMParams() {
   const urlParams = new URLSearchParams(window.location.search);
 
   // Gather all GTM related params
@@ -121,6 +121,12 @@ export function addUTMToLinks() {
       campaign: urlParams.get('utm_campaign'),
       content: urlParams.get('utm_content')
   };
+
+  return [utmIds, utmParams];
+}
+
+export function addUTMToLinks() {
+  const [utmIds, utmParams] = getUTMParams();
 
   // Create new params string for outbound links and store in sessionStorage
   let newParams = '';

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -1,4 +1,4 @@
-import { addGA4Properties, addUTMToLinks, getCookie, tagCloudUILinksWithAnonymousId } from './helpers';
+import { addGA4Properties, addUTMToLinks, getCookie, getUTMParams, tagCloudUILinksWithAnonymousId } from './helpers';
 import { registerAndCall } from './onetrust-helpers';
 
 const PAGES_SESSION_STORAGE_KEY = 'segmentPages';
@@ -96,7 +96,8 @@ const trackPageView = () => {
   const category = 'Qdrant.tech';
   const name = nameMapper(window.location.href);
   
-  const properties = {};
+  const isFirstPageView = localStorage.getItem('isFirstPageView');
+  const properties = { isFirstPageView };
   addGA4Properties(properties);
 
   window.analytics.page(category, name, properties);
@@ -143,6 +144,19 @@ export function handleSegmentReady() {
   addUTMToLinks();
 
   analytics.ready(() => {
+    const [utmIds, utmParams] = getUTMParams();
+    const isFirstPageView = localStorage.getItem('isFirstPageView');
+
+    if (isFirstPageView === 'true') {
+      analytics.identify({
+        firstVisitAttribution: {
+          referrer: document.referrer,
+          ...utmParams,
+          ...utmIds
+        }
+      });
+    }
+
     registerAndCall();
     tagCloudUILinksWithAnonymousId();
     tagAllAnchors();

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
@@ -11,6 +11,10 @@
 <!-- OneTrust Cookies Consent Notice end for local.qdrant.tech -->
 
 <!-- Segment -->
+<script>
+  const isFirstPageView = !localStorage.getItem('ajs_anonymous_id') && localStorage.getItem('isFirstPageView') === null;
+  localStorage.setItem('isFirstPageView', isFirstPageView);
+</script>
 {{ if hugo.IsProduction }}
   <script>
     !function(){const writeKey = "{{ .Site.Params.segmentWriteKey }}";var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://evs.analytics.qdrant.tech/5caWuitPgcGFN5Q7HMpTaj/vEkmzjuRSqeXGbhGAFTWex.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey=writeKey;analytics._cdn = "https://evs.analytics.qdrant.tech";analytics.SNIPPET_VERSION="5.2.0";


### PR DESCRIPTION
## Context
Marketing Team needs to be able to identify utm params and referrer for a new user's FIRST visit to the marketing site. We've done this implicitly in the warehouse but we need the information further upstream for Hubspot/CRM AND this will make even the downstream research easier and more reliable (ie not relying on JOINing many different tables in hopes of uncovering the true initial touch point with qdrant.tech).

## Implementation
Introducing isFirstPageView property in Page event and in new identity call for Marketing traffic source attribution