### PR TITLE
Add 1px border around images in the docs

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-article.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-article.scss
@@ -54,6 +54,7 @@
         width: 100%;
         height: auto;
         margin: 0 auto;
+        border: none;
       }
     }
   }
@@ -149,6 +150,14 @@
       }
     }
   }
+}
+
+article.documentation-article {
+
+  img {
+    border: 1px solid #8f98b2;
+  }
+
 }
 
 [data-theme='light'] {

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-article.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-article.scss
@@ -155,7 +155,7 @@
 article.documentation-article {
 
   img {
-    border: 1px solid #8f98b2;
+    border: 1px solid $neutral-80;
   }
 
 }


### PR DESCRIPTION
Small change that adds a 1px gray border around images in the docs, to make them stand out more from the background.

Compare before:
<img width="1273" height="884" alt="image" src="https://github.com/user-attachments/assets/88bf993b-61db-4739-85b4-d658e8becc54" />

After:
<img width="1276" height="894" alt="image" src="https://github.com/user-attachments/assets/6142e24f-f194-4f05-9f8d-d0fd63fab2c1" />
