### PR TITLE
Text search guide tweaks

### DIFF
--- a/qdrant-landing/content/documentation/guides/text-search.md
+++ b/qdrant-landing/content/documentation/guides/text-search.md
@@ -29,7 +29,7 @@ To find books related to "time travel", use the following query:
 
 {{< code-snippet path="/documentation/headless/snippets/text-search/query-description-dense/" >}}
 
-In these examples, Qdrant uses [inference](/documentation/concepts/inference) to generate vectors from the `text` provided in the request using the specified `model`. Alternatively, you can generate explicitß vectors on the client side with a library like [FastEmbed](/documentation/fastembed/).
+In these examples, Qdrant uses [inference](/documentation/concepts/inference) to generate vectors from the `text` provided in the request using the specified `model`. Alternatively, you can generate explicit vectors on the client side with a library like [FastEmbed](/documentation/fastembed/).
 
 ### Lexical Search
 


### PR DESCRIPTION
[Rendered](https://deploy-preview-2057--condescending-goldwasser-91acf0.netlify.app/documentation/guides/text-search/)

This PR makes two small tweaks to the text search guide:

- adds a more explicit note about inference being a cloud-only feature, with the exception of bm25
- moves the guide up in the navigation, to just below the quantization guide.