### PR TITLE
Fix broken FAQ link to retrieval-quality tutorial

### DIFF
--- a/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
+++ b/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
@@ -152,7 +152,7 @@ Both methods combine scores from multiple retrieval legs (for example, dense and
 
 For custom fusion, use the [Formula Query](/documentation/search/search-relevance/#score-boosting). For example, you can use decay functions to normalize both scores to a 0-1 range and then fuse them. This approach requires you to determine the approximate score distribution for each corpus, since you can't set decay function parameters dynamically. The Formula Query doesn't support custom rank-based fusion because it doesn't have access to prefetch ranks; only to the raw scores.
 
-To evaluate which works better for your use case, create a small golden query set and compare [retrieval quality metrics](/documentation/tutorials-search-engineering/retrieval-quality/) (for example, NDCG@10) under each method.
+To evaluate which works better for your use case, create a small golden query set and compare [retrieval quality metrics](/documentation/improve-search/retrieval-relevance/) (for example, NDCG@10) under each method.
 
 See also: [Hybrid Queries](/documentation/search/hybrid-queries/)
 


### PR DESCRIPTION
## Summary
- FAQ pointed at `/documentation/tutorials-search-engineering/retrieval-quality/`, which now only exists as a Hugo alias on the ANN recall tutorial. Aliases emit `index.html` redirects but not `index.md`, so the link checker scanning `public/.../index.md` 404s on the alias path.
- Repointed the link to `/documentation/improve-search/retrieval-relevance/` — a direct (non-alias) URL whose content matches the surrounding prose about golden query sets and NDCG@10.

## Test plan
- [ ] Link checker (`internal-dead-links` workflow) passes on this branch.
- [ ] Spot-check the FAQ entry in the rendered docs lands on the relevance tutorial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)