### PR TITLE
Fix Kafka example

### DIFF
--- a/qdrant-landing/content/documentation/send-data/data-streaming-kafka-qdrant.md
+++ b/qdrant-landing/content/documentation/send-data/data-streaming-kafka-qdrant.md
@@ -197,8 +197,7 @@ from fastembed import TextEmbedding
 
 collection_name: str = 'test'
 embed_model_name: str = 'snowflake/snowflake-arctic-embed-s'
-```
-```python
+
 # Step 0: create qdrant_collection
 create_qdrant_collection(collection_name=collection_name, embed_model=embed_model_name)
 


### PR DESCRIPTION
## [Preview](https://deploy-preview-2031--condescending-goldwasser-91acf0.netlify.app/documentation/send-data/data-streaming-kafka-qdrant/#playground-application)

Fixes an issue with the Kafka example, where part of the code samples would not render.