### PR TITLE
Document audit logging tracing ID support (v1.18.0)

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/_description.md
@@ -1,0 +1,1 @@
+Attach a tracing ID to a request so it appears in the audit log entry for that request.

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/bash.sh
@@ -1,0 +1,3 @@
+curl -X GET http://localhost:6333/collections \
+    --header 'api-key: your_api_key_here' \
+    --header 'x-request-id: my-trace-id'

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/csharp.cs
@@ -1,0 +1,12 @@
+using Qdrant.Client;
+
+public class Snippet
+{
+    public static async Task Run()
+    {
+        var client = new QdrantClient("localhost", 6334);
+
+        using (RequestHeaders.Use("x-request-id", "my-trace-id"))
+            await client.ListCollectionsAsync();
+    }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/csharp.cs
@@ -4,7 +4,9 @@ public class Snippet
 {
     public static async Task Run()
     {
+        // @hide-start
         var client = new QdrantClient("localhost", 6334);
+        // @hide-end
 
         using (RequestHeaders.Use("x-request-id", "my-trace-id"))
             await client.ListCollectionsAsync();

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/bash.md
@@ -1,0 +1,5 @@
+```bash
+curl -X GET http://localhost:6333/collections \
+    --header 'api-key: your_api_key_here' \
+    --header 'x-request-id: my-trace-id'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/csharp.md
@@ -1,0 +1,6 @@
+```csharp
+using Qdrant.Client;
+
+using (RequestHeaders.Use("x-request-id", "my-trace-id"))
+    await client.ListCollectionsAsync();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/go.md
@@ -1,0 +1,10 @@
+```go
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+ctx := qdrant.WithHeader(context.Background(), "x-request-id", "my-trace-id")
+client.ListCollections(ctx)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/java.md
@@ -1,0 +1,9 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.RequestHeaders;
+import io.grpc.Context;
+
+Context ctx = RequestHeaders.withHeader(Context.current(), "x-request-id", "my-trace-id");
+ctx.run(() -> client.listCollectionsAsync());
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/python.md
@@ -1,4 +1,6 @@
 ```python
+from qdrant_client import QdrantClient, headers
+
 with headers({"x-request-id": "my-trace-id"}):
     client.get_collections()
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/python.md
@@ -1,0 +1,4 @@
+```python
+with headers({"x-request-id": "my-trace-id"}):
+    client.get_collections()
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/rust.md
@@ -1,0 +1,8 @@
+```rust
+use qdrant_client::Qdrant;
+
+client
+    .with_header("x-request-id", "my-trace-id")
+    .list_collections()
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/generated/typescript.md
@@ -1,0 +1,7 @@
+```typescript
+import { QdrantClient, withHeaders } from "@qdrant/js-client-rest";
+
+const result = await withHeaders({ "x-request-id": "my-trace-id" }, () =>
+    client.getCollections()
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/go.go
@@ -7,8 +7,10 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{Host: "localhost", Port: 6334})
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	ctx := qdrant.WithHeader(context.Background(), "x-request-id", "my-trace-id")
 	client.ListCollections(ctx)

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/go.go
@@ -1,0 +1,15 @@
+package snippet
+
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{Host: "localhost", Port: 6334})
+	if err != nil { panic(err) } // @hide
+
+	ctx := qdrant.WithHeader(context.Background(), "x-request-id", "my-trace-id")
+	client.ListCollections(ctx)
+}

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/java.java
@@ -7,8 +7,10 @@ import io.grpc.Context;
 
 public class Snippet {
     public static void run() throws Exception {
+        // @hide-start
         QdrantClient client = new QdrantClient(
             QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+        // @hide-end
 
         Context ctx = RequestHeaders.withHeader(Context.current(), "x-request-id", "my-trace-id");
         ctx.run(() -> client.listCollectionsAsync());

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/java.java
@@ -1,0 +1,16 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.RequestHeaders;
+import io.grpc.Context;
+
+public class Snippet {
+    public static void run() throws Exception {
+        QdrantClient client = new QdrantClient(
+            QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+        Context ctx = RequestHeaders.withHeader(Context.current(), "x-request-id", "my-trace-id");
+        ctx.run(() -> client.listCollectionsAsync());
+    }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/python.py
@@ -1,0 +1,6 @@
+from qdrant_client import QdrantClient, headers  # @hide
+
+client = QdrantClient(url="http://localhost:6333")  # @hide
+
+with headers({"x-request-id": "my-trace-id"}):
+    client.get_collections()

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/python.py
@@ -1,4 +1,4 @@
-from qdrant_client import QdrantClient, headers  # @hide
+from qdrant_client import QdrantClient, headers
 
 client = QdrantClient(url="http://localhost:6333")  # @hide
 

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/rust.rs
@@ -1,0 +1,8 @@
+use qdrant_client::Qdrant;
+
+let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
+
+client
+    .with_header("x-request-id", "my-trace-id")
+    .list_collections()
+    .await?;

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/rust.rs
@@ -1,8 +1,12 @@
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
-client
-    .with_header("x-request-id", "my-trace-id")
-    .list_collections()
-    .await?;
+    client
+        .with_header("x-request-id", "my-trace-id")
+        .list_collections()
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/audit-tracing-id/simple/typescript.ts
@@ -1,0 +1,7 @@
+import { QdrantClient, withHeaders } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
+
+const result = await withHeaders({ "x-request-id": "my-trace-id" }, () =>
+    client.getCollections()
+);

--- a/qdrant-landing/content/documentation/security.md
+++ b/qdrant-landing/content/documentation/security.md
@@ -487,6 +487,16 @@ By default, audit logs are rotated daily, and the seven most recent log files ar
 
 <aside role="alert">Audit logging is verbose and audit logs can grow in size rapidly. Ensure that you have sufficient disk space.</aside>
 
+### Tracing IDs
+
+*Available as of v1.18.0*
+
+You can attach a tracing ID to individual requests. When audit logging is enabled, Qdrant includes the tracing ID in the audit log entry, making it easy to correlate client-side operations with their corresponding log entries.
+
+Qdrant reads the tracing ID from the first matching header in the following order: `x-request-id`, `x-tracing-id`, `traceparent`. Tracing IDs longer than 256 characters are truncated.
+
+{{< code-snippet path="/documentation/headless/snippets/audit-tracing-id/simple/" >}}
+
 ## Network Bind
 
 By default, a custom Qdrant deployment binds to all network interfaces. Your

--- a/qdrant-landing/content/documentation/security.md
+++ b/qdrant-landing/content/documentation/security.md
@@ -491,7 +491,7 @@ By default, audit logs are rotated daily, and the seven most recent log files ar
 
 *Available as of v1.18.0*
 
-You can attach a tracing ID to individual requests. When audit logging is enabled, Qdrant includes the tracing ID in the audit log entry, making it easy to correlate client-side operations with their corresponding log entries.
+You can attach a tracing ID to individual requests. When audit logging is enabled, Qdrant includes the tracing ID in the audit log entry, enabling the correlation of client-side operations with their corresponding log entries.
 
 Qdrant reads the tracing ID from the first matching header in the following order: `x-request-id`, `x-tracing-id`, `traceparent`. Tracing IDs longer than 256 characters are truncated.
 


### PR DESCRIPTION
Adds documentation for tracing IDs in audit logging (https://github.com/qdrant/qdrant/pull/8402)