### PR TITLE
cleaning redundant whitespaces from segment labels

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -29,10 +29,13 @@ const nameMapper = (url) => { // Mapping names based on pathname for Segment
 /* DOM helpers */
 /***************/
 const handleClickInteraction = (event) => {
+  const rawLabel = event.target.getAttribute('data-metric-label') ?? event.target.innerText;
+  const cleanedLabel = rawLabel ? rawLabel.replace(/\s+/g, ' ').trim() : '';
+
   const payload = {
     ...PAYLOAD_BOILERPLATE,
     location: event.target.getAttribute('data-metric-loc') ?? '',
-    label: event.target.getAttribute('data-metric-label') ?? event.target.innerText,
+    label: cleanedLabel,
     action: 'clicked'
   };
 


### PR DESCRIPTION
"\n        \n        Yes\n      " -->  "Yes" (redundant white spaces caused by html markup, sometimes it's just looks better to move text after the long opening tag to the new line.