### PR TITLE
Use section titles in docs breadcrumbs

### DIFF
--- a/qdrant-landing/content/documentation/_index.md
+++ b/qdrant-landing/content/documentation/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: Documentation
 weight: 2
 hideTOC: true
 breadcrumb: false

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/documentation/breadcrumbs.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/documentation/breadcrumbs.html
@@ -5,7 +5,9 @@
   {{ range first $len $paths }}
     {{ if gt (len . ) 0 }}
       {{ $rellink = printf "%s/%s" $rellink . }}
-      <li class="docs-breadcrumbs__crumb"><a href="{{ $rellink }}/">{{ humanize . }}</a></li>
+      {{ $section := $.Site.GetPage $rellink }}
+      {{ $label := cond (ne $section nil) $section.Title (humanize .) }}
+      <li class="docs-breadcrumbs__crumb"><a href="{{ $rellink }}/">{{ $label }}</a></li>
       <li class="docs-breadcrumbs__crumb-separator"></li>
     {{ end }}
   {{ end }}


### PR DESCRIPTION
The breadcrumbs at the top of the navigation currently use the URL slugs as display values. This is not ideal for some URLs, for example:

<img width="592" height="73" alt="image" src="https://github.com/user-attachments/assets/02b90af9-4105-41a1-b56b-360a8d5e517f" />

This PR changes that so the breadcrumbs use the section title instead of the URL slugs. If no section title is defined, it falls back to the URL slug. Result:

<img width="664" height="63" alt="image" src="https://github.com/user-attachments/assets/d61eb2b3-5df7-4b59-a9d0-43abc2723c06" />

This PR also renames the "Home" section into "Documentation", to match the original breadcrumb. This has the side effect that page `<title>`s (and as a result, also browser tabs) now say "Documentation" instead of "Home", which IMO is an improvement.