### PR TITLE
ci: fix remaining GitHub Actions on Node 20

### DIFF
--- a/.github/workflows/check-dead-links.yml
+++ b/.github/workflows/check-dead-links.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           hugo-version: "0.160.1"
       - name: Install npm
-        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
       - name: Run hugo

--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           hugo-version: "0.160.1"
       - name: Install npm
-        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
       - name: Run hugo


### PR DESCRIPTION
Follow-up to the bulk Node 24 migration. These SHA-pinned refs were missed in the first pass.