### PR TITLE
Cluster Telemetry docs

### DIFF
--- a/qdrant-landing/content/documentation/guides/monitoring.md
+++ b/qdrant-landing/content/documentation/guides/monitoring.md
@@ -147,7 +147,7 @@ Qdrant also provides a `/telemetry` endpoint, which provides information about t
 
 The `/telemetry` endpoint reports from the point of view of the peer being queried. But Qdrant also provides a `/cluster/telemetry` endpoint, which aggregates telemetries from all peers. 
 
-This includes less information than `/telemetry`, but includes information like shard transfer progress more reliably.
+This includes less information than `/telemetry`, but provides information like shard transfer progress more reliably.
 You can find a full documentation of this endpoint in the [API reference](https://api.qdrant.tech/api-reference/service/cluster-telemetry).
 
 ## Kubernetes health endpoints


### PR DESCRIPTION
Mentions `/cluster/telemetry` endpoint under `/telemetry` and references its API spec

[[PREVIEW](https://deploy-preview-2068--condescending-goldwasser-91acf0.netlify.app/documentation/guides/monitoring/#cluster-wide-telemetry)]