### PR TITLE
Document per-collection metrics (v1.18.0)

### DIFF
--- a/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
@@ -164,8 +164,6 @@ grpc_responses_total{endpoint="/qdrant.Points/Search",status="0",collection="my-
 
 The `endpoint` label uses the route template, not the resolved path. The actual collection name is in the separate `collection` label.
 
-Only endpoints in the search, query, recommend, scroll, upsert, discover, facet, and payload families are tracked. Collection-info, listing, and snapshot endpoints don't appear in either mode.
-
 <aside role="status">Per-collection metrics increase the cardinality of the <code>/metrics</code> output. In deployments with many collections, ensure that your monitoring infrastructure can handle the additional label values.</aside>
 
 ## Telemetry Endpoint

--- a/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
@@ -94,6 +94,8 @@ Counters - such as the number of created snapshots - are reset when the node is 
 
 [^metrics-per-collection]: When `/metrics?per_collection=true` is used, these metrics include a `collection` label. See [Per-Collection API Metrics](#per-collection-api-metrics).
 
+ The output does not include metrics for the collection info, listing, and snapshot endpoints.
+
 **Process Metrics**
 
 | Name                                | Type    | Meaning                                                                                                                       |
@@ -147,20 +149,22 @@ QDRANT__SERVICE__METRICS_PREFIX="qdrant_"
 
 *Available as of v1.18.0*
 
-By default, the API response metrics (`rest_responses_*`, `grpc_responses_*`) are global — they don't distinguish between collections. You can request per-collection breakdowns by adding `?per_collection=true` to the `/metrics` endpoint:
+By default, the API response metrics (`rest_responses_*`, `grpc_responses_*`) are global — they don't distinguish between collections. To request per-collection breakdowns, add `?per_collection=true` to the `/metrics` endpoint:
 
 ```bash
 curl http://localhost:6333/metrics?per_collection=true
 ```
 
-When enabled, metrics such as `rest_responses_total` and `grpc_responses_total` include a `collection` label:
+Enabling per-collection mode replaces the global metrics entirely. The unlabeled `rest_responses_total` and `grpc_responses_total` are not returned when per-collection data is enabled. Instead, `rest_responses_total` carries four labels (`method`, `endpoint`, `status`, `collection`) and `grpc_responses_total` carries three (`endpoint`, `status`, `collection`):
 
-```
-rest_responses_total{endpoint="/collections/{name}/points/search",collection="my-collection",status="200"} 42
-grpc_responses_total{endpoint="/qdrant.Points/Search",collection="my-collection",status="Ok"} 17
+```text
+rest_responses_total{method="POST",endpoint="/collections/{collection_name}/points/search",status="200",collection="my-collection"} 42
+grpc_responses_total{endpoint="/qdrant.Points/Search",status="0",collection="my-collection"} 17
 ```
 
-Without `?per_collection=true`, the same metrics omit the collection label and report global totals — this is the default behavior.
+The `endpoint` label uses the route template, not the resolved path. The actual collection name is in the separate `collection` label.
+
+Only endpoints in the search, query, recommend, scroll, upsert, discover, facet, and payload families are tracked. Collection-info, listing, and snapshot endpoints don't appear in either mode.
 
 <aside role="status">Per-collection metrics increase the cardinality of the <code>/metrics</code> output. In deployments with many collections, ensure that your monitoring infrastructure can handle the additional label values.</aside>
 

--- a/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
@@ -79,18 +79,20 @@ Counters - such as the number of created snapshots - are reset when the node is 
 
 | Name                                | Type      | Meaning                                                            |
 | ----------------------------------- | --------- | ------------------------------------------------------------------ |
-| rest_responses_total                | counter   | Number of responses through REST API                               |
+| rest_responses_total                | counter   | Number of responses through REST API [^metrics-per-collection]     |
 | rest_responses_fail_total           | counter   | Number of failed responses through REST API                        |
 | rest_responses_avg_duration_seconds | gauge     | Average response duration in REST API                              |
 | rest_responses_min_duration_seconds | gauge     | Minimum response duration in REST API                              |
 | rest_responses_max_duration_seconds | gauge     | Maximum response duration in REST API                              |
 | rest_responses_duration_seconds     | histogram | Histogram of response durations in the REST API <sup>(v1.8+)</sup> |
-| grpc_responses_total                | counter   | Number of responses through gRPC API                               |
+| grpc_responses_total                | counter   | Number of responses through gRPC API [^metrics-per-collection]     |
 | grpc_responses_fail_total           | counter   | Number of failed responses through REST API                        |
 | grpc_responses_avg_duration_seconds | gauge     | Average response duration in gRPC API                              |
 | grpc_responses_min_duration_seconds | gauge     | Minimum response duration in gRPC API                              |
 | grpc_responses_max_duration_seconds | gauge     | Maximum response duration in gRPC API                              |
 | grpc_responses_duration_seconds     | histogram | Histogram of response durations in the gRPC API <sup>(v1.8+)</sup> |
+
+[^metrics-per-collection]: When `/metrics?per_collection=true` is used, these metrics include a `collection` label. See [Per-Collection API Metrics](#per-collection-api-metrics).
 
 **Process metrics**
 
@@ -140,6 +142,27 @@ To achieve this you may use the following environment variable for example:
 ```bash
 QDRANT__SERVICE__METRICS_PREFIX="qdrant_"
 ```
+
+### Per-Collection API Metrics
+
+*Available as of v1.18.0*
+
+By default, the API response metrics (`rest_responses_*`, `grpc_responses_*`) are global — they don't distinguish between collections. You can request per-collection breakdowns by adding `?per_collection=true` to the `/metrics` endpoint:
+
+```bash
+curl http://localhost:6333/metrics?per_collection=true
+```
+
+When enabled, metrics such as `rest_responses_total` and `grpc_responses_total` include a `collection` label:
+
+```
+rest_responses_total{endpoint="/collections/{name}/points/search",collection="my-collection",status="200"} 42
+grpc_responses_total{endpoint="/qdrant.Points/Search",collection="my-collection",status="Ok"} 17
+```
+
+Without `?per_collection=true`, the same metrics omit the collection label and report global totals — this is the default behavior.
+
+<aside role="status">Per-collection metrics increase the cardinality of the <code>/metrics</code> output. In deployments with many collections, ensure that your monitoring infrastructure can handle the additional label values.</aside>
 
 ## Telemetry endpoint
 

--- a/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
@@ -31,20 +31,20 @@ Two endpoints are available:
 
 Note that `/metrics` only reports metrics for the peer connected to. It is therefore important to scrape from each peer individually, even if a load balancer is involved.
 
-### Node metrics `/metrics`
+### Node Metrics `/metrics`
 
 Each Qdrant node will expose the following metrics.
 
 Counters - such as the number of created snapshots - are reset when the node is restarted.
 
-**Application metrics**
+**Application Metrics**
 
 | Name                                | Type    | Meaning                        |
 | ----------------------------------- | ------- | ------------------------------ |
 | app_info                            | gauge   | Qdrant server name and version |
 | app_status_recovery_mode            | gauge   | If started in recovery mode    |
 
-**Collection metrics**
+**Collection Metrics**
 
 | Name                                              | Type    | Meaning                                                                                               |
 | ------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
@@ -67,7 +67,7 @@ Counters - such as the number of created snapshots - are reset when the node is 
 
 [^metrics-hwreporting]: Only reported if hardware metrics are enabled in the configuration. See `service.hardware_reporting` in the [configuration](/documentation/ops-configuration/configuration/).
 
-**Snapshot metrics**
+**Snapshot Metrics**
 
 | Name                                    | Type    | Meaning                                                                     |
 | --------------------------------------- | ------- | --------------------------------------------------------------------------- |
@@ -75,7 +75,7 @@ Counters - such as the number of created snapshots - are reset when the node is 
 | snapshot_recovery_running               | gauge   | Number of snapshots being recovered, per collection <sup>(v1.16+)</sup>     |
 | snapshot_created_total                  | counter | Number of created snapshots since start, per collection <sup>(v1.16+)</sup> |
 
-**API response metrics**
+**API Response Metrics**
 
 | Name                                | Type      | Meaning                                                            |
 | ----------------------------------- | --------- | ------------------------------------------------------------------ |
@@ -94,7 +94,7 @@ Counters - such as the number of created snapshots - are reset when the node is 
 
 [^metrics-per-collection]: When `/metrics?per_collection=true` is used, these metrics include a `collection` label. See [Per-Collection API Metrics](#per-collection-api-metrics).
 
-**Process metrics**
+**Process Metrics**
 
 | Name                                | Type    | Meaning                                                                                                                       |
 | ----------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
@@ -111,7 +111,7 @@ Counters - such as the number of created snapshots - are reset when the node is 
 | process_minor_page_faults_total     | counter | Number of minor page faults encountered by the process <sup>(v1.16+)</sup>                                                    |
 | process_major_page_faults_total     | counter | Number of major page faults encountered by the process <sup>(v1.16+)</sup>                                                    |
 
-**Cluster metrics (consensus)**
+**Cluster Metrics (Consensus)**
 
 Metrics reporting the current cluster consensus state of the node. Exposed only
 when distributed mode is enabled.
@@ -127,7 +127,7 @@ when distributed mode is enabled.
 
 [^metrics-distributed]: Only reported if distributed mode (cluster mode) is enabled. Enabled by default in all Qdrant Cloud environments. See `cluster.enabled` in the [configuration](/documentation/ops-configuration/configuration/).
 
-### Metrics configuration
+### Metrics Configuration
 
 *Available as of v1.16.0*
 
@@ -164,18 +164,18 @@ Without `?per_collection=true`, the same metrics omit the collection label and r
 
 <aside role="status">Per-collection metrics increase the cardinality of the <code>/metrics</code> output. In deployments with many collections, ensure that your monitoring infrastructure can handle the additional label values.</aside>
 
-## Telemetry endpoint
+## Telemetry Endpoint
 
 Qdrant also provides a `/telemetry` endpoint, which provides information about the current state of the database, including the number of vectors, shards, and other useful information. You can find the full documentation for this endpoint in the [API reference](https://api.qdrant.tech/api-reference/service/telemetry).
 
-## Cluster-wide telemetry
+## Cluster-Wide Telemetry
 
 The `/telemetry` endpoint reports from the point of view of the peer being queried. Qdrant also provides a `/cluster/telemetry` endpoint, which aggregates telemetry from all peers.
 
 This includes less information than `/telemetry`, but provides information like shard transfer progress more reliably.
 You can find the full documentation for this endpoint in the [API reference](https://api.qdrant.tech/api-reference/service/cluster-telemetry).
 
-## Kubernetes health endpoints
+## Kubernetes Health Endpoints
 
 *Available as of v1.5.0*
 


### PR DESCRIPTION
# [Preview](https://deploy-preview-2288--condescending-goldwasser-91acf0.netlify.app/documentation/ops-monitoring/monitoring/#per-collection-api-metrics)

Adds documentation for per-collection metrics (https://github.com/qdrant/qdrant/pull/8214)