### PR TITLE
ci: poll hugo serve readiness in internal link checker

### DIFF
--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -25,8 +25,13 @@ jobs:
           bash -x ./install-and-build.sh
           CURRENT_DIR=$(pwd)
           export PATH="${CURRENT_DIR}/dart-sass:${PATH}"
-          cd qdrant-landing && hugo --gc -b 'http://localhost:1314' && hugo serve --port 1314 &
-          sleep 5 # wait for server to start
+          cd qdrant-landing
+          hugo --gc -b 'http://localhost:1314'
+          hugo serve --port 1314 &
+          for i in {1..60}; do
+            curl -sf http://localhost:1314/ >/dev/null && break
+            sleep 1
+          done
       - name: Internal Links Check
         id: lychee
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421 # v1.8.0


### PR DESCRIPTION
## Summary
- The internal link checker workflow backgrounded `hugo --gc && hugo serve` as one chain and waited a fixed `sleep 5`. With the Hugo 0.160.1 upgrade the build alone takes ~6s, so `hugo serve` was usually not yet listening when lychee fired.
- lychee's first probe got `Connection refused`, was cached per host, and every subsequent internal URL was reported as `Cached: Error` — surfacing as "thousands of broken links" that don't actually exist.
- Fix: build synchronously, start `hugo serve` in the background, then poll `curl -sf http://localhost:1314/` for up to 60s before running lychee.

`check-dead-links.yml` was not affected — it runs lychee against static files in `qdrant-landing/public/` and never starts a server.

## Test plan
- [ ] Workflow `Links` (this PR run) completes successfully.
- [ ] Re-run workflow on master after merge — should stop reporting bulk false-positive 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)