### PR TITLE
Add with_lookup example

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/_description.md
@@ -1,0 +1,1 @@
+Populate both collections for the `with_lookup` pattern. The `documents` collection holds one point per document with payload only. Each chunk in `chunks` carries a `document_id` payload value that matches the id of a point in `documents`.

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/csharp.cs
@@ -48,7 +48,7 @@ public class Snippet
 				{
 					Id = 1,
 					Vectors = new float[] { 0.5f, 0.6f, 0.7f, 0.8f },
-					Payload = { ["document_id"] = 201 },
+					Payload = { ["document_id"] = new Value[] { 200L, 201L } },
 				},
 			}
 		);

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/csharp.cs
@@ -13,7 +13,7 @@ public class Snippet
 			{
 				new()
 				{
-					Id = 1,
+					Id = 200,
 					Vectors = new Dictionary<string, Vector>(),
 					Payload =
 					{
@@ -23,7 +23,7 @@ public class Snippet
 				},
 				new()
 				{
-					Id = 2,
+					Id = 201,
 					Vectors = new Dictionary<string, Vector>(),
 					Payload =
 					{
@@ -42,13 +42,13 @@ public class Snippet
 				{
 					Id = 0,
 					Vectors = new float[] { 0.1f, 0.2f, 0.3f, 0.4f },
-					Payload = { ["document_id"] = 1 },
+					Payload = { ["document_id"] = 200 },
 				},
 				new()
 				{
 					Id = 1,
 					Vectors = new float[] { 0.5f, 0.6f, 0.7f, 0.8f },
-					Payload = { ["document_id"] = 2 },
+					Payload = { ["document_id"] = 201 },
 				},
 			}
 		);

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/csharp.cs
@@ -1,0 +1,56 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.UpsertAsync(
+			collectionName: "documents",
+			points: new List<PointStruct>
+			{
+				new()
+				{
+					Id = 1,
+					Vectors = new Dictionary<string, Vector>(),
+					Payload =
+					{
+						["title"] = "Document A",
+						["text"] = "This is document A",
+					},
+				},
+				new()
+				{
+					Id = 2,
+					Vectors = new Dictionary<string, Vector>(),
+					Payload =
+					{
+						["title"] = "Document B",
+						["text"] = "This is document B",
+					},
+				},
+			}
+		);
+
+		await client.UpsertAsync(
+			collectionName: "chunks",
+			points: new List<PointStruct>
+			{
+				new()
+				{
+					Id = 0,
+					Vectors = new float[] { 0.1f, 0.2f, 0.3f, 0.4f },
+					Payload = { ["document_id"] = 1 },
+				},
+				new()
+				{
+					Id = 1,
+					Vectors = new float[] { 0.5f, 0.6f, 0.7f, 0.8f },
+					Payload = { ["document_id"] = 2 },
+				},
+			}
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/csharp.md
@@ -45,7 +45,7 @@ await client.UpsertAsync(
 		{
 			Id = 1,
 			Vectors = new float[] { 0.5f, 0.6f, 0.7f, 0.8f },
-			Payload = { ["document_id"] = 201 },
+			Payload = { ["document_id"] = new Value[] { 200L, 201L } },
 		},
 	}
 );

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/csharp.md
@@ -1,0 +1,52 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.UpsertAsync(
+	collectionName: "documents",
+	points: new List<PointStruct>
+	{
+		new()
+		{
+			Id = 1,
+			Vectors = new Dictionary<string, Vector>(),
+			Payload =
+			{
+				["title"] = "Document A",
+				["text"] = "This is document A",
+			},
+		},
+		new()
+		{
+			Id = 2,
+			Vectors = new Dictionary<string, Vector>(),
+			Payload =
+			{
+				["title"] = "Document B",
+				["text"] = "This is document B",
+			},
+		},
+	}
+);
+
+await client.UpsertAsync(
+	collectionName: "chunks",
+	points: new List<PointStruct>
+	{
+		new()
+		{
+			Id = 0,
+			Vectors = new float[] { 0.1f, 0.2f, 0.3f, 0.4f },
+			Payload = { ["document_id"] = 1 },
+		},
+		new()
+		{
+			Id = 1,
+			Vectors = new float[] { 0.5f, 0.6f, 0.7f, 0.8f },
+			Payload = { ["document_id"] = 2 },
+		},
+	}
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/csharp.md
@@ -10,7 +10,7 @@ await client.UpsertAsync(
 	{
 		new()
 		{
-			Id = 1,
+			Id = 200,
 			Vectors = new Dictionary<string, Vector>(),
 			Payload =
 			{
@@ -20,7 +20,7 @@ await client.UpsertAsync(
 		},
 		new()
 		{
-			Id = 2,
+			Id = 201,
 			Vectors = new Dictionary<string, Vector>(),
 			Payload =
 			{
@@ -39,13 +39,13 @@ await client.UpsertAsync(
 		{
 			Id = 0,
 			Vectors = new float[] { 0.1f, 0.2f, 0.3f, 0.4f },
-			Payload = { ["document_id"] = 1 },
+			Payload = { ["document_id"] = 200 },
 		},
 		new()
 		{
 			Id = 1,
 			Vectors = new float[] { 0.5f, 0.6f, 0.7f, 0.8f },
-			Payload = { ["document_id"] = 2 },
+			Payload = { ["document_id"] = 201 },
 		},
 	}
 );

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/go.md
@@ -14,7 +14,7 @@ client.Upsert(context.Background(), &qdrant.UpsertPoints{
 	CollectionName: "documents",
 	Points: []*qdrant.PointStruct{
 		{
-			Id: qdrant.NewIDNum(1),
+			Id: qdrant.NewIDNum(200),
 			Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
 			Payload: qdrant.NewValueMap(map[string]any{
 				"title": "Document A",
@@ -22,7 +22,7 @@ client.Upsert(context.Background(), &qdrant.UpsertPoints{
 			}),
 		},
 		{
-			Id: qdrant.NewIDNum(2),
+			Id: qdrant.NewIDNum(201),
 			Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
 			Payload: qdrant.NewValueMap(map[string]any{
 				"title": "Document B",
@@ -38,12 +38,12 @@ client.Upsert(context.Background(), &qdrant.UpsertPoints{
 		{
 			Id:      qdrant.NewIDNum(0),
 			Vectors: qdrant.NewVectors(0.1, 0.2, 0.3, 0.4),
-			Payload: qdrant.NewValueMap(map[string]any{"document_id": 1}),
+			Payload: qdrant.NewValueMap(map[string]any{"document_id": 200}),
 		},
 		{
 			Id:      qdrant.NewIDNum(1),
 			Vectors: qdrant.NewVectors(0.5, 0.6, 0.7, 0.8),
-			Payload: qdrant.NewValueMap(map[string]any{"document_id": 2}),
+			Payload: qdrant.NewValueMap(map[string]any{"document_id": 201}),
 		},
 	},
 })

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/go.md
@@ -43,7 +43,7 @@ client.Upsert(context.Background(), &qdrant.UpsertPoints{
 		{
 			Id:      qdrant.NewIDNum(1),
 			Vectors: qdrant.NewVectors(0.5, 0.6, 0.7, 0.8),
-			Payload: qdrant.NewValueMap(map[string]any{"document_id": 201}),
+			Payload: qdrant.NewValueMap(map[string]any{"document_id": []int{200, 201}}),
 		},
 	},
 })

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/go.md
@@ -1,0 +1,50 @@
+```go
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+	Host: "localhost",
+	Port: 6334,
+})
+
+client.Upsert(context.Background(), &qdrant.UpsertPoints{
+	CollectionName: "documents",
+	Points: []*qdrant.PointStruct{
+		{
+			Id: qdrant.NewIDNum(1),
+			Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
+			Payload: qdrant.NewValueMap(map[string]any{
+				"title": "Document A",
+				"text":  "This is document A",
+			}),
+		},
+		{
+			Id: qdrant.NewIDNum(2),
+			Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
+			Payload: qdrant.NewValueMap(map[string]any{
+				"title": "Document B",
+				"text":  "This is document B",
+			}),
+		},
+	},
+})
+
+client.Upsert(context.Background(), &qdrant.UpsertPoints{
+	CollectionName: "chunks",
+	Points: []*qdrant.PointStruct{
+		{
+			Id:      qdrant.NewIDNum(0),
+			Vectors: qdrant.NewVectors(0.1, 0.2, 0.3, 0.4),
+			Payload: qdrant.NewValueMap(map[string]any{"document_id": 1}),
+		},
+		{
+			Id:      qdrant.NewIDNum(1),
+			Vectors: qdrant.NewVectors(0.5, 0.6, 0.7, 0.8),
+			Payload: qdrant.NewValueMap(map[string]any{"document_id": 2}),
+		},
+	},
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/java.md
@@ -1,5 +1,6 @@
 ```java
 import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.list;
 import static io.qdrant.client.ValueFactory.value;
 import static io.qdrant.client.VectorsFactory.namedVectors;
 import static io.qdrant.client.VectorsFactory.vectors;
@@ -42,6 +43,6 @@ client.upsertAsync(
         PointStruct.newBuilder()
             .setId(id(1))
             .setVectors(vectors(0.5f, 0.6f, 0.7f, 0.8f))
-            .putAllPayload(Map.of("document_id", value(201)))
+            .putAllPayload(Map.of("document_id", list(List.of(value(200), value(201)))))
             .build())).get();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/java.md
@@ -1,0 +1,47 @@
+```java
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.VectorsFactory.namedVectors;
+import static io.qdrant.client.VectorsFactory.vectors;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Points.PointStruct;
+import java.util.List;
+import java.util.Map;
+
+QdrantClient client = new QdrantClient(
+    QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client.upsertAsync(
+    "documents",
+    List.of(
+        PointStruct.newBuilder()
+            .setId(id(1))
+            .setVectors(namedVectors(Map.of()))
+            .putAllPayload(Map.of(
+                "title", value("Document A"),
+                "text", value("This is document A")))
+            .build(),
+        PointStruct.newBuilder()
+            .setId(id(2))
+            .setVectors(namedVectors(Map.of()))
+            .putAllPayload(Map.of(
+                "title", value("Document B"),
+                "text", value("This is document B")))
+            .build())).get();
+
+client.upsertAsync(
+    "chunks",
+    List.of(
+        PointStruct.newBuilder()
+            .setId(id(0))
+            .setVectors(vectors(0.1f, 0.2f, 0.3f, 0.4f))
+            .putAllPayload(Map.of("document_id", value(1)))
+            .build(),
+        PointStruct.newBuilder()
+            .setId(id(1))
+            .setVectors(vectors(0.5f, 0.6f, 0.7f, 0.8f))
+            .putAllPayload(Map.of("document_id", value(2)))
+            .build())).get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/java.md
@@ -17,14 +17,14 @@ client.upsertAsync(
     "documents",
     List.of(
         PointStruct.newBuilder()
-            .setId(id(1))
+            .setId(id(200))
             .setVectors(namedVectors(Map.of()))
             .putAllPayload(Map.of(
                 "title", value("Document A"),
                 "text", value("This is document A")))
             .build(),
         PointStruct.newBuilder()
-            .setId(id(2))
+            .setId(id(201))
             .setVectors(namedVectors(Map.of()))
             .putAllPayload(Map.of(
                 "title", value("Document B"),
@@ -37,11 +37,11 @@ client.upsertAsync(
         PointStruct.newBuilder()
             .setId(id(0))
             .setVectors(vectors(0.1f, 0.2f, 0.3f, 0.4f))
-            .putAllPayload(Map.of("document_id", value(1)))
+            .putAllPayload(Map.of("document_id", value(200)))
             .build(),
         PointStruct.newBuilder()
             .setId(id(1))
             .setVectors(vectors(0.5f, 0.6f, 0.7f, 0.8f))
-            .putAllPayload(Map.of("document_id", value(2)))
+            .putAllPayload(Map.of("document_id", value(201)))
             .build())).get();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/python.md
@@ -3,12 +3,12 @@ client.upsert(
     collection_name="documents",
     points=[
         models.PointStruct(
-            id=1,
+            id=200,
             vector={},
             payload={"title": "Document A", "text": "This is document A"},
         ),
         models.PointStruct(
-            id=2,
+            id=201,
             vector={},
             payload={"title": "Document B", "text": "This is document B"},
         ),
@@ -21,12 +21,12 @@ client.upsert(
         models.PointStruct(
             id=0,
             vector=[0.1, 0.2, 0.3, 0.4],
-            payload={"document_id": 1},
+            payload={"document_id": 200},
         ),
         models.PointStruct(
             id=1,
             vector=[0.5, 0.6, 0.7, 0.8],
-            payload={"document_id": 2},
+            payload={"document_id": 201},
         ),
     ],
 )

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/python.md
@@ -1,0 +1,33 @@
+```python
+client.upsert(
+    collection_name="documents",
+    points=[
+        models.PointStruct(
+            id=1,
+            vector={},
+            payload={"title": "Document A", "text": "This is document A"},
+        ),
+        models.PointStruct(
+            id=2,
+            vector={},
+            payload={"title": "Document B", "text": "This is document B"},
+        ),
+    ],
+)
+
+client.upsert(
+    collection_name="chunks",
+    points=[
+        models.PointStruct(
+            id=0,
+            vector=[0.1, 0.2, 0.3, 0.4],
+            payload={"document_id": 1},
+        ),
+        models.PointStruct(
+            id=1,
+            vector=[0.5, 0.6, 0.7, 0.8],
+            payload={"document_id": 2},
+        ),
+    ],
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/python.md
@@ -26,7 +26,7 @@ client.upsert(
         models.PointStruct(
             id=1,
             vector=[0.5, 0.6, 0.7, 0.8],
-            payload={"document_id": 201},
+            payload={"document_id": [200, 201]},
         ),
     ],
 )

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/rust.md
@@ -33,7 +33,7 @@ client
         "chunks",
         vec![
             PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 200.into())]),
-            PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 201.into())]),
+            PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", vec![200, 201].into())]),
         ],
     ))
     .await?;

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/rust.md
@@ -1,0 +1,40 @@
+```rust
+use std::collections::HashMap;
+
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder, Vector};
+
+client
+    .upsert_points(UpsertPointsBuilder::new(
+        "documents",
+        vec![
+            PointStruct::new(
+                1,
+                HashMap::<String, Vector>::new(),
+                [
+                    ("title", "Document A".into()),
+                    ("text", "This is document A".into()),
+                ],
+            ),
+            PointStruct::new(
+                2,
+                HashMap::<String, Vector>::new(),
+                [
+                    ("title", "Document B".into()),
+                    ("text", "This is document B".into()),
+                ],
+            ),
+        ],
+    ))
+    .await?;
+
+client
+    .upsert_points(UpsertPointsBuilder::new(
+        "chunks",
+        vec![
+            PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 1.into())]),
+            PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 2.into())]),
+        ],
+    ))
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/rust.md
@@ -9,7 +9,7 @@ client
         "documents",
         vec![
             PointStruct::new(
-                1,
+                200,
                 HashMap::<String, Vector>::new(),
                 [
                     ("title", "Document A".into()),
@@ -17,7 +17,7 @@ client
                 ],
             ),
             PointStruct::new(
-                2,
+                201,
                 HashMap::<String, Vector>::new(),
                 [
                     ("title", "Document B".into()),
@@ -32,8 +32,8 @@ client
     .upsert_points(UpsertPointsBuilder::new(
         "chunks",
         vec![
-            PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 1.into())]),
-            PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 2.into())]),
+            PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 200.into())]),
+            PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 201.into())]),
         ],
     ))
     .await?;

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/typescript.md
@@ -24,7 +24,7 @@ await client.upsert("chunks", {
         {
             id: 1,
             vector: [0.5, 0.6, 0.7, 0.8],
-            payload: { document_id: 201 },
+            payload: { document_id: [200, 201] },
         },
     ],
 });

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/typescript.md
@@ -1,0 +1,31 @@
+```typescript
+await client.upsert("documents", {
+    points: [
+        {
+            id: 1,
+            vector: {},
+            payload: { title: "Document A", text: "This is document A" },
+        },
+        {
+            id: 2,
+            vector: {},
+            payload: { title: "Document B", text: "This is document B" },
+        },
+    ],
+});
+
+await client.upsert("chunks", {
+    points: [
+        {
+            id: 0,
+            vector: [0.1, 0.2, 0.3, 0.4],
+            payload: { document_id: 1 },
+        },
+        {
+            id: 1,
+            vector: [0.5, 0.6, 0.7, 0.8],
+            payload: { document_id: 2 },
+        },
+    ],
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/generated/typescript.md
@@ -2,12 +2,12 @@
 await client.upsert("documents", {
     points: [
         {
-            id: 1,
+            id: 200,
             vector: {},
             payload: { title: "Document A", text: "This is document A" },
         },
         {
-            id: 2,
+            id: 201,
             vector: {},
             payload: { title: "Document B", text: "This is document B" },
         },
@@ -19,12 +19,12 @@ await client.upsert("chunks", {
         {
             id: 0,
             vector: [0.1, 0.2, 0.3, 0.4],
-            payload: { document_id: 1 },
+            payload: { document_id: 200 },
         },
         {
             id: 1,
             vector: [0.5, 0.6, 0.7, 0.8],
-            payload: { document_id: 2 },
+            payload: { document_id: 201 },
         },
     ],
 });

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/go.go
@@ -47,7 +47,7 @@ func Main() {
 			{
 				Id:      qdrant.NewIDNum(1),
 				Vectors: qdrant.NewVectors(0.5, 0.6, 0.7, 0.8),
-				Payload: qdrant.NewValueMap(map[string]any{"document_id": 201}),
+				Payload: qdrant.NewValueMap(map[string]any{"document_id": []int{200, 201}}),
 			},
 		},
 	})

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/go.go
@@ -1,0 +1,54 @@
+package snippet
+
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+		Host: "localhost",
+		Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.Upsert(context.Background(), &qdrant.UpsertPoints{
+		CollectionName: "documents",
+		Points: []*qdrant.PointStruct{
+			{
+				Id: qdrant.NewIDNum(1),
+				Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
+				Payload: qdrant.NewValueMap(map[string]any{
+					"title": "Document A",
+					"text":  "This is document A",
+				}),
+			},
+			{
+				Id: qdrant.NewIDNum(2),
+				Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
+				Payload: qdrant.NewValueMap(map[string]any{
+					"title": "Document B",
+					"text":  "This is document B",
+				}),
+			},
+		},
+	})
+
+	client.Upsert(context.Background(), &qdrant.UpsertPoints{
+		CollectionName: "chunks",
+		Points: []*qdrant.PointStruct{
+			{
+				Id:      qdrant.NewIDNum(0),
+				Vectors: qdrant.NewVectors(0.1, 0.2, 0.3, 0.4),
+				Payload: qdrant.NewValueMap(map[string]any{"document_id": 1}),
+			},
+			{
+				Id:      qdrant.NewIDNum(1),
+				Vectors: qdrant.NewVectors(0.5, 0.6, 0.7, 0.8),
+				Payload: qdrant.NewValueMap(map[string]any{"document_id": 2}),
+			},
+		},
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/go.go
@@ -18,7 +18,7 @@ func Main() {
 		CollectionName: "documents",
 		Points: []*qdrant.PointStruct{
 			{
-				Id: qdrant.NewIDNum(1),
+				Id: qdrant.NewIDNum(200),
 				Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
 				Payload: qdrant.NewValueMap(map[string]any{
 					"title": "Document A",
@@ -26,7 +26,7 @@ func Main() {
 				}),
 			},
 			{
-				Id: qdrant.NewIDNum(2),
+				Id: qdrant.NewIDNum(201),
 				Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{}),
 				Payload: qdrant.NewValueMap(map[string]any{
 					"title": "Document B",
@@ -42,12 +42,12 @@ func Main() {
 			{
 				Id:      qdrant.NewIDNum(0),
 				Vectors: qdrant.NewVectors(0.1, 0.2, 0.3, 0.4),
-				Payload: qdrant.NewValueMap(map[string]any{"document_id": 1}),
+				Payload: qdrant.NewValueMap(map[string]any{"document_id": 200}),
 			},
 			{
 				Id:      qdrant.NewIDNum(1),
 				Vectors: qdrant.NewVectors(0.5, 0.6, 0.7, 0.8),
-				Payload: qdrant.NewValueMap(map[string]any{"document_id": 2}),
+				Payload: qdrant.NewValueMap(map[string]any{"document_id": 201}),
 			},
 		},
 	})

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/http.md
@@ -1,0 +1,33 @@
+```http
+PUT /collections/documents/points
+{
+    "points": [
+        {
+            "id": 1,
+            "vector": {},
+            "payload": {"title": "Document A", "text": "This is document A"}
+        },
+        {
+            "id": 2,
+            "vector": {},
+            "payload": {"title": "Document B", "text": "This is document B"}
+        }
+    ]
+}
+
+PUT /collections/chunks/points
+{
+    "points": [
+        {
+            "id": 0,
+            "vector": [0.1, 0.2, 0.3, 0.4],
+            "payload": {"document_id": 1}
+        },
+        {
+            "id": 1,
+            "vector": [0.5, 0.6, 0.7, 0.8],
+            "payload": {"document_id": 2}
+        }
+    ]
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/http.md
@@ -26,7 +26,7 @@ PUT /collections/chunks/points
         {
             "id": 1,
             "vector": [0.5, 0.6, 0.7, 0.8],
-            "payload": {"document_id": 201}
+            "payload": {"document_id": [200, 201]}
         }
     ]
 }

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/http.md
@@ -3,12 +3,12 @@ PUT /collections/documents/points
 {
     "points": [
         {
-            "id": 1,
+            "id": 200,
             "vector": {},
             "payload": {"title": "Document A", "text": "This is document A"}
         },
         {
-            "id": 2,
+            "id": 201,
             "vector": {},
             "payload": {"title": "Document B", "text": "This is document B"}
         }
@@ -21,12 +21,12 @@ PUT /collections/chunks/points
         {
             "id": 0,
             "vector": [0.1, 0.2, 0.3, 0.4],
-            "payload": {"document_id": 1}
+            "payload": {"document_id": 200}
         },
         {
             "id": 1,
             "vector": [0.5, 0.6, 0.7, 0.8],
-            "payload": {"document_id": 2}
+            "payload": {"document_id": 201}
         }
     ]
 }

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/java.java
@@ -1,0 +1,51 @@
+package com.example.snippets_amalgamation;
+
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.VectorsFactory.namedVectors;
+import static io.qdrant.client.VectorsFactory.vectors;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Points.PointStruct;
+import java.util.List;
+import java.util.Map;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client = new QdrantClient(
+                    QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client.upsertAsync(
+                    "documents",
+                    List.of(
+                        PointStruct.newBuilder()
+                            .setId(id(1))
+                            .setVectors(namedVectors(Map.of()))
+                            .putAllPayload(Map.of(
+                                "title", value("Document A"),
+                                "text", value("This is document A")))
+                            .build(),
+                        PointStruct.newBuilder()
+                            .setId(id(2))
+                            .setVectors(namedVectors(Map.of()))
+                            .putAllPayload(Map.of(
+                                "title", value("Document B"),
+                                "text", value("This is document B")))
+                            .build())).get();
+
+                client.upsertAsync(
+                    "chunks",
+                    List.of(
+                        PointStruct.newBuilder()
+                            .setId(id(0))
+                            .setVectors(vectors(0.1f, 0.2f, 0.3f, 0.4f))
+                            .putAllPayload(Map.of("document_id", value(1)))
+                            .build(),
+                        PointStruct.newBuilder()
+                            .setId(id(1))
+                            .setVectors(vectors(0.5f, 0.6f, 0.7f, 0.8f))
+                            .putAllPayload(Map.of("document_id", value(2)))
+                            .build())).get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/java.java
@@ -1,6 +1,7 @@
 package com.example.snippets_amalgamation;
 
 import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.list;
 import static io.qdrant.client.ValueFactory.value;
 import static io.qdrant.client.VectorsFactory.namedVectors;
 import static io.qdrant.client.VectorsFactory.vectors;
@@ -45,7 +46,7 @@ public class Snippet {
                         PointStruct.newBuilder()
                             .setId(id(1))
                             .setVectors(vectors(0.5f, 0.6f, 0.7f, 0.8f))
-                            .putAllPayload(Map.of("document_id", value(201)))
+                            .putAllPayload(Map.of("document_id", list(List.of(value(200), value(201)))))
                             .build())).get();
         }
 }

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/java.java
@@ -20,14 +20,14 @@ public class Snippet {
                     "documents",
                     List.of(
                         PointStruct.newBuilder()
-                            .setId(id(1))
+                            .setId(id(200))
                             .setVectors(namedVectors(Map.of()))
                             .putAllPayload(Map.of(
                                 "title", value("Document A"),
                                 "text", value("This is document A")))
                             .build(),
                         PointStruct.newBuilder()
-                            .setId(id(2))
+                            .setId(id(201))
                             .setVectors(namedVectors(Map.of()))
                             .putAllPayload(Map.of(
                                 "title", value("Document B"),
@@ -40,12 +40,12 @@ public class Snippet {
                         PointStruct.newBuilder()
                             .setId(id(0))
                             .setVectors(vectors(0.1f, 0.2f, 0.3f, 0.4f))
-                            .putAllPayload(Map.of("document_id", value(1)))
+                            .putAllPayload(Map.of("document_id", value(200)))
                             .build(),
                         PointStruct.newBuilder()
                             .setId(id(1))
                             .setVectors(vectors(0.5f, 0.6f, 0.7f, 0.8f))
-                            .putAllPayload(Map.of("document_id", value(2)))
+                            .putAllPayload(Map.of("document_id", value(201)))
                             .build())).get();
         }
 }

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/python.py
@@ -29,7 +29,7 @@ client.upsert(
         models.PointStruct(
             id=1,
             vector=[0.5, 0.6, 0.7, 0.8],
-            payload={"document_id": 201},
+            payload={"document_id": [200, 201]},
         ),
     ],
 )

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/python.py
@@ -1,0 +1,35 @@
+from qdrant_client import QdrantClient, models  # @hide
+
+client = QdrantClient(url="http://localhost:6333")  # @hide
+
+client.upsert(
+    collection_name="documents",
+    points=[
+        models.PointStruct(
+            id=1,
+            vector={},
+            payload={"title": "Document A", "text": "This is document A"},
+        ),
+        models.PointStruct(
+            id=2,
+            vector={},
+            payload={"title": "Document B", "text": "This is document B"},
+        ),
+    ],
+)
+
+client.upsert(
+    collection_name="chunks",
+    points=[
+        models.PointStruct(
+            id=0,
+            vector=[0.1, 0.2, 0.3, 0.4],
+            payload={"document_id": 1},
+        ),
+        models.PointStruct(
+            id=1,
+            vector=[0.5, 0.6, 0.7, 0.8],
+            payload={"document_id": 2},
+        ),
+    ],
+)

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/python.py
@@ -6,12 +6,12 @@ client.upsert(
     collection_name="documents",
     points=[
         models.PointStruct(
-            id=1,
+            id=200,
             vector={},
             payload={"title": "Document A", "text": "This is document A"},
         ),
         models.PointStruct(
-            id=2,
+            id=201,
             vector={},
             payload={"title": "Document B", "text": "This is document B"},
         ),
@@ -24,12 +24,12 @@ client.upsert(
         models.PointStruct(
             id=0,
             vector=[0.1, 0.2, 0.3, 0.4],
-            payload={"document_id": 1},
+            payload={"document_id": 200},
         ),
         models.PointStruct(
             id=1,
             vector=[0.5, 0.6, 0.7, 0.8],
-            payload={"document_id": 2},
+            payload={"document_id": 201},
         ),
     ],
 )

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/rust.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder, Vector};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
+
+    client
+        .upsert_points(UpsertPointsBuilder::new(
+            "documents",
+            vec![
+                PointStruct::new(
+                    1,
+                    HashMap::<String, Vector>::new(),
+                    [
+                        ("title", "Document A".into()),
+                        ("text", "This is document A".into()),
+                    ],
+                ),
+                PointStruct::new(
+                    2,
+                    HashMap::<String, Vector>::new(),
+                    [
+                        ("title", "Document B".into()),
+                        ("text", "This is document B".into()),
+                    ],
+                ),
+            ],
+        ))
+        .await?;
+
+    client
+        .upsert_points(UpsertPointsBuilder::new(
+            "chunks",
+            vec![
+                PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 1.into())]),
+                PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 2.into())]),
+            ],
+        ))
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/rust.rs
@@ -11,7 +11,7 @@ pub async fn main() -> anyhow::Result<()> {
             "documents",
             vec![
                 PointStruct::new(
-                    1,
+                    200,
                     HashMap::<String, Vector>::new(),
                     [
                         ("title", "Document A".into()),
@@ -19,7 +19,7 @@ pub async fn main() -> anyhow::Result<()> {
                     ],
                 ),
                 PointStruct::new(
-                    2,
+                    201,
                     HashMap::<String, Vector>::new(),
                     [
                         ("title", "Document B".into()),
@@ -34,8 +34,8 @@ pub async fn main() -> anyhow::Result<()> {
         .upsert_points(UpsertPointsBuilder::new(
             "chunks",
             vec![
-                PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 1.into())]),
-                PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 2.into())]),
+                PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 200.into())]),
+                PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 201.into())]),
             ],
         ))
         .await?;

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/rust.rs
@@ -35,7 +35,7 @@ pub async fn main() -> anyhow::Result<()> {
             "chunks",
             vec![
                 PointStruct::new(0, vec![0.1, 0.2, 0.3, 0.4], [("document_id", 200.into())]),
-                PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", 201.into())]),
+                PointStruct::new(1, vec![0.5, 0.6, 0.7, 0.8], [("document_id", vec![200, 201].into())]),
             ],
         ))
         .await?;

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/typescript.ts
@@ -5,12 +5,12 @@ const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 await client.upsert("documents", {
     points: [
         {
-            id: 1,
+            id: 200,
             vector: {},
             payload: { title: "Document A", text: "This is document A" },
         },
         {
-            id: 2,
+            id: 201,
             vector: {},
             payload: { title: "Document B", text: "This is document B" },
         },
@@ -22,12 +22,12 @@ await client.upsert("chunks", {
         {
             id: 0,
             vector: [0.1, 0.2, 0.3, 0.4],
-            payload: { document_id: 1 },
+            payload: { document_id: 200 },
         },
         {
             id: 1,
             vector: [0.5, 0.6, 0.7, 0.8],
-            payload: { document_id: 2 },
+            payload: { document_id: 201 },
         },
     ],
 });

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/typescript.ts
@@ -1,0 +1,33 @@
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
+
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
+
+await client.upsert("documents", {
+    points: [
+        {
+            id: 1,
+            vector: {},
+            payload: { title: "Document A", text: "This is document A" },
+        },
+        {
+            id: 2,
+            vector: {},
+            payload: { title: "Document B", text: "This is document B" },
+        },
+    ],
+});
+
+await client.upsert("chunks", {
+    points: [
+        {
+            id: 0,
+            vector: [0.1, 0.2, 0.3, 0.4],
+            payload: { document_id: 1 },
+        },
+        {
+            id: 1,
+            vector: [0.5, 0.6, 0.7, 0.8],
+            payload: { document_id: 2 },
+        },
+    ],
+});

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-ingest/typescript.ts
@@ -27,7 +27,7 @@ await client.upsert("chunks", {
         {
             id: 1,
             vector: [0.5, 0.6, 0.7, 0.8],
-            payload: { document_id: 201 },
+            payload: { document_id: [200, 201] },
         },
     ],
 });

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/_description.md
@@ -1,0 +1,1 @@
+Create the two collections used by the `with_lookup` pattern. The `chunks` collection holds one point per chunk with its own vector. The `documents` collection holds one point per document and carries only payload, no vectors. A payload index on `document_id` is required for `group_by` to work on that field.

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/csharp.cs
@@ -1,0 +1,27 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+			collectionName: "chunks",
+			vectorsConfig: new VectorParams { Size = 4, Distance = Distance.Cosine }
+		);
+
+		await client.CreatePayloadIndexAsync(
+			collectionName: "chunks",
+			fieldName: "document_id",
+			schemaType: PayloadSchemaType.Integer
+		);
+
+		// No vectors, payload only.
+		await client.CreateCollectionAsync(
+			collectionName: "documents",
+			vectorsConfig: new VectorParamsMap()
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/csharp.md
@@ -1,0 +1,23 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+	collectionName: "chunks",
+	vectorsConfig: new VectorParams { Size = 4, Distance = Distance.Cosine }
+);
+
+await client.CreatePayloadIndexAsync(
+	collectionName: "chunks",
+	fieldName: "document_id",
+	schemaType: PayloadSchemaType.Integer
+);
+
+// No vectors, payload only.
+await client.CreateCollectionAsync(
+	collectionName: "documents",
+	vectorsConfig: new VectorParamsMap()
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/go.md
@@ -1,0 +1,34 @@
+```go
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+	Host: "localhost",
+	Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	CollectionName: "chunks",
+	VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+		Size:     4,
+		Distance: qdrant.Distance_Cosine,
+	}),
+})
+
+client.CreateFieldIndex(context.Background(), &qdrant.CreateFieldIndexCollection{
+	CollectionName: "chunks",
+	FieldName:      "document_id",
+	FieldType:      qdrant.FieldType_FieldTypeInteger.Enum(),
+})
+
+// No vectors, payload only.
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	CollectionName: "documents",
+	VectorsConfig: qdrant.NewVectorsConfigMap(
+		map[string]*qdrant.VectorParams{},
+	),
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/java.md
@@ -1,0 +1,34 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.Distance;
+import io.qdrant.client.grpc.Collections.PayloadSchemaType;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import io.qdrant.client.grpc.Collections.VectorParamsMap;
+import io.qdrant.client.grpc.Collections.VectorsConfig;
+
+QdrantClient client = new QdrantClient(
+    QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client.createCollectionAsync("chunks",
+        VectorParams.newBuilder().setDistance(Distance.Cosine).setSize(4).build()).get();
+
+client.createPayloadIndexAsync(
+    "chunks",
+    "document_id",
+    PayloadSchemaType.Integer,
+    null,
+    true,
+    null,
+    null).get();
+
+// No vectors, payload only.
+client.createCollectionAsync(
+    CreateCollection.newBuilder()
+        .setCollectionName("documents")
+        .setVectorsConfig(VectorsConfig.newBuilder()
+            .setParamsMap(VectorParamsMap.newBuilder().build())
+            .build())
+        .build()).get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/python.md
@@ -1,0 +1,17 @@
+```python
+client.create_collection(
+    collection_name="chunks",
+    vectors_config=models.VectorParams(size=4, distance=models.Distance.COSINE),
+)
+
+client.create_payload_index(
+    collection_name="chunks",
+    field_name="document_id",
+    field_schema=models.PayloadSchemaType.INTEGER,
+)
+
+client.create_collection(
+    collection_name="documents",
+    vectors_config={},  # no vectors, payload only
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/rust.md
@@ -1,0 +1,29 @@
+```rust
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, CreateFieldIndexCollectionBuilder, Distance, FieldType,
+    VectorParamsBuilder, VectorsConfigBuilder,
+};
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("chunks")
+            .vectors_config(VectorParamsBuilder::new(4, Distance::Cosine)),
+    )
+    .await?;
+
+client
+    .create_field_index(
+        CreateFieldIndexCollectionBuilder::new("chunks", "document_id", FieldType::Integer)
+            .wait(true),
+    )
+    .await?;
+
+// No vectors, payload only.
+client
+    .create_collection(
+        CreateCollectionBuilder::new("documents")
+            .vectors_config(VectorsConfigBuilder::default()),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/generated/typescript.md
@@ -1,0 +1,14 @@
+```typescript
+await client.createCollection("chunks", {
+    vectors: { size: 4, distance: "Cosine" },
+});
+
+await client.createPayloadIndex("chunks", {
+    field_name: "document_id",
+    field_schema: "integer",
+});
+
+await client.createCollection("documents", {
+    vectors: {}, // no vectors, payload only
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/go.go
@@ -1,0 +1,38 @@
+package snippet
+
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+		Host: "localhost",
+		Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+		CollectionName: "chunks",
+		VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+			Size:     4,
+			Distance: qdrant.Distance_Cosine,
+		}),
+	})
+
+	client.CreateFieldIndex(context.Background(), &qdrant.CreateFieldIndexCollection{
+		CollectionName: "chunks",
+		FieldName:      "document_id",
+		FieldType:      qdrant.FieldType_FieldTypeInteger.Enum(),
+	})
+
+	// No vectors, payload only.
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+		CollectionName: "documents",
+		VectorsConfig: qdrant.NewVectorsConfigMap(
+			map[string]*qdrant.VectorParams{},
+		),
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/http.md
@@ -1,0 +1,20 @@
+```http
+PUT /collections/chunks
+{
+    "vectors": {
+        "size": 4,
+        "distance": "Cosine"
+    }
+}
+
+PUT /collections/chunks/index
+{
+    "field_name": "document_id",
+    "field_schema": "integer"
+}
+
+PUT /collections/documents
+{
+    "vectors": {}
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/java.java
@@ -1,0 +1,38 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.Distance;
+import io.qdrant.client.grpc.Collections.PayloadSchemaType;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import io.qdrant.client.grpc.Collections.VectorParamsMap;
+import io.qdrant.client.grpc.Collections.VectorsConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client = new QdrantClient(
+                    QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client.createCollectionAsync("chunks",
+                        VectorParams.newBuilder().setDistance(Distance.Cosine).setSize(4).build()).get();
+
+                client.createPayloadIndexAsync(
+                    "chunks",
+                    "document_id",
+                    PayloadSchemaType.Integer,
+                    null,
+                    true,
+                    null,
+                    null).get();
+
+                // No vectors, payload only.
+                client.createCollectionAsync(
+                    CreateCollection.newBuilder()
+                        .setCollectionName("documents")
+                        .setVectorsConfig(VectorsConfig.newBuilder()
+                            .setParamsMap(VectorParamsMap.newBuilder().build())
+                            .build())
+                        .build()).get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/python.py
@@ -1,0 +1,19 @@
+from qdrant_client import QdrantClient, models  # @hide
+
+client = QdrantClient(url="http://localhost:6333")  # @hide
+
+client.create_collection(
+    collection_name="chunks",
+    vectors_config=models.VectorParams(size=4, distance=models.Distance.COSINE),
+)
+
+client.create_payload_index(
+    collection_name="chunks",
+    field_name="document_id",
+    field_schema=models.PayloadSchemaType.INTEGER,
+)
+
+client.create_collection(
+    collection_name="documents",
+    vectors_config={},  # no vectors, payload only
+)

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/rust.rs
@@ -1,0 +1,33 @@
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, CreateFieldIndexCollectionBuilder, Distance, FieldType,
+    VectorParamsBuilder, VectorsConfigBuilder,
+};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("chunks")
+                .vectors_config(VectorParamsBuilder::new(4, Distance::Cosine)),
+        )
+        .await?;
+
+    client
+        .create_field_index(
+            CreateFieldIndexCollectionBuilder::new("chunks", "document_id", FieldType::Integer)
+                .wait(true),
+        )
+        .await?;
+
+    // No vectors, payload only.
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("documents")
+                .vectors_config(VectorsConfigBuilder::default()),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup-setup/typescript.ts
@@ -1,0 +1,16 @@
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
+
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
+
+await client.createCollection("chunks", {
+    vectors: { size: 4, distance: "Cosine" },
+});
+
+await client.createPayloadIndex("chunks", {
+    field_name: "document_id",
+    field_schema: "integer",
+});
+
+await client.createCollection("documents", {
+    vectors: {}, // no vectors, payload only
+});

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/csharp.cs
@@ -7,10 +7,10 @@ public class Snippet
 	{
 		var client = new QdrantClient("localhost", 6334);
 
-		await client.SearchGroupsAsync(
-		    collectionName: "{collection_name}",
-		    vector: new float[] { 0.2f, 0.1f, 0.9f, 0.7f},
+		await client.QueryGroupsAsync(
+		    collectionName: "chunks",
 		    groupBy: "document_id",
+		    query: new float[] { 0.2f, 0.1f, 0.9f, 0.7f },
 		    limit: 2,
 		    groupSize: 2,
 		    withLookup: new WithLookup

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/csharp.md
@@ -4,10 +4,10 @@ using Qdrant.Client.Grpc;
 
 var client = new QdrantClient("localhost", 6334);
 
-await client.SearchGroupsAsync(
-    collectionName: "{collection_name}",
-    vector: new float[] { 0.2f, 0.1f, 0.9f, 0.7f},
+await client.QueryGroupsAsync(
+    collectionName: "chunks",
     groupBy: "document_id",
+    query: new float[] { 0.2f, 0.1f, 0.9f, 0.7f },
     limit: 2,
     groupSize: 2,
     withLookup: new WithLookup

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/go.md
@@ -11,9 +11,10 @@ client, err := qdrant.NewClient(&qdrant.Config{
 })
 
 client.QueryGroups(context.Background(), &qdrant.QueryPointGroups{
-	CollectionName: "{collection_name}",
+	CollectionName: "chunks",
 	Query:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),
 	GroupBy:        "document_id",
+	Limit:          qdrant.PtrOf(uint64(2)),
 	GroupSize:      qdrant.PtrOf(uint64(2)),
 	WithLookup: &qdrant.WithLookup{
 		Collection:  "documents",

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/java.md
@@ -9,7 +9,7 @@ import java.util.List;
 
 client.queryGroupsAsync(
         QueryPointGroups.newBuilder()
-                .setCollectionName("{collection_name}")
+                .setCollectionName("chunks")
                 .setQuery(nearest(0.2f, 0.1f, 0.9f, 0.7f))
                 .setGroupBy("document_id")
                 .setLimit(2)

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/python.md
@@ -2,7 +2,7 @@
 client.query_points_groups(
     collection_name="chunks",
     # Same as in the regular search() API
-    query=[1.1],
+    query=[0.2, 0.1, 0.9, 0.7],
     # Grouping parameters
     group_by="document_id",  # Path of the field to group by
     limit=2,  # Max amount of groups
@@ -15,7 +15,7 @@ client.query_points_groups(
         # of the looked up point, True by default
         with_payload=["title", "text"],
         # Options for specifying what to bring from the vector(s)
-        # of the looked up point, True by default
+        # of the looked up point, False by default
         with_vectors=False,
     ),
 )

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/rust.md
@@ -3,10 +3,10 @@ use qdrant_client::qdrant::{with_payload_selector::SelectorOptions, QueryPointGr
 
 client
     .query_groups(
-        QueryPointGroupsBuilder::new("{collection_name}", "document_id")
+        QueryPointGroupsBuilder::new("chunks", "document_id")
             .query(vec![0.2, 0.1, 0.9, 0.7])
             .limit(2u64)
-            .limit(2u64)
+            .group_size(2u64)
             .with_lookup(
                 WithLookupBuilder::new("documents")
                     .with_payload(SelectorOptions::Include(

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/generated/typescript.md
@@ -1,6 +1,6 @@
 ```typescript
-client.queryGroups("{collection_name}", {
-    query: [1.1],
+client.queryGroups("chunks", {
+    query: [0.2, 0.1, 0.9, 0.7],
     group_by: "document_id",
     limit: 2,
     group_size: 2,

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/go.go
@@ -15,9 +15,10 @@ func Main() {
 	if err != nil { panic(err) } // @hide
 
 	client.QueryGroups(context.Background(), &qdrant.QueryPointGroups{
-		CollectionName: "{collection_name}",
+		CollectionName: "chunks",
 		Query:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),
 		GroupBy:        "document_id",
+		Limit:          qdrant.PtrOf(uint64(2)),
 		GroupSize:      qdrant.PtrOf(uint64(2)),
 		WithLookup: &qdrant.WithLookup{
 			Collection:  "documents",

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/http.md
@@ -2,7 +2,7 @@
 POST /collections/chunks/points/query/groups
 {
     // Same as in the regular query API
-    "query": [1.1],
+    "query": [0.2, 0.1, 0.9, 0.7],
 
     // Grouping parameters
     "group_by": "document_id",
@@ -19,7 +19,7 @@ POST /collections/chunks/points/query/groups
         "with_payload": ["title", "text"],
 
         // Options for specifying what to bring from the vector(s) 
-        // of the looked up point, true by default
+        // of the looked up point, false by default
         "with_vectors": false
     }
 }

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/java.java
@@ -17,7 +17,7 @@ public class Snippet {
 
                 client.queryGroupsAsync(
                         QueryPointGroups.newBuilder()
-                                .setCollectionName("{collection_name}")
+                                .setCollectionName("chunks")
                                 .setQuery(nearest(0.2f, 0.1f, 0.9f, 0.7f))
                                 .setGroupBy("document_id")
                                 .setLimit(2)

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/python.py
@@ -5,7 +5,7 @@ client = QdrantClient(url="http://localhost:6333")  # @hide
 client.query_points_groups(
     collection_name="chunks",
     # Same as in the regular search() API
-    query=[1.1],
+    query=[0.2, 0.1, 0.9, 0.7],
     # Grouping parameters
     group_by="document_id",  # Path of the field to group by
     limit=2,  # Max amount of groups
@@ -18,7 +18,7 @@ client.query_points_groups(
         # of the looked up point, True by default
         with_payload=["title", "text"],
         # Options for specifying what to bring from the vector(s)
-        # of the looked up point, True by default
+        # of the looked up point, False by default
         with_vectors=False,
     ),
 )

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/rust.rs
@@ -5,10 +5,10 @@ pub async fn main() -> anyhow::Result<()> {
 
     client
         .query_groups(
-            QueryPointGroupsBuilder::new("{collection_name}", "document_id")
+            QueryPointGroupsBuilder::new("chunks", "document_id")
                 .query(vec![0.2, 0.1, 0.9, 0.7])
                 .limit(2u64)
-                .limit(2u64)
+                .group_size(2u64)
                 .with_lookup(
                     WithLookupBuilder::new("documents")
                         .with_payload(SelectorOptions::Include(

--- a/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-groups/with-lookup/typescript.ts
@@ -2,8 +2,8 @@ import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
 const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
-client.queryGroups("{collection_name}", {
-    query: [1.1],
+client.queryGroups("chunks", {
+    query: [0.2, 0.1, 0.9, 0.7],
     group_by: "document_id",
     limit: 2,
     group_size: 2,

--- a/qdrant-landing/content/documentation/search/search.md
+++ b/qdrant-landing/content/documentation/search/search.md
@@ -400,25 +400,46 @@ If the `group_by` field of a point is an array (e.g. `"document_id": ["a", "b"]`
 
 ### Lookup in groups
 
-Having multiple points for parts of the same item often introduces redundancy in the stored data. Which may be fine if the information shared by the points is small, but it can become a problem if the payload is large, because it multiplies the storage space needed to store the points by a factor of the amount of points we have per group.
+When the points in a group share large fields like titles, abstracts, or full document vectors, copying that data onto every point inflates storage and forces you to rewrite every chunk whenever a shared field changes.
 
-One way of optimizing storage when using groups is to store the information shared by the points with the same group id in a single point in another collection. Then, when using the [**groups** API](#grouping-api), add the `with_lookup` parameter to bring the information from those points into each group.
+`with_lookup` solves this. Store the shared data once in a separate collection, then attach it to each group at query time using the [groups API](#grouping-api).
 
 ![Group id matches point id](/docs/lookup_id_linking.png)
 
 <aside role="status">Store only document-level metadata (e.g., titles, abstracts) in the lookup collection, not chunks or duplicated data.</aside>
 
-This has the extra benefit of having a single point to update when the information shared by the points in a group changes.
+Set up the two collections. `chunks` holds one point per chunk with its own vector. `documents` holds one point per document with payload only. The payload index on `document_id` lets `group_by` work on that field.
 
-For example, if you have a collection of documents, you may want to chunk them and store the points for the chunks in a separate collection, making sure that you store the point id from the document it belongs in the payload of the chunk point.
+{{< code-snippet path="/documentation/headless/snippets/query-groups/with-lookup-setup/" >}}
 
-In this case, to bring the information from the documents into the chunks grouped by the document id, you can use the `with_lookup` parameter:
+Ingest both collections, with `documents` populated before any query that uses `with_lookup`.
+
+{{< code-snippet path="/documentation/headless/snippets/query-groups/with-lookup-ingest/" >}}
+
+The lookup is a plain join by point id, not a vector search:
+
+- The `documents` collection must already contain a point whose id matches the `group_by` value from each chunk.
+- The id types must match. A string `group_by` value against integer point ids returns an empty `lookup` field with no error.
+- Group ids without a matching point in `documents` get an empty `lookup` field.
+
+Query the `chunks` collection with `group_by="document_id"` and `with_lookup` pointing at the `documents` collection:
 
 {{< code-snippet path="/documentation/headless/snippets/query-groups/with-lookup/" >}}
 
-For the `with_lookup` parameter, you can also use the shorthand `with_lookup="documents"` to bring the whole payload and vector(s) without explicitly specifying it.
+You can also pass `with_lookup="documents"` as a shorthand. It uses the server defaults (`with_payload=True`, `with_vectors=False`), so the documents' vectors are not returned. Use the explicit `WithLookup(...)` form when you need those vectors back.
 
-The looked up result will show up under `lookup` in each group.
+```python
+client.query_points_groups(
+    collection_name="chunks",
+    query=[0.2, 0.1, 0.9, 0.7],
+    group_by="document_id",
+    limit=2,
+    group_size=2,
+    with_lookup="documents",  # server defaults: with_payload=True, with_vectors=False
+)
+```
+
+The looked-up result appears under `lookup` in each group.
 
 ```json
 {
@@ -427,8 +448,7 @@ The looked up result will show up under `lookup` in each group.
             {
                 "id": 1,
                 "hits": [
-                    { "id": 0, "score": 0.91 },
-                    { "id": 1, "score": 0.85 }
+                    { "id": 0, "score": 0.93 }
                 ],
                 "lookup": {
                     "id": 1,
@@ -441,7 +461,7 @@ The looked up result will show up under `lookup` in each group.
             {
                 "id": 2,
                 "hits": [
-                    { "id": 1, "score": 0.85 }
+                    { "id": 1, "score": 0.88 }
                 ],
                 "lookup": {
                     "id": 2,
@@ -458,9 +478,7 @@ The looked up result will show up under `lookup` in each group.
 }
 ```
 
-Since the lookup is done by matching directly with the point id, the lookup collection must be pre-populated with points where the `id` matches the `group_by` value (e.g., document_id) from your primary collection.
-
-Any group id that is not an existing (and valid) point id in the lookup collection will be ignored, and the `lookup` field will be empty.
+For a collection of 20 000 documents with around 24 chunks each, duplicating ~3 KB of document-level data on every chunk adds up to ~1.4 GB. Storing those fields once per document in the `documents` collection brings that down to ~60 MB. The split pays off when the shared fields are large or change often, since updating one point in `documents` shows up under every chunk's group at query time.
 
 ## Random Sampling
 

--- a/qdrant-landing/content/documentation/search/search.md
+++ b/qdrant-landing/content/documentation/search/search.md
@@ -428,17 +428,6 @@ Query the `chunks` collection with `group_by="document_id"` and `with_lookup` po
 
 You can also pass `with_lookup="documents"` as a shorthand. It uses the server defaults (`with_payload=True`, `with_vectors=False`), so the documents' vectors are not returned. Use the explicit `WithLookup(...)` form when you need those vectors back.
 
-```python
-client.query_points_groups(
-    collection_name="chunks",
-    query=[0.2, 0.1, 0.9, 0.7],
-    group_by="document_id",
-    limit=2,
-    group_size=2,
-    with_lookup="documents",  # server defaults: with_payload=True, with_vectors=False
-)
-```
-
 The looked-up result appears under `lookup` in each group.
 
 ```json

--- a/qdrant-landing/content/documentation/search/search.md
+++ b/qdrant-landing/content/documentation/search/search.md
@@ -428,19 +428,20 @@ Query the `chunks` collection with `group_by="document_id"` and `with_lookup` po
 
 You can also pass `with_lookup="documents"` as a shorthand. It uses the server defaults (`with_payload=True`, `with_vectors=False`), so the documents' vectors are not returned. Use the explicit `WithLookup(...)` form when you need those vectors back.
 
-The looked-up result appears under `lookup` in each group.
+The looked-up result appears under `lookup` in each group. Below, chunk id 1 shows up in both groups because its `document_id` payload is an array (`[200, 201]`), placing the chunk into every matching group.
 
 ```json
 {
     "result": {
         "groups": [
             {
-                "id": 1,
+                "id": 200,
                 "hits": [
-                    { "id": 0, "score": 0.93 }
+                    { "id": 0, "score": 0.91 },
+                    { "id": 1, "score": 0.85 }
                 ],
                 "lookup": {
-                    "id": 1,
+                    "id": 200,
                     "payload": {
                         "title": "Document A",
                         "text": "This is document A"
@@ -448,12 +449,12 @@ The looked-up result appears under `lookup` in each group.
                 }
             },
             {
-                "id": 2,
+                "id": 201,
                 "hits": [
-                    { "id": 1, "score": 0.88 }
+                    { "id": 1, "score": 0.85 }
                 ],
                 "lookup": {
-                    "id": 2,
+                    "id": 201,
                     "payload": {
                         "title": "Document B",
                         "text": "This is document B"


### PR DESCRIPTION
Preview: https://deploy-preview-2362--condescending-goldwasser-91acf0.netlify.app/documentation/search/search/?q=lookup#lookup-in-groups

## Summary

The Lookup in groups reference now ships a runnable end-to-end example across all seven client languages. Readers can set up the two-collection pattern, ingest, query, and match the documented JSON response without leaving the page.

## What's new

- **Setup snippet** (`query-groups/with-lookup-setup/`): creates `chunks`, the required payload index on `document_id`, and a vectorless `documents` sidecar.
- **Ingest snippet** (`query-groups/with-lookup-ingest/`): upserts documents then chunks.
- **Shorthand Python example** alongside the existing explicit `WithLookup(...)` snippet.
- **Storage trade-off paragraph** quantifying when the split pays off.

## Reference page improvements

- Intro trimmed from 5 paragraphs to 3.
- Constraint paragraph reshaped into a 3-bullet list, moved before the query, and now covers the silent-fail behavior on id type mismatch.
- JSON response example fixed: previously showed chunk id `1` in two groups, which is impossible.
- Shorthand prose corrected: `with_lookup="documents"` does not return looked-up vectors (server default `with_vectors=False`).

## Existing snippet fixes

All six already existed on master and surfaced when running the new walkthrough against the snippet.
| Bug | Fix |
|---|---|
| `with_vectors` comment claimed "true by default" | Corrected to `false` |
| `query=[1.1]` (1-dim) in Python/TS/HTTP vs 4-dim elsewhere | All seven aligned to `[0.2, 0.1, 0.9, 0.7]` |
| `{collection_name}` placeholder in non-Python tabs | All tabs use `"chunks"` |
| Rust `.limit(2u64)` duplicated | Second call now `.group_size(2u64)` |
| Go missing `Limit` field | Added |
| C# legacy `SearchGroupsAsync` | Switched to `QueryGroupsAsync` |

## Verification

- `check.py` compiles all six language sources across three snippet directories.
- `generate-md.py` regenerated all wrapper markdowns.
- End-to-end run against Qdrant 1.18.0: setup → ingest → snippet query → shorthand executes cleanly, matching the documented JSON.
- Silent-fail-on-type-mismatch verified empirically.
- Engine source cross-checked for `WithLookup` field shape, lookup semantics, and `WithVector::default()`.