### PR TITLE
[CP-330] Cleanup of deprecated OpenAPI endpoint PAv1

### DIFF
--- a/qdrant-landing/content/documentation/cloud-api.md
+++ b/qdrant-landing/content/documentation/cloud-api.md
@@ -45,12 +45,3 @@ For samples on how to use the API, with a tool like grpcurl, curl or any of the 
 ## Terraform Provider
 
 Qdrant Cloud also provides a Terraform provider to manage your Qdrant Cloud resources. [Learn more](/documentation/infrastructure/terraform/).
-
-## Deprecated OpenAPI specification
-
-We still support our deprecated OpenAPI endpoint, but this is scheduled to be removed later this year (November 1st, 2025).
-We do _NOT_ recommend to use this endpoint anymore and use the replacement as described above.
-
-| REST API      | Documentation                                                                        |
-| -------- | ------------------------------------------------------------------------------------ |
-| v.0.1.0 | [OpenAPI Specification](https://cloud.qdrant.io/pa/v1/docs)                       |


### PR DESCRIPTION
The actual endpoint stills runs [until after the offsite], this is to remove it from the website only.