### PR TITLE
fix course sidebar menu styles in the light theme

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-menu.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-menu.scss
@@ -327,7 +327,7 @@
         }
 
         &.active {
-          .docs-menu__links-group-heading>a {
+          &>.docs-menu__links-group-heading>a {
             color: $primary-50;
             background: $neutral-90;
           }


### PR DESCRIPTION
| Before | After |
|--------|------|
|<img width="252" height="380" alt="Screenshot 2025-10-23 at 03 31 22" src="https://github.com/user-attachments/assets/9a12d665-0a0f-4903-a648-f969c06ae166" />|<img width="289" height="292" alt="Screenshot 2025-10-23 at 03 31 32" src="https://github.com/user-attachments/assets/24a826cc-f117-4e22-88d9-53edde3807c6" />|