### PR TITLE
Fix GitHub repo links in sparse embeddings e-commerce series

### DIFF
--- a/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-1.md
+++ b/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-1.md
@@ -28,7 +28,7 @@ Search "iPhone 15 Pro Max 256GB" on a dense embedding system and it happily retu
 
 This is the gap that sparse embeddings fill. And with fine-tuning, they fill it dramatically well - we achieved a **29% improvement over BM25** on Amazon's ESCI dataset, one of the largest public e-commerce search benchmarks.
 
-In this series, we'll build the entire system: data loading, GPU training on Modal, evaluation with Qdrant, and hard negative mining. The [full code is on GitHub](https://github.com/thierrypdamiba/finetune-ecommerce-search) and the [fine-tuned models are on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci). If you want to skip the walkthrough and fine-tune on your own data, the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI runs the entire pipeline with one command. But first, let's understand why sparse embeddings are the right tool for e-commerce search.
+In this series, we'll build the entire system: data loading, GPU training on Modal, evaluation with Qdrant, and hard negative mining. The [full code is on GitHub](https://github.com/qdrant-labs/devrel-projects/tree/main/qdrant-sparse-finetune) and the [fine-tuned models are on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci). If you want to skip the walkthrough and fine-tune on your own data, the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI runs the entire pipeline with one command. But first, let's understand why sparse embeddings are the right tool for e-commerce search.
 
 ## The Problem with Dense Embeddings in E-Commerce
 

--- a/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-2.md
+++ b/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-2.md
@@ -22,7 +22,7 @@ category: practicle-examples
 
 ---
 
-In the last article we made the case for sparse embeddings in e-commerce search. Now we write the code. All source code is available in the [GitHub repo](https://github.com/thierrypdamiba/finetune-ecommerce-search), and you can try the [fine-tuned models on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci). Want to skip straight to fine-tuning on your own data? See the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI. By the end of this piece, you'll have a SPLADE model trained on Amazon's ESCI dataset, running on Modal's serverless GPUs, with checkpoints saved to persistent storage.
+In the last article we made the case for sparse embeddings in e-commerce search. Now we write the code. All source code is available in the [GitHub repo](https://github.com/qdrant-labs/devrel-projects/tree/main/qdrant-sparse-finetune), and you can try the [fine-tuned models on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci). Want to skip straight to fine-tuning on your own data? See the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI. By the end of this piece, you'll have a SPLADE model trained on Amazon's ESCI dataset, running on Modal's serverless GPUs, with checkpoints saved to persistent storage.
 
 ## The Dataset: Amazon ESCI
 

--- a/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-3.md
+++ b/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-3.md
@@ -22,7 +22,7 @@ category: practicle-examples
 
 ---
 
-We have a trained SPLADE model sitting on a Modal volume (or grab it from [HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci)). Now comes the question that matters: is it actually better? In this article, we'll index products into Qdrant, run retrieval benchmarks, implement hard negative mining, and dig into what the model learned. Full evaluation code is in the [GitHub repo](https://github.com/thierrypdamiba/finetune-ecommerce-search). To run this entire pipeline on your own data, see the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI.
+We have a trained SPLADE model sitting on a Modal volume (or grab it from [HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci)). Now comes the question that matters: is it actually better? In this article, we'll index products into Qdrant, run retrieval benchmarks, implement hard negative mining, and dig into what the model learned. Full evaluation code is in the [GitHub repo](https://github.com/qdrant-labs/devrel-projects/tree/main/qdrant-sparse-finetune). To run this entire pipeline on your own data, see the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI.
 
 ## Indexing Products in Qdrant
 

--- a/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-4.md
+++ b/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-4.md
@@ -22,7 +22,7 @@ category: practicle-examples
 
 ---
 
-We've built a SPLADE model that beats BM25 by 28% on Amazon ESCI. But here's the question that determines whether this is a lab result or a production strategy: does it work on data it wasn't trained on? Full code is on [GitHub](https://github.com/thierrypdamiba/finetune-ecommerce-search), you can try the [fine-tuned models on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci), or fine-tune on your own catalog with the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI.
+We've built a SPLADE model that beats BM25 by 28% on Amazon ESCI. But here's the question that determines whether this is a lab result or a production strategy: does it work on data it wasn't trained on? Full code is on [GitHub](https://github.com/qdrant-labs/devrel-projects/tree/main/qdrant-sparse-finetune), you can try the [fine-tuned models on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci), or fine-tune on your own catalog with the [`sparse-finetune`](https://github.com/qdrant/sparse-finetune) CLI.
 
 In this final article, we test cross-domain generalization, train a multi-domain model, and lay out a decision framework for when to specialize vs generalize.
 
@@ -171,7 +171,7 @@ Extensions worth exploring:
 - **Full dataset training**: We used 100K samples from ESCI. The full 1.2M with multiple epochs would likely improve results further.
 - **Curriculum learning**: Start with general data, gradually specialize to your domain. This can mitigate catastrophic forgetting while still achieving strong in-domain performance.
 
-The [code is open source](https://github.com/thierrypdamiba/finetune-ecommerce-search). The [pre-trained models are on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci) (including a [multi-domain variant](https://huggingface.co/thierrydamiba/splade-ecommerce-multidomain)). Training runs on Modal for under $1. Qdrant handles the [sparse vectors](https://qdrant.tech/articles/sparse-vectors/), indexing, and retrieval out of the box. The barrier to building better e-commerce search has never been lower.
+The [code is open source](https://github.com/qdrant-labs/devrel-projects/tree/main/qdrant-sparse-finetune). The [pre-trained models are on HuggingFace](https://huggingface.co/thierrydamiba/splade-ecommerce-esci) (including a [multi-domain variant](https://huggingface.co/thierrydamiba/splade-ecommerce-multidomain)). Training runs on Modal for under $1. Qdrant handles the [sparse vectors](https://qdrant.tech/articles/sparse-vectors/), indexing, and retrieval out of the box. The barrier to building better e-commerce search has never been lower.
 
 We also packaged this entire pipeline into an open-source toolkit with a CLI and web dashboard. See [Part 5: From Research to Product](/articles/sparse-embeddings-ecommerce-part-5/) for how to fine-tune a SPLADE model on your own catalog with a single command.
 

--- a/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-5.md
+++ b/qdrant-landing/content/articles/sparse-embeddings-ecommerce-part-5.md
@@ -32,7 +32,7 @@ So we packaged everything into [`qdrant-sparse-finetune`](https://github.com/qdr
 
 ![From research repo to production CLI](/articles_data/sparse-embeddings-ecommerce-part-5/research-to-production-pipeline.png)
 
-The series repo ([finetune-ecommerce-search](https://github.com/thierrypdamiba/finetune-ecommerce-search)) is research code. It demonstrates how sparse embedding fine-tuning works. Actually using it on your data means you need to:
+The series repo ([qdrant-sparse-finetune](https://github.com/qdrant-labs/devrel-projects/tree/main/qdrant-sparse-finetune)) is research code. It demonstrates how sparse embedding fine-tuning works. Actually using it on your data means you need to:
 
 1. Format your product data to match the expected schema
 2. Either provide labeled queries or set up an LLM API for synthetic generation


### PR DESCRIPTION
## Summary

- Update GitHub repo links across all 5 sparse embeddings e-commerce articles
- Old URL: `github.com/thierrypdamiba/finetune-ecommerce-search`
- New URL: `github.com/qdrant-labs/devrel-projects/tree/main/qdrant-sparse-finetune`

🤖 Generated with [Claude Code](https://claude.com/claude-code)