### PR TITLE
[doc] Add limit parameter to query configuration

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/csharp.cs
@@ -25,7 +25,8 @@ public class Snippet
 		        Limit = 20
 		    }
 		  },
-		  query: new Rrf()
+		  query: new Rrf(),
+		  limit: 10
 		);
 	}
 }

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/csharp.md
@@ -22,6 +22,7 @@ await client.QueryAsync(
         Limit = 20
     }
   },
-  query: new Rrf()
+  query: new Rrf(),
+  limit: 10
 );
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/go.md
@@ -25,5 +25,6 @@ client.Query(context.Background(), &qdrant.QueryPoints{
 		},
 	},
 	Query: qdrant.NewQueryRRF(&qdrant.Rrf{}),
+	Limit: qdrant.PtrOf(uint64(10)),
 })
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/java.md
@@ -25,6 +25,7 @@ client.queryAsync(
       .setLimit(20)
       .build())
     .setQuery(rrf(Rrf.newBuilder().build()))
+    .setLimit(10)
     .build())
   .get();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/python.md
@@ -18,5 +18,6 @@ client.query_points(
         ),
     ],
     query=models.RrfQuery(rrf=models.Rrf()),
+    limit=10,
 )
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/rust.md
@@ -17,5 +17,6 @@ client.query(
             .limit(20u64)
         )
         .query(Query::new_rrf(RrfBuilder::default()))
+        .limit(10u64)
 ).await?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/generated/typescript.md
@@ -22,5 +22,6 @@ client.query("{collection_name}", {
     query: {
         rrf: {},
     },
+    limit: 10,
 });
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/go.go
@@ -29,5 +29,6 @@ func Main() {
 			},
 		},
 		Query: qdrant.NewQueryRRF(&qdrant.Rrf{}),
+		Limit: qdrant.PtrOf(uint64(10)),
 	})
 }

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/java.java
@@ -28,6 +28,7 @@ public class Snippet {
                       .setLimit(20)
                       .build())
                     .setQuery(rrf(Rrf.newBuilder().build()))
+                    .setLimit(10)
                     .build())
                   .get();
         }

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/python.py
@@ -17,4 +17,5 @@ client.query_points(
         ),
     ],
     query=models.RrfQuery(rrf=models.Rrf()),
+    limit=10,
 )

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/rust.rs
@@ -17,6 +17,7 @@ pub async fn main() -> anyhow::Result<()> {
                 .limit(20u64)
             )
             .query(Query::new_rrf(RrfBuilder::default()))
+            .limit(10u64)
     ).await?;
 
     Ok(())

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-rrf/typescript.ts
@@ -21,4 +21,5 @@ client.query("{collection_name}", {
     query: {
         rrf: {},
     },
+    limit: 10,
 });


### PR DESCRIPTION
It took me forever to understand why the hell it was only retrieving 10 results if I was properly set `limit:20` inside each prefetch.

Then I saw the HTTP example: https://github.com/qdrant/landing_page/blob/master/qdrant-landing/content/documentation/headless/snippets/query-points/hybrid-basic/http.md


So, I'm fixing for the future fellas.

PS.: I ❤️ qdrant

I'm using it on [ArchivosYa.com - AI for lawyers, in argentina](https://archivosya.com) (soon to go abroad!)