### PR TITLE
[fix: cognee.md] include vector_dataset_database_handler information

### DIFF
--- a/qdrant-landing/content/documentation/frameworks/cognee.md
+++ b/qdrant-landing/content/documentation/frameworks/cognee.md
@@ -69,13 +69,9 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-> Note: You can specify vector_dataset_database_handler in the config if it is not defined in the .env file.
+> Note: You can specify `vector_dataset_database_handler` in the config if it is not defined in the `.env` file.
 
-```bash
-VECTOR_DATASET_DATABASE_HANDLER=qdrant
-```
-
-> Example .env usage file for Cognee with Qdrant adapter
+Example `.env` usage file for Cognee with Qdrant adapter
 
 ```bash
 LLM_API_KEY=your-openai-api-key


### PR DESCRIPTION
In the latest update, when we try Cognee with Qdrant Adapter, it doesn't allow ENABLE_BACKEND_ACCESS_CONTROL for the dataset database handler, attached screenshot:

<img width="1335" height="282" alt="Screenshot 2026-01-02 at 17 07 27" src="https://github.com/user-attachments/assets/b4ed217e-d53d-4ce2-b381-aa6985acbff4" />

As per the updated README.md for Cognee- Qdrant adapter, it is specified under Usage to include ``VECTOR_DATASET_DATABASE_HANDLER="qdrant"`` in ``.env`` file.  

Source: [cognee-community-vector-adapter-qdrant](https://github.com/topoteretes/cognee-community/tree/main/packages/vector/qdrant)
