### PR TITLE
Internal dead link checker: respect _redirects file

### DIFF
--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -27,6 +27,8 @@ jobs:
           export PATH="${CURRENT_DIR}/dart-sass:${PATH}"
           cd qdrant-landing && hugo --gc -b 'http://localhost:1314' && hugo serve --port 1314 &
           sleep 5 # wait for server to start
+      - name: Generate lychee remap config from _redirects
+        run: bash automation/generate_lychee_toml.sh > lychee.toml
       - name: Internal Links Check
         id: lychee
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421 # v1.8.0

--- a/automation/generate_lychee_toml.sh
+++ b/automation/generate_lychee_toml.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Generates lychee.toml with remap entries derived from Netlify's _redirects file.
+#
+# Each _redirects entry that maps an internal source path to an internal destination
+# is converted into a lychee remap rule so the link checker resolves old URLs to
+# their new locations instead of flagging them as broken.
+#
+# External destinations (https?://) are skipped — the internal link checker only
+# checks localhost URLs anyway.
+#
+# Usage (from repo root):
+#   bash automation/generate_lychee_toml.sh > lychee.toml
+#
+# Or with a custom base URL:
+#   bash automation/generate_lychee_toml.sh http://localhost:9000 > lychee.toml
+
+set -euo pipefail
+
+BASE="${1:-http://localhost:1314}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REDIRECTS="${SCRIPT_DIR}/../qdrant-landing/static/_redirects"
+
+if [[ ! -f "$REDIRECTS" ]]; then
+  echo "Error: _redirects file not found at ${REDIRECTS}" >&2
+  exit 1
+fi
+
+echo "# Auto-generated from qdrant-landing/static/_redirects"
+echo "# Do not edit manually — regenerate with: bash automation/generate_lychee_toml.sh > lychee.toml"
+echo ""
+echo "remap = ["
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  # Skip blank lines and comments
+  [[ -z "${line//[[:space:]]/}" ]] && continue
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+  # Parse whitespace-separated fields; _rest captures the status code and any trailing content
+  read -r src dest _rest <<< "$line"
+
+  # Skip entries whose destination is an external URL
+  [[ "$dest" =~ ^https?:// ]] && continue
+
+  if [[ "$src" == *"/*" ]]; then
+    # Wildcard entry: /old/path/* -> /new/path/:splat
+    prefix="${src%\/*}"                        # strip trailing /*
+    repl="${dest//:splat/\$1}"                 # :splat -> $1 (literal, not expanded)
+    printf '  "%s%s/(.*) %s%s",\n' "$BASE" "$prefix" "$BASE" "$repl"
+  else
+    # Simple entry: /old/path -> /new/path
+    printf '  "%s%s %s%s",\n' "$BASE" "$src" "$BASE" "$dest"
+  fi
+done < "$REDIRECTS"
+
+echo "]"

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,27 @@
+# Auto-generated from qdrant-landing/static/_redirects
+# Do not edit manually — regenerate with: bash automation/generate_lychee_toml.sh > lychee.toml
+
+remap = [
+  "http://localhost:1314/documentation/guides/optimize/(.*) http://localhost:1314/documentation/operations/optimize/$1",
+  "http://localhost:1314/documentation/guides/distributed_deployment/(.*) http://localhost:1314/documentation/operations/distributed_deployment/$1",
+  "http://localhost:1314/documentation/guides/capacity-planning/(.*) http://localhost:1314/documentation/operations/capacity-planning/$1",
+  "http://localhost:1314/documentation/guides/security/(.*) http://localhost:1314/documentation/operations/security/$1",
+  "http://localhost:1314/documentation/guides/monitoring/(.*) http://localhost:1314/documentation/operations/monitoring/$1",
+  "http://localhost:1314/documentation/guides/configuration/(.*) http://localhost:1314/documentation/operations/configuration/$1",
+  "http://localhost:1314/documentation/guides/installation/(.*) http://localhost:1314/documentation/operations/installation/$1",
+  "http://localhost:1314/documentation/guides/administration/(.*) http://localhost:1314/documentation/operations/administration/$1",
+  "http://localhost:1314/documentation/guides/quantization/(.*) http://localhost:1314/documentation/manage-data/quantization/$1",
+  "http://localhost:1314/documentation/guides/multiple-partitions/(.*) http://localhost:1314/documentation/manage-data/multitenancy/$1",
+  "http://localhost:1314/documentation/guides/multitenancy/(.*) http://localhost:1314/documentation/manage-data/multitenancy/$1",
+  "http://localhost:1314/documentation/concepts/explore/(.*) http://localhost:1314/documentation/search/explore/$1",
+  "http://localhost:1314/documentation/concepts/filtering/(.*) http://localhost:1314/documentation/search/filtering/$1",
+  "http://localhost:1314/documentation/concepts/hybrid-queries/(.*) http://localhost:1314/documentation/search/hybrid-queries/$1",
+  "http://localhost:1314/documentation/concepts/collections/(.*) http://localhost:1314/documentation/manage-data/collections/$1",
+  "http://localhost:1314/documentation/concepts/indexing/(.*) http://localhost:1314/documentation/manage-data/indexing/$1",
+  "http://localhost:1314/documentation/concepts/vectors/(.*) http://localhost:1314/documentation/manage-data/vectors/$1",
+  "http://localhost:1314/documentation/concepts/storage/(.*) http://localhost:1314/documentation/manage-data/storage/$1",
+  "http://localhost:1314/documentation/concepts/snapshots/(.*) http://localhost:1314/documentation/operations/snapshots/$1",
+  "http://localhost:1314/documentation/concepts/optimizer/(.*) http://localhost:1314/documentation/operations/optimizer/$1",
+  "http://localhost:1314/documentation/concepts/inference/(.*) http://localhost:1314/documentation/inference/$1",
+  "http://localhost:1314/documentation/quickstart-cloud/(.*) http://localhost:1314/documentation/cloud-quickstart/$1",
+]


### PR DESCRIPTION
When we move a page, it causes the dead link checker to report a 404 for the markdown version of the moved page, even when setting up an alias or an entry in `_redirects`. This is caused by: 1) Hugo not creating stub files for aliases for alternate output formats like MD, and 2) Lychee not supporting a `_redirects` file.

The reported 404s are false positives, because once deployed, the `_redirects` file causes server-side 301s, and any client would be served the redirected page.

This PR modifies the internal dead links checker such that it does take into account the `_redirects` file. It adds a step that converts the `_redirects` file into a `lychee.toml` configuration file with a `remap` entry for each redirect.