### PR TITLE
add empty pages rendering guard

### DIFF
--- a/qdrant-landing/content/documentation/cloud-tab.md
+++ b/qdrant-landing/content/documentation/cloud-tab.md
@@ -104,4 +104,6 @@ content:
         url: https://qdrant.to/cloud
 partition: deploy
 hideInSidebar: true
+build:
+  render: always
 ---

--- a/qdrant-landing/content/documentation/deploy-tab.md
+++ b/qdrant-landing/content/documentation/deploy-tab.md
@@ -107,4 +107,6 @@ content:
         url: https://qdrant.to/cloud
 partition: deploy
 hideInSidebar: true
+build:
+  render: always
 ---

--- a/qdrant-landing/content/documentation/ecosystem-tab.md
+++ b/qdrant-landing/content/documentation/ecosystem-tab.md
@@ -50,4 +50,6 @@ content:
         text: Read More
 partition: ecosystem
 hideInSidebar: true
+build:
+  render: always
 ---

--- a/qdrant-landing/themes/qdrant-2024/layouts/_default/baseof.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ if (eq .Params.type "external-link") }}
         Redirecting to <a href="{{ .Params.external_url }}">external page</a>...

--- a/qdrant-landing/themes/qdrant-2024/layouts/articles/list.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/articles/list.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "documentation/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/articles/single.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/articles/single.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "documentation/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/course/list.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/course/list.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "course/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/course/single.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/course/single.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "course/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/documentation/list.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/documentation/list.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "documentation/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/documentation/single.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/documentation/single.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "documentation/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/learn/list.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/learn/list.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "documentation/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/learn/single.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/learn/single.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    {{- partial "validate-content.html" . -}}
     <main>
       {{ partial "documentation/header" . }}
       {{ partial "documentation/content-layout" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/validate-content.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/validate-content.html
@@ -1,0 +1,9 @@
+{{ if and (not (in (slice "section" "home") .Kind)) (not .Content) (ne .Params.type "external-link") (ne .Params.build.render "always") }}
+  {{- $reset := "\033[0m" -}}
+  {{- $code := "\033[36m" -}}
+  {{- $msg := print
+    "Page %q has empty " $code ".Content" $reset ". If this is a headless file, consider adding build options to the parent " $code "_index.md" $reset " or the file itself to prevent it from being rendered. "
+    "Otherwise, add " $code "build.render: always" $reset " to the file."
+  -}}
+  {{ errorf $msg .Path }}
+{{ end }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/subscribe/list.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/subscribe/list.html
@@ -3,6 +3,7 @@
 {{- partial "head.html" . -}}
 
 <body>
+{{- partial "validate-content.html" . -}}
 {{ partial "site-header" . }}
 {{ partial "subscribe" . }}
 </body>


### PR DESCRIPTION
<img width="970" height="264" alt="image" src="https://github.com/user-attachments/assets/b7626d16-4cf0-4c94-ad73-7d0b7af9e493" />

If a markdown file has no content and no build options, Hugo will throw an error. This is needed to prevent headless markdown files from rendering as empty pages.