### PR TITLE
Correct parameterized index note

### DIFF
--- a/qdrant-landing/content/documentation/manage-data/indexing.md
+++ b/qdrant-landing/content/documentation/manage-data/indexing.md
@@ -72,12 +72,15 @@ filters to `true`:
 | `false` | `true` | Parameterized integer index |
 | `false` | `false` | No integer index            |
 
-The parameterized index can enhance performance in collections with millions
-of points. We encourage you to try it out. If it does not enhance performance
-in your use case, you can always restore the regular `integer` index.
+The parameterized index may help to tune and reduce memory usage in collections
+with millions of points. We encourage you to try it out if mutual exclusively
+using range or lookup payload filter types. If you don't see an improvement or
+if you're not sure what kind of payload filters you're using, you can always go
+back the regular `integer` index.
 
-Note: If you set `"lookup": true` with a range filter, that may lead to
-significant performance issues.
+Note: If you set `"range": false` and still use a range filter, it may lead to
+significant performance issues. The same is true for the lookup parameter and
+its respective filters.
 
 For example, the following code sets up a parameterized integer index which
 supports only range filters:

--- a/qdrant-landing/content/documentation/manage-data/indexing.md
+++ b/qdrant-landing/content/documentation/manage-data/indexing.md
@@ -72,11 +72,10 @@ filters to `true`:
 | `false` | `true` | Parameterized integer index |
 | `false` | `false` | No integer index            |
 
-The parameterized index may help to tune and reduce memory usage in collections
-with millions of points. We encourage you to try it out if mutual exclusively
-using range or lookup payload filter types. If you don't see an improvement or
-if you're not sure what kind of payload filters you're using, you can always go
-back the regular `integer` index.
+Setting `lookup` or `range` to `false` may help to tune and reduce memory usage
+in large collections. We encourage you to try out if setting either to `false`
+improves memory usage. If you don't see an improvement or if you're not sure
+what kind of payload filters you're using, use the regular `integer` index.
 
 Note: If you set `"range": false` and still use a range filter, it may lead to
 significant performance issues. The same is true for the lookup parameter and

--- a/qdrant-landing/static/llms-full.txt
+++ b/qdrant-landing/static/llms-full.txt
@@ -28175,8 +28175,9 @@ The parameterized index can enhance performance in collections with millions
 of points. We encourage you to try it out. If it does not enhance performance
 in your use case, you can always restore the regular `integer` index.
 
-Note: If you set `"lookup": true` with a range filter, that may lead to
-significant performance issues.
+Note: If you set `"range": false` and still use a range filter, it may lead to
+significant performance issues. The same is true for the lookup parameter and
+its respective filters.
 
 For example, the following code sets up a parameterized integer index which
 supports only range filters:

--- a/qdrant-landing/static/llms-full.txt
+++ b/qdrant-landing/static/llms-full.txt
@@ -28171,9 +28171,11 @@ filters to `true`:
 | `false` | `true` | Parameterized integer index |
 | `false` | `false` | No integer index |
 
-The parameterized index can enhance performance in collections with millions
-of points. We encourage you to try it out. If it does not enhance performance
-in your use case, you can always restore the regular `integer` index.
+The parameterized index may help to tune and reduce memory usage in collections
+with millions of points. We encourage you to try it out if mutual exclusively
+using range or lookup payload filter types. If you don't see an improvement or
+if you're not sure what kind of payload filters you're using, you can always go
+back the regular `integer` index.
 
 Note: If you set `"range": false` and still use a range filter, it may lead to
 significant performance issues. The same is true for the lookup parameter and

--- a/qdrant-landing/static/llms-full.txt
+++ b/qdrant-landing/static/llms-full.txt
@@ -28171,11 +28171,10 @@ filters to `true`:
 | `false` | `true` | Parameterized integer index |
 | `false` | `false` | No integer index |
 
-The parameterized index may help to tune and reduce memory usage in collections
-with millions of points. We encourage you to try it out if mutual exclusively
-using range or lookup payload filter types. If you don't see an improvement or
-if you're not sure what kind of payload filters you're using, you can always go
-back the regular `integer` index.
+Setting `lookup` or `range` to `false` may help to tune and reduce memory usage
+in large collections. We encourage you to try out if setting either to `false`
+improves memory usage. If you don't see an improvement or if you're not sure
+what kind of payload filters you're using, use the regular `integer` index.
 
 Note: If you set `"range": false` and still use a range filter, it may lead to
 significant performance issues. The same is true for the lookup parameter and


### PR DESCRIPTION
[Rendered](https://deploy-preview-2263--condescending-goldwasser-91acf0.netlify.app/documentation/manage-data/indexing/#parameterized-index)

The parameterized index note elaborating on performance is confusing. This corrects it to be more explicit.

Specifically: if you disable the integer range index using `"range": false` any kind of range-based payload filter may become very very slow. It is **not** related to what setting `"lookup"` has. That is because setting `"range": false` disables the part of the index which makes range-based payload filters fast, and so it won't be able to use the optimization at search time. The default for `"range"` and `"lookup"` is `true`.

I'm not super happy about the first (modified) paragraph. @abdonpijpelink maybe you have a nice suggestion for how to reword it?
