### PR TITLE
Code snippet widget: sync and persist language selection

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/lang-switcher.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/lang-switcher.js
@@ -1,4 +1,14 @@
 (function () {
+  const STORAGE_KEY = 'preferred-lang';
+
+  function saveLanguage(lang) {
+    try { localStorage.setItem(STORAGE_KEY, lang); } catch (_) {}
+  }
+
+  function loadLanguage() {
+    try { return localStorage.getItem(STORAGE_KEY); } catch (_) { return null; }
+  }
+
   /**
    * @class LangSwitcher
    * create tabs with buttons to switching
@@ -51,6 +61,10 @@
       this.#setActiveButton(lang);
     }
 
+    hasLang(lang) {
+      return this.tabs.some(t => t.querySelector(`code.language-${lang}`) !== null);
+    }
+
     setTabs(tabs) {
       tabs[0].active = true;
       this.tabs = tabs;
@@ -89,21 +103,39 @@
     }
   }
 
+  const allSwitchers = [];
+
   /**
    * init switcher for each group of tabs
    */
   tabsGroups.forEach((g, i) => {
     const langSwitcher = new LangSwitcher(g);
     langSwitcher.initLangButtons();
+    allSwitchers.push(langSwitcher);
 
     const tabBtns = langSwitcher.getLangButtons();
     if (tabBtns) {
-      langSwitcher.getLangButtons().addEventListener('click', (e) => {
+      tabBtns.addEventListener('click', (e) => {
         const button = e.target.closest('.lang-tabs__button');
         if (button && button.dataset.lang) {
-          langSwitcher.switchLanguage(button.dataset.lang);
+          const lang = button.dataset.lang;
+          langSwitcher.switchLanguage(lang);
+          saveLanguage(lang);
+          allSwitchers.forEach(s => {
+            if (s !== langSwitcher && s.hasLang(lang)) {
+              s.switchLanguage(lang);
+            }
+          });
         }
       });
     }
   });
+
+  // Apply stored language preference on page load
+  const saved = loadLanguage();
+  if (saved) {
+    allSwitchers.forEach(s => {
+      if (s.hasLang(saved)) s.switchLanguage(saved);
+    });
+  }
 }).call(this);


### PR DESCRIPTION
Currently, clicking a language tab of the code snippet widget only switches the current widget. The other widgets don't change to the selected language and the selection is not persisted across page loads.

This PR switches the behavior so all other code-snippet widgets on the page also switch to the same language. The choice is saved to localStorage and it is auto-applied on future page loads.

## Preview

1. Navigate to https://deploy-preview-2291--condescending-goldwasser-91acf0.netlify.app/documentation/manage-data/points/#update-mode
2. Select a language on one of the code snippet widgets
3. Check all code snippet widgets on the page now show the selected language
4. Navigate to https://deploy-preview-2291--condescending-goldwasser-91acf0.netlify.app/documentation/manage-data/storage/#configuring-memmap-storage
5. Check all code snippet widgets on the page show the previously selected language

## Details of the change

- `hasLang(lang)` — new method on `LangSwitcher` to check if a widget has a given language tab (prevents errors when broadcasting to incompatible widgets).
- `allSwitchers` registry — all instances are collected so they can be coordinated.
- Click handler — after switching locally, saves to `localStorage` and calls `switchLanguage` on every other switcher that supports that language.
- Page load — reads the saved preference and applies it to all widgets before the user interacts.