### PR TITLE
Update cloud quickstart to use cloud inference

### DIFF
--- a/qdrant-landing/content/documentation/cloud-quickstart.md
+++ b/qdrant-landing/content/documentation/cloud-quickstart.md
@@ -48,6 +48,7 @@ from qdrant_client.models import Distance, VectorParams, PointStruct, Document
 client = QdrantClient(
     url="https://xyz-example.eu-central.aws.cloud.qdrant.io",
     api_key="your-api-key",
+    cloud_inference=True
 )
 ```
 


### PR DESCRIPTION
This PR updates the [cloud quickstart](https://qdrant.tech/documentation/cloud-quickstart/) in two specific ways:

1. Use cloud inference instead of `fastembed` and local inference. I leverage one of the free models: `all-MiniLM-L6-v2`.
2. Introduce three new languages: Java, C#, and Golang

There were so many languages and code snippets, I ended up creating a complementary [cloud quickstart (cqs) test harness](https://github.com/qdrant/cqs-test-harness) that extracts code-snippets and runs them. To that end, I've test all code locally myself with `1.16.2` and it all appears to work great.