### PR TITLE
Fix dead chunking-strategies link in FAQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ qdrant-landing/.DS_Store
 package-lock.json
 .claude/
 dart-sass/
+
+.env
+.venv/

--- a/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
+++ b/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
@@ -79,7 +79,7 @@ Yes, in most Retrieval-Augmented Generation (RAG) setups, each chunk is stored a
 
 How you chunk matters significantly and is domain-dependent. As a starting point: paragraph-level chunking works well for books and prose; sentence-level chunking tends to work better for technical articles and Q\&A content. Plan to experiment — chunking strategy is one of the highest-leverage variables in retrieval quality.
 
-See also: [Text Chunking Strategies](course/essentials/day-1/chunking-strategies/)
+See also: [Text Chunking Strategies](/course/essentials/day-1/chunking-strategies/)
 
 ### How does point deletion work internally? Does Qdrant rebuild the index on every delete?
 


### PR DESCRIPTION
## What

Two small changes:

1. **Fix dead link** in `faq/qdrant-fundamentals.md`. The "Text Chunking Strategies" link used a relative path (`course/...`), so it resolved against the FAQ page to `/documentation/faq/qdrant-fundamentals/course/.../chunking-strategies/` → 404. Changed to the absolute path `/course/essentials/day-1/chunking-strategies/` (200, and consistent with how the same link is written in `branch-aware-search.md`).
2. **`.gitignore`** — add `.env` and `.venv/`.

## Verification

- `https://qdrant.tech/documentation/faq/qdrant-fundamentals/course/essentials/day-1/chunking-strategies/` → **404** (old behavior)
- `https://qdrant.tech/course/essentials/day-1/chunking-strategies/` → **200** (fixed target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)