### PR TITLE
Document new strict_mode_config parameters (v1.18.0)

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `max_resident_memory_percent` on the strict mode configuration to reject memory-consuming write operations when resident memory exceeds the given percentage of total system memory.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/bash.sh
@@ -1,0 +1,8 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "max_resident_memory_percent": 90
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/csharp.cs
@@ -1,0 +1,15 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig { Enabled = true, MaxResidentMemoryPercent = 90 }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/bash.md
@@ -1,0 +1,10 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "max_resident_memory_percent": 90
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/csharp.md
@@ -1,0 +1,11 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig { Enabled = true, MaxResidentMemoryPercent = 90 }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/go.md
@@ -1,0 +1,20 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    MaxResidentMemoryPercent: qdrant.PtrOf(uint32(90)),
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/java.md
@@ -1,0 +1,18 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder().setEnabled(true).setMaxResidentMemoryPercent(90).build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/python.md
@@ -1,0 +1,10 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, max_resident_memory_percent=90),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/rust.md
@@ -1,0 +1,13 @@
+```rust
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}")
+            .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).max_resident_memory_percent(90u32)),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/generated/typescript.md
@@ -1,0 +1,12 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    max_resident_memory_percent: 90,
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/go.go
@@ -1,0 +1,24 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    MaxResidentMemoryPercent: qdrant.PtrOf(uint32(90)),
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/http.md
@@ -1,0 +1,9 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "max_resident_memory_percent": 90
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/java.java
@@ -1,0 +1,22 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder().setEnabled(true).setMaxResidentMemoryPercent(90).build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/python.py
@@ -1,0 +1,8 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, max_resident_memory_percent=90),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/rust.rs
@@ -1,0 +1,15 @@
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}")
+                .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).max_resident_memory_percent(90u32)),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-resident-memory-percent/typescript.ts
@@ -1,0 +1,10 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    max_resident_memory_percent: 90,
+  },
+});

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `multivector_config` on the strict mode configuration to cap the maximum number of vectors per multivector for a named vector.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/bash.sh
@@ -1,0 +1,12 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "multivector_config": {
+        "{vector_name}": {
+          "max_vectors": 10
+        }
+      }
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/csharp.cs
@@ -1,0 +1,22 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig
+		  {
+		    Enabled = true,
+		    MultivectorConfig = new StrictModeMultivectorConfig
+		    {
+		      MultivectorConfig = { ["{vector_name}"] = new StrictModeMultivector { MaxVectors = 10 } }
+		    }
+		  }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/bash.md
@@ -1,0 +1,14 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "multivector_config": {
+        "{vector_name}": {
+          "max_vectors": 10
+        }
+      }
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/csharp.md
@@ -1,0 +1,18 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig
+  {
+    Enabled = true,
+    MultivectorConfig = new StrictModeMultivectorConfig
+    {
+      MultivectorConfig = { ["{vector_name}"] = new StrictModeMultivector { MaxVectors = 10 } }
+    }
+  }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/go.md
@@ -1,0 +1,24 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    MultivectorConfig: &qdrant.StrictModeMultivectorConfig{
+      MultivectorConfig: map[string]*qdrant.StrictModeMultivector{
+        "{vector_name}": {MaxVectors: qdrant.PtrOf(uint64(10))},
+      },
+    },
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/java.md
@@ -1,0 +1,26 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+import io.qdrant.client.grpc.Collections.StrictModeMultivector;
+import io.qdrant.client.grpc.Collections.StrictModeMultivectorConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder()
+                    .setEnabled(true)
+                    .setMultivectorConfig(
+                        StrictModeMultivectorConfig.newBuilder()
+                            .putMultivectorConfig("{vector_name}", StrictModeMultivector.newBuilder().setMaxVectors(10).build())
+                            .build())
+                    .build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/python.md
@@ -1,0 +1,13 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(
+        enabled=True,
+        multivector_config={"{vector_name}": models.StrictModeMultivector(max_vectors=10)},
+    ),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/rust.md
@@ -1,0 +1,28 @@
+```rust
+use std::collections::HashMap;
+
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, StrictModeConfigBuilder, StrictModeMultivector,
+    StrictModeMultivectorConfig,
+};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}").strict_mode_config(
+            StrictModeConfigBuilder::default()
+                .enabled(true)
+                .multivector_config(StrictModeMultivectorConfig {
+                    multivector_config: HashMap::from([(
+                        "{vector_name}".to_string(),
+                        StrictModeMultivector {
+                            max_vectors: Some(10),
+                        },
+                    )]),
+                }),
+        ),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/generated/typescript.md
@@ -1,0 +1,16 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    multivector_config: {
+      "{vector_name}": {
+        max_vectors: 10,
+      },
+    },
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/go.go
@@ -1,0 +1,28 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    MultivectorConfig: &qdrant.StrictModeMultivectorConfig{
+	      MultivectorConfig: map[string]*qdrant.StrictModeMultivector{
+	        "{vector_name}": {MaxVectors: qdrant.PtrOf(uint64(10))},
+	      },
+	    },
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/http.md
@@ -1,0 +1,13 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "multivector_config": {
+            "{vector_name}": {
+                "max_vectors": 10
+            }
+        }
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/java.java
@@ -1,0 +1,30 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+import io.qdrant.client.grpc.Collections.StrictModeMultivector;
+import io.qdrant.client.grpc.Collections.StrictModeMultivectorConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder()
+                                    .setEnabled(true)
+                                    .setMultivectorConfig(
+                                        StrictModeMultivectorConfig.newBuilder()
+                                            .putMultivectorConfig("{vector_name}", StrictModeMultivector.newBuilder().setMaxVectors(10).build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/python.py
@@ -1,0 +1,11 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(
+        enabled=True,
+        multivector_config={"{vector_name}": models.StrictModeMultivector(max_vectors=10)},
+    ),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/rust.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, StrictModeConfigBuilder, StrictModeMultivector,
+    StrictModeMultivectorConfig,
+};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}").strict_mode_config(
+                StrictModeConfigBuilder::default()
+                    .enabled(true)
+                    .multivector_config(StrictModeMultivectorConfig {
+                        multivector_config: HashMap::from([(
+                            "{vector_name}".to_string(),
+                            StrictModeMultivector {
+                                max_vectors: Some(10),
+                            },
+                        )]),
+                    }),
+            ),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/multivector-config/typescript.ts
@@ -1,0 +1,14 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    multivector_config: {
+      "{vector_name}": {
+        max_vectors: 10,
+      },
+    },
+  },
+});

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `search_allow_exact` to false on the strict mode configuration to prevent exact (brute-force) search, which can be very slow on large collections.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/bash.sh
@@ -1,0 +1,8 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_allow_exact": false
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/csharp.cs
@@ -1,0 +1,15 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig { Enabled = true, SearchAllowExact = false }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/bash.md
@@ -1,0 +1,10 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_allow_exact": false
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/csharp.md
@@ -1,0 +1,11 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig { Enabled = true, SearchAllowExact = false }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/go.md
@@ -1,0 +1,20 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    SearchAllowExact: qdrant.PtrOf(false),
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/java.md
@@ -1,0 +1,18 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder().setEnabled(true).setSearchAllowExact(false).build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/python.md
@@ -1,0 +1,10 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_allow_exact=False),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/rust.md
@@ -1,0 +1,13 @@
+```rust
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}")
+            .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_allow_exact(false)),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/generated/typescript.md
@@ -1,0 +1,12 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_allow_exact: false,
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/go.go
@@ -1,0 +1,24 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    SearchAllowExact: qdrant.PtrOf(false),
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/http.md
@@ -1,0 +1,9 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "search_allow_exact": false
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/java.java
@@ -1,0 +1,22 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder().setEnabled(true).setSearchAllowExact(false).build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/python.py
@@ -1,0 +1,8 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_allow_exact=False),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/rust.rs
@@ -1,0 +1,15 @@
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}")
+                .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_allow_exact(false)),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-allow-exact/typescript.ts
@@ -1,0 +1,10 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_allow_exact: false,
+  },
+});

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `search_max_batchsize` on the strict mode configuration to cap the maximum number of searches in a single batch request.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/bash.sh
@@ -1,0 +1,8 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_max_batchsize": 1000
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/csharp.cs
@@ -1,0 +1,15 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig { Enabled = true, SearchMaxBatchsize = 1000 }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/bash.md
@@ -1,0 +1,10 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_max_batchsize": 1000
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/csharp.md
@@ -1,0 +1,11 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig { Enabled = true, SearchMaxBatchsize = 1000 }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/go.md
@@ -1,0 +1,20 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    SearchMaxBatchsize: qdrant.PtrOf(uint64(1000)),
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/java.md
@@ -1,0 +1,18 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder().setEnabled(true).setSearchMaxBatchsize(1000).build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/python.md
@@ -1,0 +1,10 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_max_batchsize=1000),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/rust.md
@@ -1,0 +1,13 @@
+```rust
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}")
+            .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_max_batchsize(1000u64)),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/generated/typescript.md
@@ -1,0 +1,12 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_max_batchsize: 1000,
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/go.go
@@ -1,0 +1,24 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    SearchMaxBatchsize: qdrant.PtrOf(uint64(1000)),
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/http.md
@@ -1,0 +1,9 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "search_max_batchsize": 1000
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/java.java
@@ -1,0 +1,22 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder().setEnabled(true).setSearchMaxBatchsize(1000).build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/python.py
@@ -1,0 +1,8 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_max_batchsize=1000),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/rust.rs
@@ -1,0 +1,15 @@
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}")
+                .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_max_batchsize(1000u64)),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-batchsize/typescript.ts
@@ -1,0 +1,10 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_max_batchsize: 1000,
+  },
+});

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `search_max_hnsw_ef` on the strict mode configuration to cap the maximum HNSW ef value allowed in search parameters.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/bash.sh
@@ -1,0 +1,8 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_max_hnsw_ef": 128
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/csharp.cs
@@ -1,0 +1,15 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig { Enabled = true, SearchMaxHnswEf = 128 }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/bash.md
@@ -1,0 +1,10 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_max_hnsw_ef": 128
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/csharp.md
@@ -1,0 +1,11 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig { Enabled = true, SearchMaxHnswEf = 128 }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/go.md
@@ -1,0 +1,20 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    SearchMaxHnswEf: qdrant.PtrOf(uint32(128)),
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/java.md
@@ -1,0 +1,18 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder().setEnabled(true).setSearchMaxHnswEf(128).build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/python.md
@@ -1,0 +1,10 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_max_hnsw_ef=128),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/rust.md
@@ -1,0 +1,13 @@
+```rust
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}")
+            .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_max_hnsw_ef(128u32)),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/generated/typescript.md
@@ -1,0 +1,12 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_max_hnsw_ef: 128,
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/go.go
@@ -1,0 +1,24 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    SearchMaxHnswEf: qdrant.PtrOf(uint32(128)),
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/http.md
@@ -1,0 +1,9 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "search_max_hnsw_ef": 128
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/java.java
@@ -1,0 +1,22 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder().setEnabled(true).setSearchMaxHnswEf(128).build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/python.py
@@ -1,0 +1,8 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_max_hnsw_ef=128),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/rust.rs
@@ -1,0 +1,15 @@
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}")
+                .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_max_hnsw_ef(128u32)),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/typescript.ts
@@ -1,0 +1,10 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_max_hnsw_ef: 128,
+  },
+});

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `search_max_oversampling` on the strict mode configuration to cap the maximum oversampling factor allowed in search parameters.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/bash.sh
@@ -1,0 +1,8 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_max_oversampling": 2.0
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/csharp.cs
@@ -1,0 +1,15 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig { Enabled = true, SearchMaxOversampling = 2.0f }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/bash.md
@@ -1,0 +1,10 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "search_max_oversampling": 2.0
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/csharp.md
@@ -1,0 +1,11 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig { Enabled = true, SearchMaxOversampling = 2.0f }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/go.md
@@ -1,0 +1,20 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    SearchMaxOversampling: qdrant.PtrOf(float32(2.0)),
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/java.md
@@ -1,0 +1,18 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder().setEnabled(true).setSearchMaxOversampling(2.0f).build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/python.md
@@ -1,0 +1,10 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_max_oversampling=2.0),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/rust.md
@@ -1,0 +1,13 @@
+```rust
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}")
+            .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_max_oversampling(2.0f32)),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/generated/typescript.md
@@ -1,0 +1,12 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_max_oversampling: 2.0,
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/go.go
@@ -1,0 +1,24 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    SearchMaxOversampling: qdrant.PtrOf(float32(2.0)),
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/http.md
@@ -1,0 +1,9 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "search_max_oversampling": 2.0
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/java.java
@@ -1,0 +1,22 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder().setEnabled(true).setSearchMaxOversampling(2.0f).build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/python.py
@@ -1,0 +1,8 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, search_max_oversampling=2.0),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/rust.rs
@@ -1,0 +1,15 @@
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}")
+                .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).search_max_oversampling(2.0f32)),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/search-max-oversampling/typescript.ts
@@ -1,0 +1,10 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    search_max_oversampling: 2.0,
+  },
+});

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `sparse_config` on the strict mode configuration to cap the maximum length of sparse vectors for a named vector.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/bash.sh
@@ -1,0 +1,12 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "sparse_config": {
+        "{vector_name}": {
+          "max_length": 1000
+        }
+      }
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/csharp.cs
@@ -1,0 +1,22 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig
+		  {
+		    Enabled = true,
+		    SparseConfig = new StrictModeSparseConfig
+		    {
+		      SparseConfig = { ["{vector_name}"] = new StrictModeSparse { MaxLength = 1000 } }
+		    }
+		  }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/bash.md
@@ -1,0 +1,14 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "sparse_config": {
+        "{vector_name}": {
+          "max_length": 1000
+        }
+      }
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/csharp.md
@@ -1,0 +1,18 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig
+  {
+    Enabled = true,
+    SparseConfig = new StrictModeSparseConfig
+    {
+      SparseConfig = { ["{vector_name}"] = new StrictModeSparse { MaxLength = 1000 } }
+    }
+  }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/go.md
@@ -1,0 +1,24 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    SparseConfig: &qdrant.StrictModeSparseConfig{
+      SparseConfig: map[string]*qdrant.StrictModeSparse{
+        "{vector_name}": {MaxLength: qdrant.PtrOf(uint64(1000))},
+      },
+    },
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/java.md
@@ -1,0 +1,26 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+import io.qdrant.client.grpc.Collections.StrictModeSparse;
+import io.qdrant.client.grpc.Collections.StrictModeSparseConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder()
+                    .setEnabled(true)
+                    .setSparseConfig(
+                        StrictModeSparseConfig.newBuilder()
+                            .putSparseConfig("{vector_name}", StrictModeSparse.newBuilder().setMaxLength(1000).build())
+                            .build())
+                    .build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/python.md
@@ -1,0 +1,13 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(
+        enabled=True,
+        sparse_config={"{vector_name}": models.StrictModeSparse(max_length=1000)},
+    ),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/rust.md
@@ -1,0 +1,27 @@
+```rust
+use std::collections::HashMap;
+
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, StrictModeConfigBuilder, StrictModeSparse, StrictModeSparseConfig,
+};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}").strict_mode_config(
+            StrictModeConfigBuilder::default()
+                .enabled(true)
+                .sparse_config(StrictModeSparseConfig {
+                    sparse_config: HashMap::from([(
+                        "{vector_name}".to_string(),
+                        StrictModeSparse {
+                            max_length: Some(1000),
+                        },
+                    )]),
+                }),
+        ),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/generated/typescript.md
@@ -1,0 +1,16 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    sparse_config: {
+      "{vector_name}": {
+        max_length: 1000,
+      },
+    },
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/go.go
@@ -1,0 +1,28 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    SparseConfig: &qdrant.StrictModeSparseConfig{
+	      SparseConfig: map[string]*qdrant.StrictModeSparse{
+	        "{vector_name}": {MaxLength: qdrant.PtrOf(uint64(1000))},
+	      },
+	    },
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/http.md
@@ -1,0 +1,13 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "sparse_config": {
+            "{vector_name}": {
+                "max_length": 1000
+            }
+        }
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/java.java
@@ -1,0 +1,30 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+import io.qdrant.client.grpc.Collections.StrictModeSparse;
+import io.qdrant.client.grpc.Collections.StrictModeSparseConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder()
+                                    .setEnabled(true)
+                                    .setSparseConfig(
+                                        StrictModeSparseConfig.newBuilder()
+                                            .putSparseConfig("{vector_name}", StrictModeSparse.newBuilder().setMaxLength(1000).build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/python.py
@@ -1,0 +1,11 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(
+        enabled=True,
+        sparse_config={"{vector_name}": models.StrictModeSparse(max_length=1000)},
+    ),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/rust.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, StrictModeConfigBuilder, StrictModeSparse, StrictModeSparseConfig,
+};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}").strict_mode_config(
+                StrictModeConfigBuilder::default()
+                    .enabled(true)
+                    .sparse_config(StrictModeSparseConfig {
+                        sparse_config: HashMap::from([(
+                            "{vector_name}".to_string(),
+                            StrictModeSparse {
+                                max_length: Some(1000),
+                            },
+                        )]),
+                    }),
+            ),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/sparse-config/typescript.ts
@@ -1,0 +1,14 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    sparse_config: {
+      "{vector_name}": {
+        max_length: 1000,
+      },
+    },
+  },
+});

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -122,7 +122,31 @@ Setting `max_timeout` caps the maximum value in seconds for the `timeout` parame
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/max-timeout/" >}}
 
-### Maximum Size of a Filtering Condition
+### Disable exact search
+
+Exact search bypasses the HNSW index and performs a brute-force scan, which can be very slow on large collections.
+
+Setting `search_allow_exact` to false prevents clients from requesting exact search.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/search-allow-exact/" >}}
+
+### Maximum HNSW ef parameter
+
+A high HNSW `ef` value increases recall but also increases search latency.
+
+Setting `search_max_hnsw_ef` caps the maximum `ef` value allowed in search parameters.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/" >}}
+
+### Maximum search oversampling
+
+A high oversampling factor increases the number of candidates evaluated during search, which can significantly increase latency.
+
+Setting `search_max_oversampling` caps the maximum oversampling factor allowed in search parameters.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/search-max-oversampling/" >}}
+
+### Maximum size of a filtering condition
 
 Large filtering conditions are expensive to evaluate.
 
@@ -148,7 +172,15 @@ Setting `upsert_max_batchsize` caps the maximum size in bytes of a batch during 
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/upsert-max-batchsize/" >}}
 
-### Maximum Collection Storage Size
+### Maximum batch size when searching
+
+Sending very large search batches can create internal congestion.
+
+Setting `search_max_batchsize` caps the maximum number of searches in a single batch request.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/search-max-batchsize/" >}}
+
+### Maximum collection storage size
 
 It is possible to set the maximum size of a collection in terms of vectors and/or payload storage size.
 
@@ -156,7 +188,15 @@ Setting `max_collection_vector_size_bytes` and/or `max_collection_payload_size_b
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/max-collection-storage-size-bytes/" >}}
 
