### PR TITLE
snippets fallback color with higher contrast

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/syntax-highlight.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/syntax-highlight.scss
@@ -21,6 +21,10 @@ article code:not([class]) {
   margin: 0;
   padding: 1rem;
   border-radius: $code-snippet-border-radius;
+
+  code {
+    color: $neutral-94;
+  }
 }
 /* PreWrapper */
 .chroma {


### PR DESCRIPTION
in the Chrome browser with 1password extention:
<img width="878" height="349" alt="image" src="https://github.com/user-attachments/assets/d0e00d41-8458-4154-92e0-e04424e44173" />
