### PR TITLE
Explicitly list Cloud strict mode restrictions

### DIFF
--- a/qdrant-landing/content/documentation/cloud/configure-cluster.md
+++ b/qdrant-landing/content/documentation/cloud/configure-cluster.md
@@ -12,7 +12,10 @@ The cloud platform does not expose all [configuration options](/documentation/op
 In addition, the cloud platform automatically configures the following settings for your cluster to ensure optimal performance and reliability:
 
 * The maximum number of collections in a cluster is set to 1000. Larger numbers of collections lead to performance degradation. For more information see [Multitenancy](/documentation/manage-data/multitenancy/).
-* Strict mode is activated by default for new collections enforcing that all filters being used in retrieve and update queries are indexed. This improves performance and reliability. You can disable this individually for each collection. For more information see [Strict Mode](/documentation/ops-configuration/administration/#strict-mode).
+* To improve performance and reliability, [strict mode](/documentation/ops-configuration/administration/#strict-mode) is activated by default for new collections, with the following restrictions:
+  * Retrieving points by filtering on a non indexed payload key is not allowed (`unindexed_filtering_retrieve` is set to `false`).
+  * Updating points by filtering on a non indexed payload key is not allowed (`unindexed_filtering_update` is set to `false`).
+  * The maximum number of payload indexes per collection is set to 100 (`max_payload_index_count` is set to `100`).
 * The cluster mode is automatically enabled to allow distributed deployments and horizontal scaling.
 * The maximum amount of payload indexes per collection is set to 100. Larger numbers of payload indexes lead to performance degradation (starting with Qdrant v1.16.0).
 


### PR DESCRIPTION
[Preview](https://deploy-preview-2320--condescending-goldwasser-91acf0.netlify.app/documentation/cloud/configure-cluster/)

Explicitly lists the three strict mode restrictions enabled by default on Qdrant Cloud.