### PR TITLE
Add banner to recommend creating payload index after collection create

### DIFF
--- a/qdrant-landing/content/documentation/concepts/indexing.md
+++ b/qdrant-landing/content/documentation/concepts/indexing.md
@@ -45,7 +45,7 @@ Payload index may occupy some additional memory, so it is recommended to only us
 If you need to filter by many fields and the memory limits do not allow for indexing all of them, it is recommended to choose the field that limits the search result the most.
 As a rule, the more different values a payload value has, the more efficiently the index will be used.
 
-<aside role="alert">It's highly recommended to create all payload indices immediately after collection creation. Creating them later may block updates for some time. HNSW graphs will also only benefit from <a href="#filtrable-index">additional optimizations</a> (extra edges) when they are generated after payload index creation.</aside>
+<aside role="alert">It's highly recommended to create all payload indices immediately after collection creation. Creating them later may block updates for some time. HNSW graphs will also only benefit from <a href="#filterable-index">additional optimizations</a> (extra edges) when they are generated after payload index creation.</aside>
 
 ### Parameterized index
 


### PR DESCRIPTION
[Render](https://deploy-preview-2091--condescending-goldwasser-91acf0.netlify.app/documentation/concepts/indexing/#payload-index:~:text=Payload%20index%20may%20occupy%20some%20additional%20memory)

Add a banner that recommends users to create payload indices as soon as possible, ideally right after collection creation.

There's two main reasons for it:
- HNSW graph search optimizations based on payloads are only applied when the respective payload indices are created before HNSW graph generation
- Creating a payload index on a large existing collection may block all updates for a (long!) time, potentially causing downtime depending on the use case

I've seen multiple cases where people have missed this, and so I think it's worth a banner.

<img width="1362" height="696" alt="image" src="https://github.com/user-attachments/assets/97b5ba62-2e3b-4414-81b5-095c6218a442" />

I'm not super satisfied with the text I put there. So I'm hoping for some nice suggestions. :smiley: 
