### PR TITLE
Only Fire addOneTrustPreferencesToLinks() on consent change (OneTrust)

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -16,8 +16,6 @@ document.addEventListener('DOMContentLoaded', function () {
   addUTMToLinks();
   
   const handleOneTrustLoaded = () => {   // One Trust Loaded
-    addOneTrustPreferencesToLinks();
-
     window.OneTrust.OnConsentChanged(async () => { // One Trust Preference Updated
       addOneTrustPreferencesToLinks();
       registerAndCall();


### PR DESCRIPTION
- removing `addOneTrustPreferencesToLinks` from OneTrust loaded logic: should only append IF/WHEN user makes a onetrust choice