### PR TITLE
Update the cloud quickstart to be a bit more helpful

### DIFF
--- a/qdrant-landing/content/documentation/cloud-quickstart.md
+++ b/qdrant-landing/content/documentation/cloud-quickstart.md
@@ -105,7 +105,7 @@ await client.createCollection("items", {
 });
 ```
 
-```curl
+```bash
 curl -X PUT \
   'http://<your-qdrant-host>:6333/collections/items' \
   --header 'api-key: <api-key-value>' \


### PR DESCRIPTION
These changes are trying to make the cloud quickstart a tad more useful for new users. Instead of just showing people a video and a few API calls with fake embeddings, it is more fleshed out.

There is one concern that I have: it is purely python. I debated this with myself, and the reason that I made the demo in all python is because the user needs to generate embeddings and doing so in languages that are not python is not easy, especially for OS models like bge-small. To that end, I kept it in python with the rationale that the majority of users looking for a quickstart are probably in python anyways -- open to discussion about this, however.

### TODO (before merge):
- [x] Update the snapshot to use one that has embeddings with better model support
- [x] very all code works in the example
- [x] approval from @kanungle @generall @abdonpijpelink 
- [x] review from devrel?