### PR TITLE
fix typos in hybrid-cloud and private cloud docs

### DIFF
--- a/qdrant-landing/content/documentation/hybrid-cloud/hybrid-cloud-cluster-creation.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/hybrid-cloud-cluster-creation.md
@@ -96,7 +96,7 @@ The service type and necessary annotations can be configured in the "Kubernetes 
 
 ![Hybrid Cloud API Key configuration](/documentation/cloud/hybrid_cloud_service.png)
 
-Especially if you create a LoadBalancer Service, you may need to provide annotations for the loadbalancer configration. Please refer to the documention of your cloud provider for more details.
+Especially if you create a LoadBalancer Service, you may need to provide annotations for the loadbalancer configuration. Please refer to the documentation of your cloud provider for more details.
 
 Examples:
 

--- a/qdrant-landing/content/documentation/hybrid-cloud/hybrid-cloud-setup.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/hybrid-cloud-setup.md
@@ -65,7 +65,7 @@ By default, Qdrant Cloud will provision two volumes per Qdrant Pod: One for the 
 - Helm chart repository URL for the Qdrant services. The default is <oci://registry.cloud.qdrant.io/qdrant-charts>.
 - An optional secret with credentials to access your own container registry.
 - Log level for the operator and agent.
-- Node selectors and tolerations for the operater, agent, cluster-manager and monitoring stack.
+- Node selectors and tolerations for the operator, agent, cluster-manager and monitoring stack.
 - Control Plane Labels that will be added to all Kubernetes resources of the Hybrid Cloud control-plane components.
 
 ![Create Hybrid Cloud Environment - Advanced Configuration](/documentation/cloud/hybrid_cloud_advanced_configuration.png)

--- a/qdrant-landing/content/documentation/hybrid-cloud/operator-configuration.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/operator-configuration.md
@@ -137,7 +137,7 @@ settings:
         # The endpoint address the cluster manager could be reached
         # If set, this should be a full URL like: http://cluster-manager.qdrant-cloud-ns.svc.cluster.local:7333
         endpointAddress: http://qdrant-cluster-manager:80
-        # InvocationInterval is the interval between calls (started after the previous call is retured)
+        # InvocationInterval is the interval between calls (started after the previous call is returned)
         # Default is 10 seconds
         invocationInterval: 10s
         # Timeout is the duration a single call to the cluster manager is allowed to take.

--- a/qdrant-landing/content/documentation/hybrid-cloud/platform-deployment-options.md
+++ b/qdrant-landing/content/documentation/hybrid-cloud/platform-deployment-options.md
@@ -33,7 +33,7 @@ At the time of writing, Linode [does not support CSI Volume Snapshots](https://g
 
 First, consult AWS' managed Kubernetes instructions below. Then, **to set up Qdrant Hybrid Cloud on AWS**, follow our [step-by-step documentation](/documentation/hybrid-cloud/hybrid-cloud-setup/). 
 
-For a good balance between peformance and cost, we recommend:
+For a good balance between performance and cost, we recommend:
 
 * Depending on your cluster resource configuration either general purpose (m6*, m7*, or m8*), memory optimized (r6*, r7*, or r8*) or cpu optimized (c6*, c7*, or c8*) instance types. Qdrant Hybrid Cloud also supports AWS Graviton ARM64 instances.
 * At least gp3 EBS volumes for storage
@@ -136,7 +136,7 @@ First, consult Gcore's managed Kubernetes instructions below. Then, **to set up 
 
 First, consult GCP's managed Kubernetes instructions below. Then, **to set up Qdrant Hybrid Cloud on GCP**, follow our [step-by-step documentation](/documentation/hybrid-cloud/hybrid-cloud-setup/). 
 
-For a good balance between peformance and cost, we recommend:
+For a good balance between performance and cost, we recommend:
 
 * Depending on your cluster resource configuration either general purpose (standard), memory optimized (highmem) or cpu optimized (highcpu) instance types of at least 2nd generation. Qdrant Hybrid Cloud also supports ARM64 instances.
 * At least pd-balanced disks for storage
@@ -167,7 +167,7 @@ With [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-in/products
 
 First, consult Azure's managed Kubernetes instructions below. Then, **to set up Qdrant Hybrid Cloud on Azure**, follow our [step-by-step documentation](/documentation/hybrid-cloud/hybrid-cloud-setup/). 
 
-For a good balance between peformance and cost, we recommend:
+For a good balance between performance and cost, we recommend:
 
 * Depending on your cluster resource configuration either general purpose (D-family), memory optimized (E-family) or cpu optimized (F-family) instance types. Qdrant Hybrid Cloud also supports Azure Cobalt ARM64 instances.
 * At least Premium SSD v2 disks for storage

--- a/qdrant-landing/content/documentation/private-cloud/configuration.md
+++ b/qdrant-landing/content/documentation/private-cloud/configuration.md
@@ -222,10 +222,10 @@ operator:
           enable: true
           # The endpoint address where the cluster manager can be reached
           endpointAddress: "http://qdrant-cluster-manager"
-          # InvocationInterval is the interval between calls (started after the previous call is retured)
+          # InvocationInterval is the interval between calls (started after the previous call is returned)
           # Default is 10 seconds
           invocationInterval: 10s
-          # SyncClustersInterval is the interval between sync-clusters calls (started after the previous call is retured)
+          # SyncClustersInterval is the interval between sync-clusters calls (started after the previous call is returned)
           # Default is 10 seconds
           syncClustersInterval: 10s
           # Timeout is the duration a single call to the cluster manager is allowed to take.

--- a/qdrant-landing/content/documentation/private-cloud/qdrant-cluster-management.md
+++ b/qdrant-landing/content/documentation/private-cloud/qdrant-cluster-management.md
@@ -69,7 +69,7 @@ spec:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
-Especially if you create a LoadBalancer Service, you may need to provide annotations for the loadbalancer configration. Please refer to the documention of your cloud provider for more details.
+Especially if you create a LoadBalancer Service, you may need to provide annotations for the loadbalancer configuration. Please refer to the documentation of your cloud provider for more details.
 
 Examples:
 


### PR DESCRIPTION
## summary 
 small typo cleanup in hybrid-cloud and private-cloud docs

  fixes:
  - operater -> operator
  - retured -> returned (3 spots)
  - configration -> configuration (2 spots)
  - documention -> documentation (2 spots)
  - peformance -> performance (3 spots)

  no content or code changes
