### PR TITLE
Add video import to documentation styles

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/documentation.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/documentation.scss
@@ -12,4 +12,5 @@
 @import 'partials/table-of-contents';
 @import 'partials/feedback';
 @import 'partials/documentation/docs-footer';
+@import 'partials/video';
 @import 'search/dark-theme';


### PR DESCRIPTION
Wanted to embed videos with responsive size and found an existing responsive CSS (.video) that actually works but I have to add the video styles to the CSS bundle that is used on course/documentation pages so that the .video wrapper works there too.