### PR TITLE
chore: ignore local tooling artifacts and lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__
 qdrant-landing/.DS_Store
 .DS_Store
+.tools/
+package-lock.json
+.claude/


### PR DESCRIPTION
## Summary
- Add `.tools/` to root `.gitignore`
- Add `.claude/` to root `.gitignore`
- Add `package-lock.json` to root `.gitignore` to avoid committing generated lockfiles in this repo setup

## Why
These files/directories are local or generated artifacts and should not be tracked in git.