### PR TITLE
docs: fix typos and improve clarity in quantization/turboQuant docs

### DIFF
--- a/qdrant-landing/content/articles/binary-quantization.md
+++ b/qdrant-landing/content/articles/binary-quantization.md
@@ -181,7 +181,7 @@ If you have lower accuracy requirements you can even try doing a small oversampl
 
 We retrieved some early results on the relationship between limit and oversampling using the the DBPedia OpenAI 1M vector dataset. We ran all these experiments on a Qdrant instance where 100K vectors were indexed and used 100 random queries. 
 
-We varied the 3 parameters that will affect query time and accuracy: limit, rescore and oversampling. We offer these as an initial exploration of this new feature. You are highly encouraged to reproduce these experiments with your data sets.
+We varied the 3 parameters that will affect query time and accuracy: limit, rescore and oversampling. We offer these as an initial exploration of this new feature. You are highly encouraged to reproduce these experiments with your datasets.
 
 > Aside: Since this is a new innovation in vector databases, we are keen to hear feedback and results. [Join our Discord server](https://discord.gg/Qy6HCJK9Dc) for further discussion! 
 
@@ -231,6 +231,6 @@ If you determine that binary quantization is appropriate for your datasets and q
 
 Binary quantization is exceptional if you need to work with large volumes of data under high recall expectations. You can try this feature either by spinning up a [Qdrant container image](https://hub.docker.com/r/qdrant/qdrant) locally or, having us create one for you through a [free account](https://cloud.qdrant.io/signup) in our cloud hosted service. 
 
-The article gives examples of data sets and configuration you can use to get going. Our documentation covers [adding large datasets to Qdrant](/documentation/tutorials-develop/bulk-upload/) to your Qdrant instance as well as [more quantization methods](/documentation/manage-data/quantization/).
+The article gives examples of datasets and configuration you can use to get going. Our documentation covers [adding large datasets to Qdrant](/documentation/tutorials-develop/bulk-upload/) to your Qdrant instance as well as [more quantization methods](/documentation/manage-data/quantization/).
 
 If you have any feedback, drop us a note on Twitter or LinkedIn to tell us about your results. [Join our lively Discord Server](https://discord.gg/Qy6HCJK9Dc) if you want to discuss BQ with like-minded people!

--- a/qdrant-landing/content/articles/product-quantization.md
+++ b/qdrant-landing/content/articles/product-quantization.md
@@ -224,7 +224,7 @@ In circumstances that do not align with the above, Scalar Quantization should be
 ## Using Qdrant for Product Quantization
 
 
-If you’re already a Qdrant user, we have, documentation on [Product Quantization](/documentation/manage-data/quantization/#setting-up-product-quantization) that will help you to set and configure the new quantization for your data and achieve even 
+If you’re already a Qdrant user, our documentation on [Product Quantization](/documentation/manage-data/quantization/#setting-up-product-quantization) will help you set and configure the new quantization for your data and achieve even 
 up to 64x memory reduction.
 
 Ready to experience the power of Product Quantization? [Sign up now](https://cloud.qdrant.io/signup) for a free Qdrant demo and optimize your data management today!

--- a/qdrant-landing/content/articles/turboquant-quantization.md
+++ b/qdrant-landing/content/articles/turboquant-quantization.md
@@ -46,7 +46,7 @@ To enable TurboQuant, specify it in the `quantization_config` section of the col
 
 When enabling TurboQuant on an existing collection, use a `PATCH` request, or the corresponding `update_collection` method in any client SDK.
 
-The `bits` field controls encoding bit depth. It defaults to `bits4`. Available values: `bits4`, `bits2`, `bits1_5`, and `bits1`. Lower bit depths offer higher compression at the cost of accuracy. See the [benchmarks](#detailed-benchmarks) for the recall trade-off on each bit width. The full reference is in [the quantization docs](https://qdrant.tech/documentation/guides/quantization/).
+The `bits` field controls encoding bit depth. It defaults to `bits4`. Available values: `bits4`, `bits2`, `bits1_5`, and `bits1`. Lower bit depths offer higher compression at the cost of accuracy. See the [benchmarks](#detailed-benchmarks) for the recall trade-off on each bit width. The full reference is in [the quantization docs](https://qdrant.tech/documentation/manage-data/quantization/).
 
 ## At a Glance
 
@@ -124,7 +124,7 @@ Truly isotropic data matches the theoretical Gaussian quantiles, the formula col
 
 ### L2 and Unnormalized Dot
 
-Vanilla TurboQuant assumes all inputs live on the unit sphere; that is, cosine distance only. We extend the scoring mechanism and unlock L2 and unnormalized dot by *storing the original L2 norm*, normalizing the vectors and then apply the L2 norm back during scoring.
+Vanilla TurboQuant assumes all inputs live on the unit sphere; that is, cosine distance only. We extend the scoring mechanism and unlock L2 and unnormalized dot by *storing the original L2 norm*, normalizing the vectors, and then applying the L2 norm back during scoring.
 
 L2 distances are reconstructed via the identity `‖q − v‖² = ‖q‖² + ‖v‖² − 2⟨q, v⟩ = ‖q‖² + ‖v‖² − 2 ‖v‖ ‖q‖ ⟨q_normalized, v_normalized⟩`, where all components on the right-hand side are already available.
 

--- a/qdrant-landing/content/blog/qdrant-1.18.x.md
+++ b/qdrant-landing/content/blog/qdrant-1.18.x.md
@@ -84,7 +84,7 @@ Understanding how much memory a Qdrant collection actually uses has traditionall
 
 This release introduces [collection memory monitoring](/documentation/ops-monitoring/memory-usage/), offering a detailed breakdown of disk, RAM, and OS page cache usage per component, summed across the whole cluster.
 
-In Web UI, open the collection detail page and select the **Memory** tab to see the memory breakdown.
+In the Web UI, open the collection detail page and select the **Memory** tab to see the memory breakdown.
 
 <figure>
   <img width="75%" src="/blog/qdrant-1.18.x/memory-usage.png" alt="The Memory tab showing a breakdown of disk, RAM, cached, and expected cache values per collection component.">

--- a/qdrant-landing/content/documentation/manage-data/quantization.md
+++ b/qdrant-landing/content/documentation/manage-data/quantization.md
@@ -12,7 +12,7 @@ aliases:
 # Quantization
 
 Quantization is an optional feature in Qdrant that enables efficient storage and search of high-dimensional vectors.
-By transforming original vectors into a new representations, quantization compresses data while preserving close to original relative distances between vectors.
+By transforming original vectors into new representations, quantization compresses data while preserving close to original relative distances between vectors.
 Different quantization methods have different mechanics and tradeoffs. We will cover them in this section.
 
 Quantization is primarily used to reduce the memory footprint and accelerate the search process in high-dimensional vector spaces.
@@ -109,7 +109,7 @@ Please refer to the [Quantization Tips](#quantization-tips) section for more inf
 [Binary quantization](/articles/binary-quantization/) is an extreme case of scalar quantization.
 This feature lets you represent each vector component as a single bit, effectively reducing the memory footprint by a factor of 32. This is the fastest quantization method, since it lets you perform a vector comparison with a few CPU instructions. Binary quantization can achieve up to a 40x speedup compared to the original vectors.
 
-However, binary quantization is only efficient for high-dimensional vectors and require a centered distribution of vector components.
+However, binary quantization is only efficient for high-dimensional vectors and requires a centered distribution of vector components.
 
 At the moment, binary quantization shows good accuracy results with the following models:
 
@@ -167,7 +167,7 @@ In order to build 2-bit representation, Qdrant computes values distribution and 
 - `0` - 01
 - `1` - 11
 
-1.5-bit quantization is similar, but merges buckets of pairs of elements into a binary triptets
+1.5-bit quantization is similar, but it merges buckets of element pairs into binary triplets.
 
 {{<figure src=/docs/2-bit-quantization.png caption="2-bit quantization" width=80% >}}
 
@@ -177,8 +177,8 @@ See how to set up 1.5-bit and 2-bit quantization in the [following section](#set
 
 *Available as of v1.15.0*
 
-The **Asymmetric Quantization** technique allows qdrant to use different vector encoding algorithm for stored vectors and for queries.
-Particularly interesting combination is a Binary stored vectors and Scalar quantized queries.
+The **Asymmetric Quantization** technique allows Qdrant to use different vector encoding algorithms for stored vectors and queries.
+A particularly interesting combination is binary stored vectors and Scalar quantized queries.
 
 {{<figure src=/docs/asymmetric-quantization.png caption="Asymmetric quantization" width=80% >}}
 
@@ -353,9 +353,9 @@ In this section, we will discuss how to tune the memory and speed of the search 
 
 There are 3 possible modes to place storage of vectors within the qdrant collection:
 
-- **All in RAM** - all vector, original and quantized, are loaded and kept in RAM. This is the fastest mode, but requires a lot of RAM. Enabled by default.
+- **All in RAM** - all vectors, original and quantized, are loaded and kept in RAM. This is the fastest mode, but requires a lot of RAM. Enabled by default.
 
-- **Original on Disk, quantized in RAM** - this is a hybrid mode, allows to obtain a good balance between speed and memory usage. Recommended scenario if you are aiming to shrink the memory footprint while keeping the search speed.
+- **Original on Disk, quantized in RAM** - this is a hybrid mode that provides a good balance between speed and memory usage. It is recommended if you are aiming to shrink the memory footprint while keeping the search speed.
 
   This mode is enabled by setting `always_ram` to `true` in the quantization config while using memmap storage:\
 {{< code-snippet path="/documentation/headless/snippets/create-collection/scalar-quantization-in-ram/" >}}
@@ -366,7 +366,7 @@ There are 3 possible modes to place storage of vectors within the qdrant collect
   Consider disabling `rescore` to improve the search speed:\
 {{< code-snippet path="/documentation/headless/snippets/query-points/with-disabled-rescoring/" >}}
 
-- **All on Disk** - all vectors, original and quantized, are stored on disk. This mode allows to achieve the smallest memory footprint, but at the cost of the search speed.
+- **All on Disk** - all vectors, original and quantized, are stored on disk. This mode achieves the smallest memory footprint, but at the cost of search speed.
 
   It is recommended to use this mode if you have a large collection and fast storage (e.g. SSD or NVMe).
 


### PR DESCRIPTION
### summary 

- Fix small typos and improve phrasing across quantization docs and blog posts
- the edits are for clarity and consistency in binary/product/turboquant articles and 1.18.x release notes