### PR TITLE
Fix Academy link from Learn page

### DIFF
--- a/qdrant-landing/content/learn/_index.md
+++ b/qdrant-landing/content/learn/_index.md
@@ -50,7 +50,7 @@ content:
             - "Advanced: Production optimization"
       
       link:
-        url: /course/essentials/
+        url: /course/
         text: View Courses
     - id: 3
       image:


### PR DESCRIPTION
Now points to Academy overview instead of Essentials course