### PR TITLE
Fix duplicate aliases lists

### DIFF
--- a/qdrant-landing/content/documentation/beginner-tutorials/_index.md
+++ b/qdrant-landing/content/documentation/beginner-tutorials/_index.md
@@ -2,12 +2,11 @@
 title: Vector Search Basics
 aliases:
   - /documentation/tutorials/
+  - how-to
+  - tutorials
 weight: 16
 # If the index.md file is empty, the link to the section will be hidden from the sidebar
 is_empty: false
-aliases:
-  - how-to
-  - tutorials
 partition: qdrant
 ---
 
@@ -18,4 +17,4 @@ partition: qdrant
 | [Build Your First Semantic Search Engine in 5 Minutes](/documentation/beginner-tutorials/search-beginners/) | 
 | [Build a Neural Search Service with Sentence Transformers and Qdrant](/documentation/beginner-tutorials/neural-search/)             | 
 | [Build a Hybrid Search Service with FastEmbed and Qdrant](/documentation/beginner-tutorials/hybrid-search-fastembed/) | 
-| [Measure and Improve Retrieval Quality in Semantic Search](/documentation/beginner-tutorials/retrieval-quality/)    | 
+| [Measure and Improve Retrieval Quality in Semantic Search](/documentation/beginner-tutorials/retrieval-quality/)    |


### PR DESCRIPTION
After upgrading `hugo` to latest version, `hugo serve -D` fails with the message

```
Error: error building site: process: readAndProcessContent: "/Users/luis/personal/Qdrant/landing_page/qdrant-landing/content/documentation/beginner-tutorials/_index.md:8:1": [7:1] mapping key "aliases" already defined at [2:1]
   4 | weight: 16
   5 | # If the index.md file is empty, the link to the section will be hidden from the sidebar
   6 | is_empty: false
>  7 | aliases:
       ^
   8 |   - how-to
   9 |   - tutorials
  10 | partition: qdrant
```

This is easily fixable by merging both lists