### PR TITLE
docs: fix small typos in case studies files

### DIFF
--- a/qdrant-landing/content/blog/case-study-aracor.md
+++ b/qdrant-landing/content/blog/case-study-aracor.md
@@ -28,7 +28,7 @@ partition: case-studies
 
 The world of mergers and acquisitions (M\&A) is notoriously painstaking, slow, expensive and error-prone. Lawyers spend weeks combing through thousands of documents—validating signatures, comparing versions, and flagging risks.
 
-Lawyers and dealmakers sift through mountains of documents—often numbering into the thousands—to validate every detail, from validating signatures, comparing the documents involved in the deal transaction, flagging risks to to patent validity. This meticulous process typically drains weeks or even months of productivity from highly trained professionals. [Aracor AI](https://aracor.ai/) set out to change that and to solve the M\&A transparency gap. The Miami-based AI platform is laser-focused on transforming this painstaking due diligence into an automated, accurate, and dramatically faster operation.
+Lawyers and dealmakers sift through mountains of documents—often numbering into the thousands—to validate every detail, from validating signatures, comparing the documents involved in the deal transaction, and flagging risks to patent validity. This meticulous process typically drains weeks or even months of productivity from highly trained professionals. [Aracor AI](https://aracor.ai/) set out to change that and to solve the M\&A transparency gap. The Miami-based AI platform is laser-focused on transforming this painstaking due diligence into an automated, accurate, and dramatically faster operation.
 
 ### The Challenge: Mountains of Documents, Mountains of Pain
 

--- a/qdrant-landing/content/blog/case-study-dailymotion.md
+++ b/qdrant-landing/content/blog/case-study-dailymotion.md
@@ -126,7 +126,7 @@ Looking at the complexity, scale and adaptability of the desired solution, the t
 
 ![data-processing](/case-studies/dailymotion/data-processing-pipeline.png)
 
-Figure shows the streaming architecture of the data processing pipeline that processes everytime a new video is uploaded or updated (Title, Description, Tags, Transcript), an updated embedding is computed and fed directly into Qdrant.
+Figure shows the streaming architecture of the data processing pipeline that processes every time a new video is uploaded or updated (Title, Description, Tags, Transcript), an updated embedding is computed and fed directly into Qdrant.
 
 
 ### Results

--- a/qdrant-landing/content/blog/case-study-deutsche-telekom.md
+++ b/qdrant-landing/content/blog/case-study-deutsche-telekom.md
@@ -86,7 +86,7 @@ Deutsche Telekom's engineers also cited several standout features that made Qdra
 
 As part of their evaluation, Deutsche Telekom engineers compared multiple solutions, weighing operational simplicity and reliability. 
 
-One engineer summarized their findings: "Qdrant has way fewer components, compared to the another that required required Kafka, Zookeeper, and only had a hot standby for its index and query nodes. If you rescale it, you get downtime. Qdrant stays up." 
+One engineer summarized their findings: "Qdrant has way fewer components, compared to the other solution that required Kafka, Zookeeper, and only had a hot standby for its index and query nodes. If you rescale it, you get downtime. Qdrant stays up." 
 
 ### Scaling AI at Deutsche Telekom & The Future of LMOS
 

--- a/qdrant-landing/content/blog/case-study-glassdollar.md
+++ b/qdrant-landing/content/blog/case-study-glassdollar.md
@@ -77,7 +77,7 @@ A key requirement for GlassDollar was staying productive in a Node.js and TypeSc
 
 This mattered for hiring and velocity. It enabled engineers who already shipped product in JavaScript and TypeScript to implement modern RAG pipelines without maintaining a separate Python-only stack.
 
-## User Engagement Rripled After Retrieval Quality Improved
+## User Engagement Tripled After Retrieval Quality Improved
 
 GlassDollar tracked success through product behavior. One signal was how often users saved (bookmarked) companies during sourcing workflows. Before the search improvements, many users either relied on manual sourcing or browsed results without committing them into a shortlist.
 
@@ -85,6 +85,6 @@ After migrating to Qdrant and scaling their recall-focused retrieval strategy, s
 
 ## Next Steps Focus on Repeatable Feedback Loops for Accuracy Gains
 
-With retrieval scalability in place, GlassDollar’s roadmap centers on continuous accuracy improvements across the full RAG architecture. They will continue optimizing query expansion strategy and improving reraking models to continually improve.
+With retrieval scalability in place, GlassDollar’s roadmap centers on continuous accuracy improvements across the full RAG architecture. They will continue optimizing query expansion strategy and improving reranking models to continually improve.
 
 The goal remains consistent: deliver the most accurate matchmaking between corporate pain points and startups through a search built for high-recall, decision-ready results. 

--- a/qdrant-landing/content/blog/case-study-kairoswealth.md
+++ b/qdrant-landing/content/blog/case-study-kairoswealth.md
@@ -52,9 +52,9 @@ Kairoswealth leverages Qdrant for several key use cases:
 
 Some of the key reasons, why Kairoswealth landed on Qdrant as the vector database of choice are:
 
-1. **High Performance with 2.4M Vectors:** “Qdrant efficiently handled the indexing of 1.2 million vectors with 16 metadata fields each, maintaining high performance with no degradation. Similarity queries and scrolls run in less than 0.3 seconds. When we doubled the dataset to 2.4 million vectors, performance remained consistent.So we decided to double that to 2.4M vectors, and it's as if we were inserting our first vector!” says Teyssier.
+1. **High Performance with 2.4M Vectors:** “Qdrant efficiently handled the indexing of 1.2 million vectors with 16 metadata fields each, maintaining high performance with no degradation. Similarity queries and scrolls run in less than 0.3 seconds. When we doubled the dataset to 2.4 million vectors, performance remained consistent. So we decided to double that to 2.4M vectors, and it's as if we were inserting our first vector!” says Teyssier.
 2. **8x Memory Efficiency:** The database storage size with Qdrant was eight times smaller than the previous solution, enabling the deployment of the entire dataset on smaller instances and saving significant infrastructure costs.
-3. **Embedded Capabilities:** “Beyond simple search and similarity, Qdrant hosts a bunch of very nice features around recommendation engines, adding positive and negative examples for better spacial narrowing, efficient multi-tenancy, and many more,” says Teyssier.
+3. **Embedded Capabilities:** “Beyond simple search and similarity, Qdrant hosts a bunch of very nice features around recommendation engines, adding positive and negative examples for better spatial narrowing, efficient multi-tenancy, and many more,” says Teyssier.
 4. **Support and Community:** “The Qdrant team, led by Andre Zayarni, provides exceptional support and has a strong passion for data engineering,” notes Teyssier, “the team's commitment to open-source and their active engagement in helping users, from beginners to veterans, is highly valued by Kairoswealth.”
 
 ## **Conclusion**


### PR DESCRIPTION
 ## description
  fixes several typos and wording mistakes across case-study markdown files, including the GlassDollar `Rripled` typo flagged by one of the members on discord server

  ## changes
  - Corrected spelling, duplicated words only in blog docs case-study related files 