### PR TITLE
Fix problem with Go snippet compilation

### DIFF
--- a/automation/snippets/lib/languages/go.py
+++ b/automation/snippets/lib/languages/go.py
@@ -47,7 +47,11 @@ class LanguageGo(Language):
             },
         )
 
-        subprocess.run(["go", "build", "-buildvcs=false", "-o", "tester", "."], cwd=tmpdir, check=True)
+        subprocess.run(
+            ["go", "build", "-buildvcs=false", "-o", "tester", "."],
+            cwd=tmpdir,
+            check=True,
+        )
 
         return result
 


### PR DESCRIPTION
I've been running into a problem with running the code snippet build check for Go snippets. It's been returning this error:

> error obtaining VCS status: exit status 128
>	Use -buildvcs=false to disable VCS stamping.

This seems to be common in Docker containers (see for example https://www.sobyte.net/post/2023-02/go-buildvcs/) and can be resolved by adding the `-buildvcs=false` flag to the Go build command.