### PR TITLE
Documentation for the Query Audit Logs API

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query-with-filters/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query-with-filters/_description.md
@@ -1,0 +1,1 @@
+Query the audit log with time range and exact-match filters.

--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query-with-filters/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query-with-filters/bash.sh
@@ -1,0 +1,12 @@
+curl -X POST 'https://YOUR-CLUSTER-URL:6333/audit/logs' \
+  -H 'api-key: QDRANT_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "limit": 50,
+    "time_from": "2026-03-26T00:00:00Z",
+    "time_to": "2026-03-27T00:00:00Z",
+    "filters": {
+      "result": "denied",
+      "collection": "my_collection"
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query-with-filters/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query-with-filters/generated/bash.md
@@ -1,0 +1,14 @@
+```bash
+curl -X POST 'https://YOUR-CLUSTER-URL:6333/audit/logs' \
+  -H 'api-key: QDRANT_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "limit": 50,
+    "time_from": "2026-03-26T00:00:00Z",
+    "time_to": "2026-03-27T00:00:00Z",
+    "filters": {
+      "result": "denied",
+      "collection": "my_collection"
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/_description.md
@@ -1,0 +1,1 @@
+Query the audit log via the REST API.

--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/bash.sh
@@ -1,0 +1,3 @@
+curl -X POST 'https://YOUR-CLUSTER-URL:6333/audit/logs' \
+  -H 'api-key: QDRANT_API_KEY' \
+  -H 'Content-Type: application/json'

--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/bash.sh
@@ -1,3 +1,4 @@
 curl -X POST 'https://YOUR-CLUSTER-URL:6333/audit/logs' \
   -H 'api-key: QDRANT_API_KEY' \
-  -H 'Content-Type: application/json'
+  -H 'Content-Type: application/json' \
+  -d '{}'

--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/generated/bash.md
@@ -1,5 +1,6 @@
 ```bash
 curl -X POST 'https://YOUR-CLUSTER-URL:6333/audit/logs' \
   -H 'api-key: QDRANT_API_KEY' \
-  -H 'Content-Type: application/json'
+  -H 'Content-Type: application/json' \
+  -d '{}'
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-logging/query/generated/bash.md
@@ -1,0 +1,5 @@
+```bash
+curl -X POST 'https://YOUR-CLUSTER-URL:6333/audit/logs' \
+  -H 'api-key: QDRANT_API_KEY' \
+  -H 'Content-Type: application/json'
+```

--- a/qdrant-landing/content/documentation/security.md
+++ b/qdrant-landing/content/documentation/security.md
@@ -481,6 +481,11 @@ audit:
   dir: ./storage/audit
   rotation: daily
   max_log_files: 7
+  # Only enable when Qdrant is behind a trusted reverse proxy or load balancer.
+  # When true, the client IP is taken from the X-Forwarded-For header instead of
+  # the TCP connection. Enabling this on a publicly reachable instance allows
+  # clients to spoof their IP address in audit logs.
+  trust_forwarded_headers: false
 ```
 
 By default, audit logs are rotated daily, and the seven most recent log files are kept. To configure hourly rotation, set `rotation` to `hourly`. When the number of log files exceeds `max_log_files`, the oldest log file is deleted.
@@ -496,6 +501,42 @@ You can attach a tracing ID to individual requests. When audit logging is enable
 Qdrant reads the tracing ID from the first matching header in the following order: `x-request-id`, `x-tracing-id`, `traceparent`. Tracing IDs longer than 256 characters are truncated.
 
 {{< code-snippet path="/documentation/headless/snippets/audit-tracing-id/simple/" >}}
+
+### Query Audit Logs
+
+*Available as of v1.18.0*
+
+The audit log can be queried via the `/audit/logs` API (requires [manage-level access](#table-of-access)). For example:
+
+{{< code-snippet path="/documentation/headless/snippets/audit-logging/query/" >}}
+
+By default, the API returns the 100 most recent entries, but you can change this number with the `limit` parameter.
+
+In a distributed cluster, the API aggregates results from all nodes before returning them. An optional `timeout` (seconds) query parameter controls how long to wait for remote peers in a cluster.
+
+Entries are returned in reverse-chronological order (newest first). Each entry has the following fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | ISO-8601 | When the access check occurred. |
+| `method` | string | API method name, for example `upsert_points`, `search_points`. |
+| `auth_type` | `"Jwt"` \| `"ApiKey"` \| `"None"` | How the request was authenticated. |
+| `result` | `"ok"` \| `"denied"` | Whether access was granted. |
+| `subject` | string | JWT `sub` claim. Only present for JWT-authenticated requests. |
+| `remote` | string | Client IP address, if available. |
+| `collection` | string | Collection name, for collection-scoped operations. |
+| `tracing_id` | string | Value of the `x-request-id`, `x-tracing-id`, or `traceparent` request header. |
+| `error` | string | Reason access was denied. Only present when `result` is `"denied"`. |
+
+#### Narrowing Results with Time Ranges and Filters
+
+To narrow results to a specific time range, use the `time_from` (inclusive) and `time_to` (exclusive) parameters.
+
+The `filters` parameter enables exact-match filtering of entries based on specific field values. The parameter accepts a dictionary of field-value pairs. When specifying more than one pair, only entries that match all specified criteria are returned (logical AND). 
+
+For example, to retrieve the 50 most recent denied requests to the `my_collection` collection on March 26, 2026:
+
+{{< code-snippet path="/documentation/headless/snippets/audit-logging/query-with-filters/" >}}
 
 ## Network Bind
 

--- a/qdrant-landing/content/documentation/security.md
+++ b/qdrant-landing/content/documentation/security.md
@@ -510,7 +510,7 @@ The audit log can be queried via the `/audit/logs` API (requires [manage-level a
 
 {{< code-snippet path="/documentation/headless/snippets/audit-logging/query/" >}}
 
-By default, the API returns the 100 most recent entries, but you can change this number with the `limit` parameter.
+By default, the API returns the 100 most recent entries, but you can change this number with the `limit` parameter (max 10,000).
 
 In a distributed cluster, the API aggregates results from all nodes before returning them. An optional `timeout` (seconds) query parameter controls how long to wait for remote peers in a cluster.
 
@@ -532,7 +532,11 @@ Entries are returned in reverse-chronological order (newest first). Each entry h
 
 To narrow results to a specific time range, use the `time_from` (inclusive) and `time_to` (exclusive) parameters.
 
-The `filters` parameter enables exact-match filtering of entries based on specific field values. The parameter accepts a dictionary of field-value pairs. When specifying more than one pair, only entries that match all specified criteria are returned (logical AND). 
+The `filters` parameter enables exact-match filtering of entries based on specific field values. The parameter accepts a dictionary of field-value pairs. When specifying more than one pair, only entries that match all specified criteria are returned (logical AND).
+
+Unknown filter fields silently return no matches. Filter field names are case-sensitive: filtering on a field name with incorrect casing silently returns no matches.
+
+You can filter on any field in the entry fields table except `timestamp`. Use `time_from` and `time_to` for time-range filtering instead.
 
 For example, to retrieve the 50 most recent denied requests to the `my_collection` collection on March 26, 2026:
 


### PR DESCRIPTION
# [Preview](https://deploy-preview-2232--condescending-goldwasser-91acf0.netlify.app/documentation/operations/security/#query-audit-logs)

Adds documentation for the Query Audit Logs API (https://github.com/qdrant/qdrant/pull/8498)