### PR TITLE
Revert "Fix dotnet multivector insertion snippet"

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-multivector/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-multivector/csharp.md
@@ -9,11 +9,11 @@ await client.UpsertAsync(
   points: new List <PointStruct> {
     new() {
       Id = 1,
-      Vector = new float[][] {
-        [-0.013f, 0.020f, -0.007f, -0.111f],
-        [-0.030f, -0.05f, 0.001f, 0.072f],
-        [-0.041f, 0.014f, -0.032f, -0.062f ],
-      },
+        Vectors = new float[][] {
+          [-0.013f, 0.020f, -0.007f, -0.111f],
+          [-0.030f, -0.05f, 0.001f, 0.072f],
+          [-0.041f, 0.014f, -0.032f, -0.062f ],
+        },
     },
   }
 );

--- a/qdrant-landing/static/llms-full.txt
+++ b/qdrant-landing/static/llms-full.txt
@@ -43465,11 +43465,11 @@ await client.UpsertAsync(
   points: new List <PointStruct> {
     new() {
       Id = 1,
-      Vector = new float[][] {
-        [-0.013f, 0.020f, -0.007f, -0.111f],
-        [-0.030f, -0.05f, 0.001f, 0.072f],
-        [-0.041f, 0.014f, -0.032f, -0.062f ],
-      },
+        Vectors = new float[][] {
+          [-0.013f, 0.020f, -0.007f, -0.111f],
+          [-0.030f, -0.05f, 0.001f, 0.072f],
+          [-0.041f, 0.014f, -0.032f, -0.062f ],
+        },
     },
   }
 );


### PR DESCRIPTION
Reverts qdrant/landing_page#1860

The param should stay `"Vectors"`.

The original issue is resolved with https://github.com/qdrant/qdrant-dotnet/pull/100.