### PR TITLE
Suppress OneTrust cookie banner on local hugo server

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
@@ -6,7 +6,7 @@
 </script>
 
 <!-- OneTrust Cookies Consent Notice start for local.qdrant.tech -->
-{{ if and hugo.IsProduction .Site.Params.onetrustScriptID }}
+{{ if and (not hugo.IsServer) .Site.Params.onetrustScriptID }}
   <script
     src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
     type="text/javascript"

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
@@ -6,7 +6,7 @@
 </script>
 
 <!-- OneTrust Cookies Consent Notice start for local.qdrant.tech -->
-{{ if .Site.Params.onetrustScriptID }}
+{{ if and hugo.IsProduction .Site.Params.onetrustScriptID }}
   <script
     src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
     type="text/javascript"


### PR DESCRIPTION
## Summary
  - Gate the OneTrust cookie banner on not hugo.IsServer so it no longer renders during local hugo server runs.
  - Every Netlify build (production, deploy-preview, branch) is a hugo build, not hugo server, so hugo.IsServer is false and the banner still loads in all deployed
   contexts.
  - Mirrors the gating pattern already used by the Segment loader directly below it in partials/js.html.

  ## Why
  The consent banner re-appears on every reload during local development, which adds friction when iterating on layouts and content. Gating it to production-only removes the friction without affecting deployed behavior.

  ## Local setup note
  If you've ever run a Hugo build locally, `qdrant-landing/public/` may hold pre-built HTML from before this change. Hugo's "Serving pages from disk" mode will keep returning those stale files (banner included) until they're regenerated. After pulling this branch:

  ```bash
  rm -rf qdrant-landing/public
  docker restart <hugo-container>   # or restart your `hugo server` process
```
  Then reload in an incognito window so OneTrust cookies set in earlier sessions don't fool you into thinking the banner is still there.

  ##Test plan

  - hugo server locally → no OneTrust banner, no cdn.cookielaw.org request in the network tab.
  - Netlify deploy preview → banner still appears and behaves normally.
  - Production build → banner still appears and behaves normally.