-### Maximum Points Count
+### Maximum resident memory usage
+
+When a node is under memory pressure, new write operations can destabilize the cluster.
+
+Setting `max_resident_memory_percent` rejects memory-consuming write operations (such as upsert and set payload) when process resident memory exceeds the given percentage of total system memory. Delete operations are not affected. Accepts values in the range 1–100.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/max-resident-memory-percent/" >}}
+
+### Maximum points count
 
 Setting `max_points_count` caps the maximum number of points for a collection.
 
@@ -171,3 +211,19 @@ Setting `read_rate_limit` and/or `write_rate_limit` to cap the maximum number of
 When exceeding the maximum number of operations, the client will receive an HTTP 429 error code with a suggested delay before retrying.
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/rate-limiting/" >}}
+
+### Maximum vectors per multivector
+
+A multivector with many vectors per point is expensive to store and query.
+
+Setting `multivector_config` caps the maximum number of vectors per multivector for each named vector.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/multivector-config/" >}}
+
+### Maximum sparse vector length
+
+Long sparse vectors increase memory usage and slow down filtering.
+
+Setting `sparse_config` caps the maximum length of sparse vectors for each named vector.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/sparse-config/" >}}

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -63,21 +63,19 @@ QDRANT__STORAGE__LOW_MEMORY_MODE=no_populate
 
 Low memory mode takes effect on the next restart. It doesn't modify the [vector storage](/documentation/manage-data/storage/) settings persisted in your collections.
 
