### PR TITLE
Fix missing image in css file

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/healthcare/_healthcare-use-cases.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/healthcare/_healthcare-use-cases.scss
@@ -210,7 +210,6 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-image: url('/img/healthcare/use-case-texture.png');
     background-size: pxToRem(819) pxToRem(819);
     mix-blend-mode: overlay;
     opacity: 0.5;


### PR DESCRIPTION
https://github.com/qdrant/landing_page/pull/2372 surfaced a missing image reference in a css file. To unblock https://github.com/qdrant/landing_page/pull/2372, this PR simply removes the css line that references the missing image, as it wasn't doing anything anyway. 

Let me know if you want this fixed in another way @trean .