### PR TITLE
fix(docs): correct C# MatchExcept snippet (was using Match instead of MatchExcept)

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/filter-condition/match-except/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/filter-condition/match-except/csharp.cs
@@ -4,6 +4,6 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		Match("color", ["black", "yellow"]);
+		MatchExcept("color", ["black", "yellow"]);
 	}
 }

--- a/qdrant-landing/content/documentation/headless/snippets/filter-condition/match-except/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/filter-condition/match-except/generated/csharp.md
@@ -1,5 +1,5 @@
 ```csharp
 using static Qdrant.Client.Grpc.Conditions;
 
-Match("color", ["black", "yellow"]);
+MatchExcept("color", ["black", "yellow"]);
 ```


### PR DESCRIPTION
## Summary

Fixes a copy-paste bug in the C# code example for the `MatchExcept` filter condition.

The snippet at `qdrant-landing/content/documentation/headless/snippets/filter-condition/match-except/csharp.cs` was calling `Match("color", ["black", "yellow"])` — identical to the `match-any` example — instead of `MatchExcept("color", ["black", "yellow"])`. This is misleading for developers using the C# client who are trying to implement the NOT IN (MatchExcept) filter.

**Before:**
```csharp
Match("color", ["black", "yellow"]);
```

**After:**
```csharp
MatchExcept("color", ["black", "yellow"]);
```

`MatchExcept` is a valid static method on `Qdrant.Client.Grpc.Conditions` that accepts `(string field, IReadOnlyList<string> keywords)`.

Closes #1656