-## Strict Mode
+## Strict mode
 
 *Available as of v1.13.0*
 
-Strict mode is a feature to restrict certain type of operations on a collection in order to protect the Qdrant cluster.
+Strict mode is a feature to restrict certain type of operations on a collection in order to protect the Qdrant cluster. The goal is to prevent inefficient usage patterns that could overload the system.
 
-The goal is to prevent inefficient usage patterns that could overload the system.
+Strict mode ensures a more predictable and responsive service when you do not have control over the queries that are being executed. Upon crossing a limit, the server will return a client side error with the information about the limit that was crossed.
 
-Strict mode ensures a more predictable and responsive service when you do not have control over the queries that are being executed.
+The `strict_mode_config` can be enabled when [creating](#create-a-collection) a new collection, see [schema definitions](https://api.qdrant.tech/api-reference/collections/create-collection#request.body.strict_mode_config) for all the available `strict_mode_config` parameters. As part of the config, the `enabled` field act as a toggle to enable or disable the strict mode dynamically. 
 
-Upon crossing a limit, the server will return a client side error with the information about the limit that was crossed.
+Simply enabling strict mode without specifying a specific restriction does not have any effect. You need to explicitly set the restrictions you want to enforce.
 
-The `strict_mode_config` can be enabled when [creating](#create-a-collection) a new collection, see [schema definitions](https://api.qdrant.tech/api-reference/collections/create-collection#request.body.strict_mode_config) for all the available `strict_mode_config` parameters.
-
-As part of the config, the `enabled` field act as a toggle to enable or disable the strict mode dynamically.
+On Qdrant Cloud, strict mode is enabled by default for new collections. Refer to [Configure Qdrant Cloud Clusters](/documentation/cloud/configure-cluster/) for the specific restrictions.
 
 It is possible to raise the default limits and/or disable strict mode entirely. Though, in order to ensure a stable cluster we strongly recommend to keep strict mode enabled using its default configuration. For disabling strict mode on an existing collection use:
 

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -63,7 +63,7 @@ QDRANT__STORAGE__LOW_MEMORY_MODE=no_populate
 
 Low memory mode takes effect on the next restart. It doesn't modify the [vector storage](/documentation/manage-data/storage/) settings persisted in your collections.
 
-## Strict mode
+## Strict Mode
 
 *Available as of v1.13.0*
 

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -213,7 +213,7 @@ When exceeding the maximum number of operations, the client will receive an HTTP
 
 ### Maximum Vectors per Multivector
 
-A multivector with many vectors per point is expensive to store and query.
+A multivector with many vectors per point is expensive to store, index and query.
 
 Setting `multivector_config` caps the maximum number of vectors per multivector for each named vector.
 

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -34,7 +34,6 @@ If using a Qdrant binary, recovery mode can be enabled by setting a recovery
 message in an environment variable, such as
 `QDRANT__STORAGE__RECOVERY_MODE="My recovery message"`.
 
-
 ## Low Memory Mode
 
 *Available as of v1.18.0*
@@ -122,7 +121,7 @@ Setting `max_timeout` caps the maximum value in seconds for the `timeout` parame
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/max-timeout/" >}}
 
-### Disable exact search
+### Disable Exact Search
 
 Exact search bypasses the HNSW index and performs a brute-force scan, which can be very slow on large collections.
 
@@ -130,7 +129,7 @@ Setting `search_allow_exact` to false prevents clients from requesting exact sea
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/search-allow-exact/" >}}
 
-### Maximum HNSW ef parameter
+### Maximum HNSW ef Parameter
 
 A high HNSW `ef` value increases recall but also increases search latency.
 
@@ -138,7 +137,7 @@ Setting `search_max_hnsw_ef` caps the maximum `ef` value allowed in search param
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/search-max-hnsw-ef/" >}}
 
-### Maximum search oversampling
+### Maximum Search Oversampling
 
 A high oversampling factor increases the number of candidates evaluated during search, which can significantly increase latency.
 
@@ -146,7 +145,7 @@ Setting `search_max_oversampling` caps the maximum oversampling factor allowed i
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/search-max-oversampling/" >}}
 
-### Maximum size of a filtering condition
+### Maximum Size of a Filtering Condition
 
 Large filtering conditions are expensive to evaluate.
 
@@ -172,7 +171,7 @@ Setting `upsert_max_batchsize` caps the maximum size in bytes of a batch during 
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/upsert-max-batchsize/" >}}
 
-### Maximum batch size when searching
+### Maximum Batch Size When Searching
 
 Sending very large search batches can create internal congestion.
 
@@ -180,7 +179,7 @@ Setting `search_max_batchsize` caps the maximum number of searches in a single b
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/search-max-batchsize/" >}}
 
-### Maximum collection storage size
+### Maximum Collection Storage Size
 
 It is possible to set the maximum size of a collection in terms of vectors and/or payload storage size.
 
@@ -188,7 +187,7 @@ Setting `max_collection_vector_size_bytes` and/or `max_collection_payload_size_b
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/max-collection-storage-size-bytes/" >}}
 
-### Maximum resident memory usage
+### Maximum Resident Memory Usage
 
 When a node is under memory pressure, new write operations can destabilize the cluster.
 
@@ -196,7 +195,7 @@ Setting `max_resident_memory_percent` rejects memory-consuming write operations 
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/max-resident-memory-percent/" >}}
 
-### Maximum points count
+### Maximum Points Count
 
 Setting `max_points_count` caps the maximum number of points for a collection.
 
@@ -212,7 +211,7 @@ When exceeding the maximum number of operations, the client will receive an HTTP
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/rate-limiting/" >}}
 
-### Maximum vectors per multivector
+### Maximum Vectors per Multivector
 
 A multivector with many vectors per point is expensive to store and query.
 
@@ -220,7 +219,7 @@ Setting `multivector_config` caps the maximum number of vectors per multivector 
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/multivector-config/" >}}
 
-### Maximum sparse vector length
+### Maximum Sparse Vector Length
 
 Long sparse vectors increase memory usage and slow down filtering.
 


### PR DESCRIPTION
[Preview](https://deploy-preview-2303--condescending-goldwasser-91acf0.netlify.app/documentation/ops-configuration/administration/#strict-mode)

Adds documentation for the new `max_resident_memory_percent` and `search_max_batchsize` strict_mode_config parameters.

While I was at it, also adding docs for `search_max_hnsw_ef`, `search_allow_exact`, `search_max_oversampling`, `multivector_config`, and `sparse_config`.