### PR TITLE
Fix code snippets in master

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-optimizer-config/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-optimizer-config/generated/go.md
@@ -10,9 +10,6 @@ client, err := qdrant.NewClient(&qdrant.Config{
 	Port: 6334,
 })
 
-if err != nil {
-	panic(err)
-
 client.CreateCollection(context.Background(), &qdrant.CreateCollection{
 	CollectionName: "{collection_name}",
 	VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-optimizer-config/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-optimizer-config/go.go
@@ -12,9 +12,7 @@ func Main() {
 		Port: 6334,
 	})
 
-	if err != nil {
-		panic(err)
-	} // @hide
+	if err != nil { panic(err) } // @hide
 
 	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
 		CollectionName: "{collection_name}",


### PR DESCRIPTION
https://github.com/qdrant/landing_page/pull/2041 renamed a Java snippet, which causes problems with the snippet checker. This fixes it by renaming it back to `java.java`.