### PR TITLE
Edge 0.7 documentation updates

### DIFF
--- a/automation/snippets/docker/Dockerfile
+++ b/automation/snippets/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN add-apt-repository ppa:dotnet/backports && \
 # for rust client
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     CARGO_HOME=/opt/rust RUSTUP_HOME=/opt/rust \
-    sh -s -- -y --default-toolchain 1.94.0
+    sh -s -- -y --default-toolchain nightly
 
 # for typescript client
 RUN npm install --global --prefix /usr/local pnpm

--- a/automation/snippets/templates/python/pyproject.toml
+++ b/automation/snippets/templates/python/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "datasets>=4.4.1",
     "fastembed",
     "qdrant-client",
-    "qdrant-edge-py==0.6.0"
+    "qdrant-edge-py==0.7.2"
 ]
 
 [tool.uv.sources]

--- a/automation/snippets/templates/python/uv.lock
+++ b/automation/snippets/templates/python/uv.lock
@@ -1434,17 +1434,17 @@ dependencies = [
 
 [[package]]
 name = "qdrant-edge-py"
-version = "0.6.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/72/fce3df4e4b8882b5b00ab3d0a574bbeee2d39a8e520ccf246f456effd185/qdrant_edge_py-0.6.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c9d463e7fa81541d60ab8671e6e92a9afd8c4a0e2cfb7e13ea8f5d76e70b877a", size = 9728290, upload-time = "2026-03-19T21:16:15.03Z" },
-    { url = "https://files.pythonhosted.org/packages/41/99/70f4e87f7f2ef68c5f92104b914c0e756c22b4bd19957de30a213dadff22/qdrant_edge_py-0.6.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a18b0bf0355260466bb8d453f2cedc7a9e4f6a2e9d9c58489b859150a3c7e0a6", size = 9203390, upload-time = "2026-03-19T21:16:17.255Z" },
-    { url = "https://files.pythonhosted.org/packages/80/55/998ea744a4cef59c69e86b7b2b57ca2f2d4b0f86c212c7b43dd90cc6360e/qdrant_edge_py-0.6.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cda53f31d8693d090ec564e6761037f57af6f342ac2eef82e1c160c00d80f331", size = 10287388, upload-time = "2026-03-19T21:16:19.215Z" },
-    { url = "https://files.pythonhosted.org/packages/40/d2/9e24a9c57699fe6df9a4f3b6cd0d4c3c9f0bfdbd502a28d25fdfadd44ab5/qdrant_edge_py-0.6.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:80c5e8f8cf650e422a3d313e394bde2760c6206914cd9d6142c9c5e730a76639", size = 9752632, upload-time = "2026-03-19T21:16:21.409Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/3c/a01840efcae392e5a376a483b9a19705ed0f5bc030befbe3d25b58a6d3d4/qdrant_edge_py-0.6.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:d2ab0d209f693fd0d5225072441ed47eccee4f7044470a293c54a3ffdf963cfc", size = 10287245, upload-time = "2026-03-19T21:16:24.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/45/a3ec5e7d36c5dd4510e4f90d0adaf6aa3e66cff35884ff3edefce240fd77/qdrant_edge_py-0.6.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9abd0c3aedfed380d4c4a82626004b746bd05cb6a8e28e1b2fe7467726dc8840", size = 9935881, upload-time = "2026-03-19T21:16:26.384Z" },
-    { url = "https://files.pythonhosted.org/packages/66/0d/43c9033fbb12f0858d5af73b842acb02b3208fe1a31882def2ef23fd560c/qdrant_edge_py-0.6.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ea51a917fc1b927d799d60e166337b6837ee3da39c23d4dc736b82b67497ff12", size = 10507046, upload-time = "2026-03-19T21:16:28.536Z" },
-    { url = "https://files.pythonhosted.org/packages/73/33/b2ead1c51a59d31d19418e6d6ca8ea3ce0f32f76efdd48248a1a3791357f/qdrant_edge_py-0.6.0-cp310-abi3-win_amd64.whl", hash = "sha256:d8376e30b53fbb5d9ac8b0aea683173096d7a775b351110aee4337460c906e71", size = 9905482, upload-time = "2026-03-19T21:16:30.555Z" },
+    { url = "https://files.pythonhosted.org/packages/56/cb/94de5aebf8380172da89c4028613146cf60da89b37526953495a3e938d67/qdrant_edge_py-0.7.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:55198076f0de80330737b53cee99edf95faeffb00aa9bca6bc302e1d601d20b6", size = 10526152, upload-time = "2026-06-01T10:20:58.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b2/21559919e38a039b0d1be85c024b5781cabddb8d50a28250880bc1cab503/qdrant_edge_py-0.7.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:fc34918fde9e3762c12c228a7b4e3baaaca6b3f3ddb9c9ae8092090f91d8b761", size = 9891156, upload-time = "2026-06-01T10:21:00.464Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/7fc9515d9645457effd596b5fc018510475a9f7b6d1b02f90593d507a17f/qdrant_edge_py-0.7.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1157924bdcb081af04d2f21c7658e4120e7793b214ac81f77750b359cf921689", size = 11261757, upload-time = "2026-06-01T10:21:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ec/2a475eda7f6b83a1a89f2fc41fa2c08294e0f71f735fc45148144a0185c0/qdrant_edge_py-0.7.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c8f070ca8c49e2175b405794c490340638c841459cbbacb79e873bb286f9e9ae", size = 10651844, upload-time = "2026-06-01T10:21:04.442Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4d/5d3c8ea787f2ffd47d997c575f196e7b7486db404fa6b6fe522be5a10d13/qdrant_edge_py-0.7.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f2ecd4cbe6dedfa408b933bfe28917d9274cdfa58243d32ca3c390cd3b1c721e", size = 11259962, upload-time = "2026-06-01T10:21:06.367Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ae/18c6990c3a58628f97381e1494916120350fcf05c4d3dfcf82433cedb9a9/qdrant_edge_py-0.7.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:93b8c0b4f7d6fc58284dc0533d66bf18742767c1fbaef60ddd47651a79137e57", size = 10825604, upload-time = "2026-06-01T10:21:08.404Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/eb/a79ca27405196ad3da8f1fe88c7dc5b3888e25d531c6aed043c5efa48124/qdrant_edge_py-0.7.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b13a892947b5eb2e8ac1a8049fd57a88d1b1d0a390ae2c432d1c0c8b8b0e3c0d", size = 11481427, upload-time = "2026-06-01T10:21:10.604Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/45/e7b1f28f82ba2392bc893ef65f20b8093c917396493f1ca43c1b2db56c09/qdrant_edge_py-0.7.2-cp310-abi3-win_amd64.whl", hash = "sha256:e6642e1f73ff28f6aeb2c377fdbe93dd0fa25db2d0c54936279e77e2d8ffb574", size = 10599513, upload-time = "2026-06-01T10:21:12.703Z" },
 ]
 
 [[package]]
@@ -1510,7 +1510,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.4.1" },
     { name = "fastembed" },
     { name = "qdrant-client", git = "https://github.com/qdrant/qdrant-client?tag=v1.18.0" },
-    { name = "qdrant-edge-py", specifier = "==0.6.0" },
+    { name = "qdrant-edge-py", specifier = "==0.7.2" },
 ]
 
 [package.metadata.requires-dev]

--- a/automation/snippets/templates/rust/Cargo.lock
+++ b/automation/snippets/templates/rust/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
 
 [[package]]
 name = "atomicwrites"
@@ -334,34 +334,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
@@ -370,36 +342,44 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
-name = "axum-core"
-version = "0.3.4"
+name = "axum"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
+ "axum-core 0.5.6",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
  "mime",
- "rustversion",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -413,13 +393,31 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -438,12 +436,6 @@ dependencies = [
  "rustc-demangle",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -546,11 +538,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -658,7 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.0",
 ]
 
@@ -708,6 +700,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -771,15 +769,6 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -838,12 +827,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -916,20 +904,9 @@ checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "delegate"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -973,11 +950,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -1014,6 +992,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "duplicate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,20 +1015,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a742b95783b1f45b900129082cbc47717b6a77ee8d17eea70a8ea62462f5de3"
 
 [[package]]
-name = "earcutr"
-version = "0.4.3"
+name = "earcut"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
 dependencies = [
- "itertools 0.11.0",
  "num-traits",
 ]
 
 [[package]]
 name = "ecow"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+checksum = "62bac48c16a993694c703f2991527d422d9efb8ec5625756004ba30e97683720"
 dependencies = [
  "serde",
 ]
@@ -1209,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "float_next_after"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
 
 [[package]]
 name = "fnv"
@@ -1252,12 +1240,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.13.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1380,29 +1368,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "geo"
-version = "0.32.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
 dependencies = [
- "earcutr",
+ "earcut",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "i_overlay",
  "log",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.10.1",
+ "rand_pcg",
  "robust",
  "rstar",
  "sif-itree",
@@ -1411,15 +1390,16 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
  "rayon",
  "rstar",
  "serde",
+ "spade",
 ]
 
 [[package]]
@@ -1433,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "geohash"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb94b1a65401d6cbf22958a9040aa364812c26674f841bee538b12c135db1e6"
+checksum = "7f58890382f70caccc5fa388981f7ac80c913795042afce9f3e065695d8f7464"
 dependencies = [
  "geo-types",
  "libm",
@@ -1501,25 +1481,6 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1529,7 +1490,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -1634,17 +1595,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1655,23 +1605,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1682,8 +1621,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1700,27 +1639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "0.14.32"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
+ "typenum",
 ]
 
 [[package]]
@@ -1733,9 +1657,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1752,27 +1676,15 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1781,7 +1693,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1794,13 +1706,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1813,24 +1725,27 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "i_key_sort"
-version = "0.6.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "i_overlay"
-version = "4.0.7"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -1841,18 +1756,18 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.14.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
 dependencies = [
  "i_float",
 ]
 
 [[package]]
 name = "i_tree"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "iana-time-zone"
@@ -2056,9 +1971,9 @@ checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
 
 [[package]]
 name = "io-uring"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -2097,15 +2012,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2285,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -2297,9 +2203,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2322,6 +2228,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2365,14 +2277,20 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "murmur3_32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e7c60ee0b5e809b81d443bab6a735f9c80fe2138ebc5d758cda7b4faa2cdbd"
 
 [[package]]
 name = "nix"
@@ -2522,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "bytemuck",
  "num-traits",
@@ -2818,6 +2736,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
 name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,15 +2770,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
@@ -2864,7 +2785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2876,7 +2797,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost 0.13.5",
+ "prost",
 ]
 
 [[package]]
@@ -2889,7 +2810,7 @@ dependencies = [
  "futures",
  "futures-util",
  "parking_lot",
- "prost 0.13.5",
+ "prost",
  "prost-types",
  "reqwest",
  "semver",
@@ -2902,11 +2823,12 @@ dependencies = [
 
 [[package]]
 name = "qdrant-edge"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6f1c06fc434230c87cd0a87ac24907f9e7ff06fbd4e604f775c89c17f910c6"
+checksum = "b2e5e480105a06c8f1703082758d74a13c98fb7a94df06e12d914460786e55ea"
 dependencies = [
  "ahash",
+ "aligned-vec",
  "arrayvec 0.7.6",
  "atomic_refcell",
  "atomicwrites",
@@ -2921,8 +2843,8 @@ dependencies = [
  "chrono",
  "crc32c",
  "data-encoding",
- "delegate",
  "docopt",
+ "duplicate",
  "ecow",
  "env_logger",
  "fnv",
@@ -2935,24 +2857,26 @@ dependencies = [
  "indexmap 2.13.0",
  "integer-encoding",
  "io-uring",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "lz4_flex",
  "macro_rules_attribute",
  "memmap2",
+ "murmur3_32",
  "nix 0.31.2",
  "nom",
  "num-cmp",
  "num-derive",
  "num-traits",
  "num_cpus",
- "ordered-float 5.1.0",
+ "ordered-float 5.3.0",
  "parking_lot",
  "permutation_iterator",
  "ph",
  "procfs",
  "qdrant-rust-stemmers",
- "rand 0.10.0",
+ "quick_cache",
+ "rand 0.10.1",
  "rand_distr",
  "rayon",
  "rmp-serde",
@@ -2969,6 +2893,7 @@ dependencies = [
  "serde_json",
  "serde_variant",
  "sha2",
+ "slab",
  "smallvec",
  "strum",
  "sysinfo",
@@ -2979,7 +2904,8 @@ dependencies = [
  "thread-priority",
  "tinyvec",
  "tokio",
- "tonic 0.11.0",
+ "tonic 0.14.6",
+ "typed-arena",
  "uuid",
  "validator",
  "vaporetto",
@@ -2998,6 +2924,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,7 +2947,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -3029,7 +2967,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3116,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3196,7 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -3209,10 +3147,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
+name = "rand_pcg"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3281,15 +3228,15 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3297,14 +3244,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -3358,9 +3305,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -3432,20 +3379,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -3454,7 +3387,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3488,17 +3421,6 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -3753,12 +3675,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -3822,7 +3744,7 @@ dependencies = [
  "chrono",
  "csv",
  "fs-err",
- "ordered-float 5.1.0",
+ "ordered-float 5.3.0",
  "qdrant-client",
  "qdrant-edge",
  "serde_json",
@@ -3922,12 +3844,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3968,9 +3884,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4102,9 +4018,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4118,20 +4034,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4140,22 +4046,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -4215,28 +4110,31 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
+ "axum 0.7.9",
+ "base64",
  "bytes",
  "flate2",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
+ "prost",
+ "rustls-native-certs",
  "rustls-pemfile",
- "rustls-pki-types",
+ "socket2 0.5.10",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -4246,33 +4144,30 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
- "base64 0.22.1",
+ "axum 0.8.9",
+ "base64",
  "bytes",
  "flate2",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-timeout 0.5.2",
+ "hyper",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
- "rustls-native-certs",
- "rustls-pemfile",
- "socket2 0.5.10",
+ "socket2 0.6.3",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4306,11 +4201,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "slab",
+ "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4322,8 +4221,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.3",
@@ -4381,6 +4280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4388,9 +4293,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -4442,12 +4347,12 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "cookie_store",
  "flate2",
  "log",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4462,8 +4367,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
- "base64 0.22.1",
- "http 1.4.0",
+ "base64",
+ "http",
  "httparse",
  "log",
 ]
@@ -4500,9 +4405,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5310,18 +5215,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/automation/snippets/templates/rust/Cargo.toml
+++ b/automation/snippets/templates/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 anyhow = "1.0.100"
 chrono = "0.4"
 csv = "1.3"
-qdrant-edge = "0.6.0"
+qdrant-edge = "0.7.2"
 fs-err = "3"
 ordered-float = "5"
 qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "master" }

--- a/automation/snippets/templates/rust/rust-toolchain.toml
+++ b/automation/snippets/templates/rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -44,6 +44,7 @@ To work with a Qdrant Edge Shard, use the [Python Bindings for Qdrant Edge](http
 |--------------|----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
 | **Beginner** | [Qdrant Edge Quickstart](/documentation/edge/edge-quickstart/)             | Get started with Qdrant Edge and learn the basics of managing and querying data |
 | **Beginner** | [On-Device Embeddings](/documentation/edge/edge-fastembed-embeddings/)     | Generate vector embeddings directly on edge devices using FastEmbed |
+| **Beginner** | [On-Device BM25](/documentation/edge/edge-bm25/)                          | Generate BM25 sparse embeddings on-device for keyword search |
 | **Reference** | [Data Synchronization Patterns](/documentation/edge/edge-data-synchronization-patterns/) | Overview of patterns for synchronizing data between Edge Shards and Qdrant server collections |
 | **Advanced** | [Synchronize with a Server](/documentation/edge/edge-synchronization-guide/) | Synchronize an Edge Shard with a Qdrant server collection to offload indexing and synchronize data between devices |
 

--- a/qdrant-landing/content/documentation/edge/edge-bm25.md
+++ b/qdrant-landing/content/documentation/edge/edge-bm25.md
@@ -30,7 +30,7 @@ Instantiate a BM25 embedder with a language setting. The embedder applies stemmi
 
 | Parameter | Description |
 |---|---|
-| `language` | Language for stemming and stopwords (for example, `"english"`, `"german"`). Defaults to `"english"`. |
+| `language` | Language for stemming and stopwords (for example, `"english"`, `"german"`). Defaults to `None`, which falls back to English stemming and stopwords. |
 | `k` | Term frequency saturation parameter. Default: `1.2`. |
 | `b` | Document length normalization factor. Default: `0.75`. |
 | `avg_len` | Expected average document length in tokens. Default: `256`. |
@@ -38,6 +38,7 @@ Instantiate a BM25 embedder with a language setting. The embedder applies stemmi
 | `ascii_folding` | Normalize accented characters to ASCII equivalents. Default: `false`. |
 | `stemmer` | Override the stemming algorithm. |
 | `stopwords` | Override the stopword list. |
+| `tokenizer` | Tokenizer used to break down text into individual tokens (words). Can be `"prefix"`, `"whitespace"`, `"word"`, or `"multilingual"`. Default: `"word"`. |
 | `min_token_len` | Minimum token length to include. |
 | `max_token_len` | Maximum token length to include. |
 

--- a/qdrant-landing/content/documentation/edge/edge-bm25.md
+++ b/qdrant-landing/content/documentation/edge/edge-bm25.md
@@ -1,0 +1,58 @@
+---
+title: "BM25"
+short_description: "Generate BM25 sparse embeddings for keyword search with Qdrant Edge, compatible with server-side BM25 collections."
+description: "Use the built-in BM25 embedder in Qdrant Edge to generate sparse text embeddings on-device for keyword search, without an internet connection or external model server."
+weight: 16
+partition: develop
+---
+
+# BM25 with Qdrant Edge
+
+[BM25](/documentation/search/text-search/#bm25) (Best Matching 25) is a popular sparse-vector ranking algorithm for full-text search. Qdrant Edge includes a built-in BM25 embedder, so you can run keyword search without an internet connection or external embedding service.
+
+The BM25 embedder is compatible with server-side BM25: vectors produced by the Qdrant Edge embedder use the same token IDs and scoring formula as Qdrant Server's [text search](/documentation/search/text-search/#bm25) pipeline. You can initialize an Edge Shard from a server snapshot and query it with locally produced BM25 vectors without re-indexing.
+
+In Python, use the `Bm25` and `Bm25Config` classes. In Rust, use `EdgeBm25` and `EdgeBm25Config` from the `qdrant_edge::bm25_embed` module.
+
+## Configure a Sparse Vector
+
+To get started with BM25, create an Edge Shard with a sparse vector field and `Modifier.Idf`. The IDF modifier enables inverse document frequency weighting, which is required for BM25 scoring:
+
+{{< code-snippet path="/documentation/headless/snippets/edge/bm25/" block="configure-bm25-shard" >}}
+
+## Create a BM25 Embedder
+
+Instantiate a BM25 embedder with a language setting. The embedder applies stemming and stopword filtering for the specified language:
+
+{{< code-snippet path="/documentation/headless/snippets/edge/bm25/" block="create-bm25" >}}
+
+`Bm25Config` accepts the following parameters:
+
+| Parameter | Description |
+|---|---|
+| `language` | Language for stemming and stopwords (for example, `"english"`, `"german"`). Defaults to `"english"`. |
+| `k` | Term frequency saturation parameter. Default: `1.2`. |
+| `b` | Document length normalization factor. Default: `0.75`. |
+| `avg_len` | Expected average document length in tokens. Default: `256`. |
+| `lowercase` | Convert tokens to lowercase before embedding. Default: `true`. |
+| `ascii_folding` | Normalize accented characters to ASCII equivalents. Default: `false`. |
+| `stemmer` | Override the stemming algorithm. |
+| `stopwords` | Override the stopword list. |
+| `min_token_len` | Minimum token length to include. |
+| `max_token_len` | Maximum token length to include. |
+
+For a full description of each parameter, see [Configuring BM25 Parameters](/documentation/search/text-search/#configuring-bm25-parameters).
+
+## Embed and Upsert Documents
+
+Use `embed_document` to generate a sparse vector for each document, then upsert the points. Call `optimize` after bulk inserts to build the sparse index:
+
+{{< code-snippet path="/documentation/headless/snippets/edge/bm25/" block="embed-and-upsert" >}}
+
+## Query
+
+Use `embed_query` to generate a sparse vector for the query text, then query the shard:
+
+{{< code-snippet path="/documentation/headless/snippets/edge/bm25/" block="query-with-bm25" >}}
+
+Always use `embed_query` for query text and `embed_document` for document text. Using the wrong function produces incorrect results, since BM25 applies different term weighting depending on the input type.

--- a/qdrant-landing/content/documentation/edge/edge-fastembed-embeddings.md
+++ b/qdrant-landing/content/documentation/edge/edge-fastembed-embeddings.md
@@ -10,6 +10,8 @@ partition: develop
 
 When using Python, you can use the [FastEmbed](/documentation/fastembed/) library to generate embeddings for use with Qdrant Edge. FastEmbed provides multimodal models that run efficiently on edge devices to generate vector embeddings from text and images.
 
+<aside role="status">To generate sparse BM25 embeddings for keyword search, see <a href="/documentation/edge/edge-bm25/">BM25 Embeddings on Qdrant Edge</a>.</aside>
+
 # Provision the Device
 
 Assuming the devices on which you will run Qdrant Edge have intermittent or no internet connectivity, you need to provision them with the necessary dependencies and model files ahead of time. First, install FastEmbed and the Qdrant Edge Python bindings:

--- a/qdrant-landing/content/documentation/edge/edge-quickstart.md
+++ b/qdrant-landing/content/documentation/edge/edge-quickstart.md
@@ -106,7 +106,7 @@ After closing an Edge Shard, you can reopen it by loading its data and configura
 
 ## Custom WAL Size
 
-Qdrant Edge uses a Write-Ahead Log (WAL) to record every update before it's applied to storage. On iOS and Android, the WAL file is pre-allocated to 32 MB by default, inflating backup sizes and OS storage reports. To reduce the size, set `wal_options` on `EdgeConfig` when calling `new` or `load`. WAL options are only available in Rust.
+Qdrant Edge uses a Write-Ahead Log (WAL) to record every update before it's applied to storage. The WAL file is pre-allocated to 32 MB by default, inflating backup sizes and OS storage reports. To reduce the size, set `wal_options` on `EdgeConfig` when calling `new` or `load`. WAL options are only available in Rust.
 
 For example, to set the WAL size to 4 MB:
 

--- a/qdrant-landing/content/documentation/edge/edge-quickstart.md
+++ b/qdrant-landing/content/documentation/edge/edge-quickstart.md
@@ -104,6 +104,14 @@ After closing an Edge Shard, you can reopen it by loading its data and configura
 
 {{< code-snippet path="/documentation/headless/snippets/edge/quickstart/" block="load-edge-shard" >}}
 
+## Custom WAL Size
+
+Qdrant Edge uses a Write-Ahead Log (WAL) to record every update before it's applied to storage. On iOS and Android, the WAL file is pre-allocated to 32 MB by default, inflating backup sizes and OS storage reports. To reduce the size, set `wal_options` on `EdgeConfig` when calling `new` or `load`. WAL options are only available in Rust.
+
+For example, to set the WAL size to 4 MB:
+
+{{< code-snippet path="/documentation/headless/snippets/edge/quickstart/" block="wal-options" >}}
+
 ## More Examples
 
 The Qdrant GitHub repository contains examples of using the Qdrant Edge API in [Python](https://github.com/qdrant/qdrant/tree/dev/lib/edge/python/examples) and [Rust](https://github.com/qdrant/qdrant/tree/dev/lib/edge/publish/examples).

--- a/qdrant-landing/content/documentation/edge/edge-quickstart.md
+++ b/qdrant-landing/content/documentation/edge/edge-quickstart.md
@@ -50,7 +50,7 @@ To retrieve a point by ID, use the `retrieve` method:
 
 You can add or remove named vectors to an existing Edge Shard's schema. This is useful when migrating to a new embedding model or adding hybrid search to an Edge Shard that already contains data.
 
-For example, to add a sparse vector for BM25 keyword search:
+For example, to add a sparse vector for [BM25 keyword search](/documentation/edge/edge-bm25/):
 
 {{< code-snippet path="/documentation/headless/snippets/edge/quickstart/" block="modify-vector-schema" >}}
 

--- a/qdrant-landing/content/documentation/edge/edge-quickstart.md
+++ b/qdrant-landing/content/documentation/edge/edge-quickstart.md
@@ -44,6 +44,18 @@ To retrieve a point by ID, use the `retrieve` method:
 
 {{< code-snippet path="/documentation/headless/snippets/edge/quickstart/" block="retrieve-point" >}}
 
+## Modify the Vector Schema
+
+You can add or remove named vectors to an existing Edge Shard's schema. This is useful when migrating to a new embedding model or adding hybrid search to an Edge Shard that already contains data.
+
+For example, to add a sparse vector for BM25 keyword search:
+
+{{< code-snippet path="/documentation/headless/snippets/edge/quickstart/" block="modify-vector-schema" >}}
+
+Existing points aren't automatically populated with the new vector. Re-upsert them to add their values for the new field.
+
+To remove a named vector, use `UpdateOperation.delete_vector_name("text")` (Python) or `VectorNameOperations::DeleteVectorName` (Rust).
+
 ## Create a Payload Index
 
 To optimize operations like [filtering](#filtering) and [faceting](#faceting) on payload fields, first create a payload index on the fields you plan to use with these operations:

--- a/qdrant-landing/content/documentation/edge/edge-quickstart.md
+++ b/qdrant-landing/content/documentation/edge/edge-quickstart.md
@@ -26,6 +26,8 @@ Set up a configuration by creating an instance of `EdgeConfig`. For example:
 
 {{< code-snippet path="/documentation/headless/snippets/edge/quickstart/" block="configure-edge-shard" >}}
 
+Qdrant Edge supports all Qdrant quantization methods: Scalar, Product, Binary, and TurboQuant. Configure quantization globally on `EdgeConfig.quantization_config` or override per-vector on `EdgeVectorParams.quantization_config`. See the [Quantization](/documentation/manage-data/quantization/) guide for configuration details.
+
 ## Initialize the Edge Shard
 
 Now you can create a new `EdgeShard` using `EdgeShard.create` (Python) or `EdgeShard::new` (Rust), passing the storage directory and configuration:

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/python.md
@@ -1,0 +1,14 @@
+```python
+from qdrant_edge import (
+    EdgeConfig,
+    EdgeShard,
+    EdgeSparseVectorParams,
+    Modifier,
+)
+
+config = EdgeConfig(
+    sparse_vectors={"text": EdgeSparseVectorParams(modifier=Modifier.Idf)},
+)
+
+shard = EdgeShard.create(SHARD_DIRECTORY, config)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/rust.md
@@ -1,0 +1,9 @@
+```rust
+let config = EdgeConfigBuilder::new()
+    .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()
+        .modifier(Modifier::Idf)
+        .build())
+    .build();
+
+let shard = EdgeShard::new(Path::new(SHARD_DIRECTORY), config)?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/create-bm25/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/create-bm25/python.md
@@ -1,0 +1,5 @@
+```python
+from qdrant_edge import Bm25, Bm25Config
+
+bm25 = Bm25(Bm25Config(language="english"))
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/create-bm25/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/create-bm25/rust.md
@@ -1,0 +1,6 @@
+```rust
+let bm25 = EdgeBm25::new(EdgeBm25Config {
+    language: Some("english".to_string()),
+    ..Default::default()
+})?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/embed-and-upsert/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/embed-and-upsert/python.md
@@ -1,0 +1,10 @@
+```python
+from qdrant_edge import Point, UpdateOperation
+
+shard.update(UpdateOperation.upsert_points([
+    Point(1, {"text": bm25.embed_document("the quick brown fox")}, {"title": "Article 1"}),
+    Point(2, {"text": bm25.embed_document("a lazy dog sleeps")},   {"title": "Article 2"}),
+    Point(3, {"text": bm25.embed_document("foxes are clever")},    {"title": "Article 3"}),
+]))
+shard.optimize()
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/embed-and-upsert/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/embed-and-upsert/rust.md
@@ -1,0 +1,20 @@
+```rust
+let docs = [
+    (1u64, "the quick brown fox", "Article 1"),
+    (2,    "a lazy dog sleeps",   "Article 2"),
+    (3,    "foxes are clever",    "Article 3"),
+];
+
+let points = docs.iter().map(|(id, text, title)| {
+    PointStruct::new(
+        *id,
+        Vectors::new_named([("text", bm25.embed_document(text))]),
+        json!({ "title": title }),
+    ).into()
+}).collect();
+
+shard.update(UpdateOperation::PointOperation(
+    PointOperations::UpsertPoints(PointInsertOperations::PointsList(points)),
+))?;
+shard.optimize()?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/python.md
@@ -1,0 +1,41 @@
+```python
+from pathlib import Path
+
+SHARD_DIRECTORY = "./qdrant-edge-bm25"
+
+from qdrant_edge import (
+    EdgeConfig,
+    EdgeShard,
+    EdgeSparseVectorParams,
+    Modifier,
+)
+
+config = EdgeConfig(
+    sparse_vectors={"text": EdgeSparseVectorParams(modifier=Modifier.Idf)},
+)
+
+shard = EdgeShard.create(SHARD_DIRECTORY, config)
+
+from qdrant_edge import Bm25, Bm25Config
+
+bm25 = Bm25(Bm25Config(language="english"))
+
+from qdrant_edge import Point, UpdateOperation
+
+shard.update(UpdateOperation.upsert_points([
+    Point(1, {"text": bm25.embed_document("the quick brown fox")}, {"title": "Article 1"}),
+    Point(2, {"text": bm25.embed_document("a lazy dog sleeps")},   {"title": "Article 2"}),
+    Point(3, {"text": bm25.embed_document("foxes are clever")},    {"title": "Article 3"}),
+]))
+shard.optimize()
+
+from qdrant_edge import Query, QueryRequest
+
+query_vector = bm25.embed_query("clever fox")
+
+results = shard.query(QueryRequest(
+    query=Query.Nearest(query_vector, using="text"),
+    limit=3,
+    with_payload=True,
+))
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/python.md
@@ -1,0 +1,11 @@
+```python
+from qdrant_edge import Query, QueryRequest
+
+query_vector = bm25.embed_query("clever fox")
+
+results = shard.query(QueryRequest(
+    query=Query.Nearest(query_vector, using="text"),
+    limit=3,
+    with_payload=True,
+))
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/rust.md
@@ -1,0 +1,18 @@
+```rust
+let query_vector = bm25.embed_query("clever fox");
+
+let results = shard.query(QueryRequest {
+    prefetches: vec![],
+    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+        query: VectorInternal::from(query_vector),
+        using: Some("text".to_string()),
+    }))),
+    filter: None,
+    score_threshold: None,
+    limit: 3,
+    offset: 0,
+    params: None,
+    with_vector: WithVector::Bool(false),
+    with_payload: WithPayloadInterface::Bool(true),
+})?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/rust.md
@@ -1,0 +1,63 @@
+```rust
+use std::path::Path;
+
+use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
+use qdrant_edge::external::serde_json::json;
+use qdrant_edge::{
+    EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParamsBuilder, Modifier,
+    NamedQuery, PointInsertOperations, PointOperations, PointStruct,
+    QueryEnum, QueryRequest, ScoringQuery, UpdateOperation,
+    VectorInternal, Vectors, WithPayloadInterface, WithVector,
+};
+
+const SHARD_DIRECTORY: &str = "./qdrant-edge-bm25";
+
+let config = EdgeConfigBuilder::new()
+    .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()
+        .modifier(Modifier::Idf)
+        .build())
+    .build();
+
+let shard = EdgeShard::new(Path::new(SHARD_DIRECTORY), config)?;
+
+let bm25 = EdgeBm25::new(EdgeBm25Config {
+    language: Some("english".to_string()),
+    ..Default::default()
+})?;
+
+let docs = [
+    (1u64, "the quick brown fox", "Article 1"),
+    (2,    "a lazy dog sleeps",   "Article 2"),
+    (3,    "foxes are clever",    "Article 3"),
+];
+
+let points = docs.iter().map(|(id, text, title)| {
+    PointStruct::new(
+        *id,
+        Vectors::new_named([("text", bm25.embed_document(text))]),
+        json!({ "title": title }),
+    ).into()
+}).collect();
+
+shard.update(UpdateOperation::PointOperation(
+    PointOperations::UpsertPoints(PointInsertOperations::PointsList(points)),
+))?;
+shard.optimize()?;
+
+let query_vector = bm25.embed_query("clever fox");
+
+let results = shard.query(QueryRequest {
+    prefetches: vec![],
+    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+        query: VectorInternal::from(query_vector),
+        using: Some("text".to_string()),
+    }))),
+    filter: None,
+    score_threshold: None,
+    limit: 3,
+    offset: 0,
+    params: None,
+    with_vector: WithVector::Bool(false),
+    with_payload: WithPayloadInterface::Bool(true),
+})?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/python.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+SHARD_DIRECTORY = "./qdrant-edge-bm25"
+Path(SHARD_DIRECTORY).mkdir(parents=True, exist_ok=True) # @hide
+
+# @block-start configure-bm25-shard
+from qdrant_edge import (
+    EdgeConfig,
+    EdgeShard,
+    EdgeSparseVectorParams,
+    Modifier,
+)
+
+config = EdgeConfig(
+    sparse_vectors={"text": EdgeSparseVectorParams(modifier=Modifier.Idf)},
+)
+
+shard = EdgeShard.create(SHARD_DIRECTORY, config)
+# @block-end configure-bm25-shard
+
+# @block-start create-bm25
+from qdrant_edge import Bm25, Bm25Config
+
+bm25 = Bm25(Bm25Config(language="english"))
+# @block-end create-bm25
+
+# @block-start embed-and-upsert
+from qdrant_edge import Point, UpdateOperation
+
+shard.update(UpdateOperation.upsert_points([
+    Point(1, {"text": bm25.embed_document("the quick brown fox")}, {"title": "Article 1"}),
+    Point(2, {"text": bm25.embed_document("a lazy dog sleeps")},   {"title": "Article 2"}),
+    Point(3, {"text": bm25.embed_document("foxes are clever")},    {"title": "Article 3"}),
+]))
+shard.optimize()
+# @block-end embed-and-upsert
+
+# @block-start query-with-bm25
+from qdrant_edge import Query, QueryRequest
+
+query_vector = bm25.embed_query("clever fox")
+
+results = shard.query(QueryRequest(
+    query=Query.Nearest(query_vector, using="text"),
+    limit=3,
+    with_payload=True,
+))
+# @block-end query-with-bm25

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
@@ -1,0 +1,74 @@
+use std::path::Path;
+
+use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
+use qdrant_edge::external::serde_json::json;
+use qdrant_edge::{
+    EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParamsBuilder, Modifier,
+    NamedQuery, PointInsertOperations, PointOperations, PointStruct,
+    QueryEnum, QueryRequest, ScoringQuery, UpdateOperation,
+    VectorInternal, Vectors, WithPayloadInterface, WithVector,
+};
+
+pub async fn main() -> anyhow::Result<()> {
+    const SHARD_DIRECTORY: &str = "./qdrant-edge-bm25";
+    fs_err::create_dir_all(SHARD_DIRECTORY)?; // @hide
+
+    // @block-start configure-bm25-shard
+    let config = EdgeConfigBuilder::new()
+        .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()
+            .modifier(Modifier::Idf)
+            .build())
+        .build();
+
+    let shard = EdgeShard::new(Path::new(SHARD_DIRECTORY), config)?;
+    // @block-end configure-bm25-shard
+
+    // @block-start create-bm25
+    let bm25 = EdgeBm25::new(EdgeBm25Config {
+        language: Some("english".to_string()),
+        ..Default::default()
+    })?;
+    // @block-end create-bm25
+
+    // @block-start embed-and-upsert
+    let docs = [
+        (1u64, "the quick brown fox", "Article 1"),
+        (2,    "a lazy dog sleeps",   "Article 2"),
+        (3,    "foxes are clever",    "Article 3"),
+    ];
+
+    let points = docs.iter().map(|(id, text, title)| {
+        PointStruct::new(
+            *id,
+            Vectors::new_named([("text", bm25.embed_document(text))]),
+            json!({ "title": title }),
+        ).into()
+    }).collect();
+
+    shard.update(UpdateOperation::PointOperation(
+        PointOperations::UpsertPoints(PointInsertOperations::PointsList(points)),
+    ))?;
+    shard.optimize()?;
+    // @block-end embed-and-upsert
+
+    // @block-start query-with-bm25
+    let query_vector = bm25.embed_query("clever fox");
+
+    let results = shard.query(QueryRequest {
+        prefetches: vec![],
+        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+            query: VectorInternal::from(query_vector),
+            using: Some("text".to_string()),
+        }))),
+        filter: None,
+        score_threshold: None,
+        limit: 3,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(true),
+    })?;
+    // @block-end query-with-bm25
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-edge-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-edge-shard/rust.md
@@ -2,23 +2,13 @@
 const VECTOR_NAME: &str = "my-vector";
 const VECTOR_DIMENSION: usize = 4;
 
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: Default::default(),
-};
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .build();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-optimizer/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-optimizer/rust.md
@@ -1,26 +1,17 @@
 ```rust
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: EdgeOptimizersConfig {
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .optimizers(EdgeOptimizersConfig {
         deleted_threshold: Some(0.2),
         vacuum_min_vector_number: Some(100),
         default_segment_number: Some(2),
         ..Default::default()
-    },
-};
+    })
+    .build();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/modify-vector-schema/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/modify-vector-schema/python.md
@@ -1,0 +1,8 @@
+```python
+from qdrant_edge import Modifier
+
+edge_shard.update(UpdateOperation.create_sparse_vector(
+    vector_name="text",
+    modifier=Modifier.Idf,
+))
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/modify-vector-schema/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/modify-vector-schema/rust.md
@@ -1,0 +1,11 @@
+```rust
+edge_shard.update(UpdateOperation::VectorNameOperation(
+    VectorNameOperations::CreateVectorName(CreateVectorName {
+        vector_name: "text".to_string(),
+        config: VectorNameConfig::sparse(SparseVectorConfig {
+            modifier: Some(Modifier::Idf),
+            datatype: None,
+        }),
+    }),
+))?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/python.md
@@ -43,6 +43,13 @@ records = edge_shard.retrieve(
     with_vector=False
 )
 
+from qdrant_edge import Modifier
+
+edge_shard.update(UpdateOperation.create_sparse_vector(
+    vector_name="text",
+    modifier=Modifier.Idf,
+))
+
 from qdrant_edge import Query, QueryRequest
 
 results = edge_shard.query(

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
@@ -1,16 +1,16 @@
 ```rust
-use std::collections::HashMap;
 use std::path::Path;
 
 use qdrant_edge::EdgeShard;
 use qdrant_edge::{
-    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfig, EdgeOptimizersConfig,
-    EdgeVectorParams, FacetRequest, FieldCondition, FieldIndexOperations,
-    Filter, Match, MatchValue, Modifier, NamedQuery, PayloadFieldSchema,
-    PayloadSchemaType, PointId, PointInsertOperations, PointOperations,
-    PointStruct, PointStructPersisted, QueryEnum, QueryRequest, ScoringQuery,
-    SparseVectorConfig, UpdateOperation, ValueVariants, VectorNameConfig,
-    VectorNameOperations, Vectors, WithPayloadInterface, WithVector,
+    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder,
+    EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
+    FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
+    PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,
+    PointOperations, PointStruct, PointStructPersisted, QueryEnum, QueryRequest,
+    ScoringQuery, SparseVectorConfig, UpdateOperation, ValueVariants,
+    VectorNameConfig, VectorNameOperations, Vectors, WalOptions,
+    WithPayloadInterface, WithVector,
 };
 use serde_json::json;
 
@@ -21,25 +21,15 @@ fs_err::create_dir_all(SHARD_DIRECTORY)?;
 const VECTOR_NAME: &str = "my-vector";
 const VECTOR_DIMENSION: usize = 4;
 
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: Default::default(),
-};
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .build();
 
 let edge_shard = EdgeShard::new(
     Path::new(SHARD_DIRECTORY),
@@ -128,30 +118,21 @@ let facet_response = edge_shard.facet(FacetRequest {
 
 edge_shard.optimize()?;
 
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: EdgeOptimizersConfig {
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .optimizers(EdgeOptimizersConfig {
         deleted_threshold: Some(0.2),
         vacuum_min_vector_number: Some(100),
         default_segment_number: Some(2),
         ..Default::default()
-    },
-};
+    })
+    .build();
 
 edge_shard.update(UpdateOperation::FieldIndexOperation(
     FieldIndexOperations::CreateIndex(CreateIndex {
@@ -165,4 +146,13 @@ edge_shard.update(UpdateOperation::FieldIndexOperation(
 drop(edge_shard);
 
 let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), None)?;
+
+let config = EdgeConfigBuilder::new()
+    .wal_options(WalOptions {
+        segment_capacity: 4 * 1024 * 1024,
+        ..Default::default()
+    })
+    .build();
+
+let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), Some(config))?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
@@ -4,12 +4,13 @@ use std::path::Path;
 
 use qdrant_edge::EdgeShard;
 use qdrant_edge::{
-    Condition, CreateIndex, Distance, EdgeConfig, EdgeOptimizersConfig,
+    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfig, EdgeOptimizersConfig,
     EdgeVectorParams, FacetRequest, FieldCondition, FieldIndexOperations,
-    Filter, Match, MatchValue, NamedQuery, PayloadFieldSchema,
+    Filter, Match, MatchValue, Modifier, NamedQuery, PayloadFieldSchema,
     PayloadSchemaType, PointId, PointInsertOperations, PointOperations,
     PointStruct, PointStructPersisted, QueryEnum, QueryRequest, ScoringQuery,
-    UpdateOperation, ValueVariants, Vectors, WithPayloadInterface, WithVector,
+    SparseVectorConfig, UpdateOperation, ValueVariants, VectorNameConfig,
+    VectorNameOperations, Vectors, WithPayloadInterface, WithVector,
 };
 use serde_json::json;
 
@@ -65,6 +66,16 @@ let retrieved = edge_shard.retrieve(
     Some(WithPayloadInterface::Bool(true)),
     Some(WithVector::Bool(false)),
 )?;
+
+edge_shard.update(UpdateOperation::VectorNameOperation(
+    VectorNameOperations::CreateVectorName(CreateVectorName {
+        vector_name: "text".to_string(),
+        config: VectorNameConfig::sparse(SparseVectorConfig {
+            modifier: Some(Modifier::Idf),
+            datatype: None,
+        }),
+    }),
+))?;
 
 let results = edge_shard.query(QueryRequest {
     prefetches: vec![],

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/wal-options/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/wal-options/rust.md
@@ -1,0 +1,10 @@
+```rust
+let config = EdgeConfigBuilder::new()
+    .wal_options(WalOptions {
+        segment_capacity: 4 * 1024 * 1024,
+        ..Default::default()
+    })
+    .build();
+
+let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), Some(config))?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/python.py
@@ -52,6 +52,15 @@ records = edge_shard.retrieve(
 )
 # @block-end retrieve-point
 
+# @block-start modify-vector-schema
+from qdrant_edge import Modifier
+
+edge_shard.update(UpdateOperation.create_sparse_vector(
+    vector_name="text",
+    modifier=Modifier.Idf,
+))
+# @block-end modify-vector-schema
+
 # @block-start query-points
 from qdrant_edge import Query, QueryRequest
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
@@ -1,15 +1,15 @@
-use std::collections::HashMap;
 use std::path::Path;
 
 use qdrant_edge::EdgeShard;
 use qdrant_edge::{
-    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfig, EdgeOptimizersConfig,
-    EdgeVectorParams, FacetRequest, FieldCondition, FieldIndexOperations,
-    Filter, Match, MatchValue, Modifier, NamedQuery, PayloadFieldSchema,
-    PayloadSchemaType, PointId, PointInsertOperations, PointOperations,
-    PointStruct, PointStructPersisted, QueryEnum, QueryRequest, ScoringQuery,
-    SparseVectorConfig, UpdateOperation, ValueVariants, VectorNameConfig,
-    VectorNameOperations, Vectors, WithPayloadInterface, WithVector,
+    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder,
+    EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
+    FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
+    PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,
+    PointOperations, PointStruct, PointStructPersisted, QueryEnum, QueryRequest,
+    ScoringQuery, SparseVectorConfig, UpdateOperation, ValueVariants,
+    VectorNameConfig, VectorNameOperations, Vectors, WalOptions,
+    WithPayloadInterface, WithVector,
 };
 use serde_json::json;
 
@@ -24,26 +24,15 @@ pub async fn main() -> anyhow::Result<()> {
     const VECTOR_NAME: &str = "my-vector";
     const VECTOR_DIMENSION: usize = 4;
 
-    let config = EdgeConfig {
-        on_disk_payload: true,
-        vectors: HashMap::from([(
-            VECTOR_NAME.to_string(),
-            EdgeVectorParams {
-                size: VECTOR_DIMENSION,
-                distance: Distance::Cosine,
-                on_disk: Some(true),
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-                hnsw_config: None,
-            },
-        )]),
-        sparse_vectors: HashMap::new(),
-        hnsw_config: Default::default(),
-        quantization_config: None,
-        optimizers: Default::default(),
-        wal_options: None,
-    };
+    let config = EdgeConfigBuilder::new()
+        .on_disk_payload(true)
+        .vector(
+            VECTOR_NAME,
+            EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+                .on_disk(true)
+                .build(),
+        )
+        .build();
     // @block-end configure-edge-shard
 
     // @block-start initialize-edge-shard
@@ -150,31 +139,21 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end optimize
 
     // @block-start configure-optimizer
-    let config = EdgeConfig {
-        on_disk_payload: true,
-        vectors: HashMap::from([(
-            VECTOR_NAME.to_string(),
-            EdgeVectorParams {
-                size: VECTOR_DIMENSION,
-                distance: Distance::Cosine,
-                on_disk: Some(true),
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-                hnsw_config: None,
-            },
-        )]),
-        sparse_vectors: HashMap::new(),
-        hnsw_config: Default::default(),
-        quantization_config: None,
-        optimizers: EdgeOptimizersConfig {
+    let config = EdgeConfigBuilder::new()
+        .on_disk_payload(true)
+        .vector(
+            VECTOR_NAME,
+            EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+                .on_disk(true)
+                .build(),
+        )
+        .optimizers(EdgeOptimizersConfig {
             deleted_threshold: Some(0.2),
             vacuum_min_vector_number: Some(100),
             default_segment_number: Some(2),
             ..Default::default()
-        },
-        wal_options: None,
-    };
+        })
+        .build();
     // @block-end configure-optimizer
 
     // @block-start create-payload-index
@@ -195,6 +174,17 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-start load-edge-shard
     let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), None)?;
     // @block-end load-edge-shard
+
+    // @block-start wal-options
+    let config = EdgeConfigBuilder::new()
+        .wal_options(WalOptions {
+            segment_capacity: 4 * 1024 * 1024,
+            ..Default::default()
+        })
+        .build();
+
+    let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), Some(config))?;
+    // @block-end wal-options
 
     Ok(())
 }

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
@@ -3,12 +3,13 @@ use std::path::Path;
 
 use qdrant_edge::EdgeShard;
 use qdrant_edge::{
-    Condition, CreateIndex, Distance, EdgeConfig, EdgeOptimizersConfig,
+    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfig, EdgeOptimizersConfig,
     EdgeVectorParams, FacetRequest, FieldCondition, FieldIndexOperations,
-    Filter, Match, MatchValue, NamedQuery, PayloadFieldSchema,
+    Filter, Match, MatchValue, Modifier, NamedQuery, PayloadFieldSchema,
     PayloadSchemaType, PointId, PointInsertOperations, PointOperations,
     PointStruct, PointStructPersisted, QueryEnum, QueryRequest, ScoringQuery,
-    UpdateOperation, ValueVariants, Vectors, WithPayloadInterface, WithVector,
+    SparseVectorConfig, UpdateOperation, ValueVariants, VectorNameConfig,
+    VectorNameOperations, Vectors, WithPayloadInterface, WithVector,
 };
 use serde_json::json;
 
@@ -41,6 +42,7 @@ pub async fn main() -> anyhow::Result<()> {
         hnsw_config: Default::default(),
         quantization_config: None,
         optimizers: Default::default(),
+        wal_options: None,
     };
     // @block-end configure-edge-shard
 
@@ -75,6 +77,18 @@ pub async fn main() -> anyhow::Result<()> {
         Some(WithVector::Bool(false)),
     )?;
     // @block-end retrieve-point
+
+    // @block-start modify-vector-schema
+    edge_shard.update(UpdateOperation::VectorNameOperation(
+        VectorNameOperations::CreateVectorName(CreateVectorName {
+            vector_name: "text".to_string(),
+            config: VectorNameConfig::sparse(SparseVectorConfig {
+                modifier: Some(Modifier::Idf),
+                datatype: None,
+            }),
+        }),
+    ))?;
+    // @block-end modify-vector-schema
 
     // @block-start query-points
     let results = edge_shard.query(QueryRequest {
@@ -159,6 +173,7 @@ pub async fn main() -> anyhow::Result<()> {
             default_segment_number: Some(2),
             ..Default::default()
         },
+        wal_options: None,
     };
     // @block-end configure-optimizer
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-mutable-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-mutable-shard/rust.md
@@ -4,25 +4,15 @@ const VECTOR_DIMENSION: usize = 4;
 const VECTOR_NAME: &str = "my-vector";
 
 fs_err::create_dir_all(MUTABLE_SHARD_DIR)?;
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: Default::default(),
-};
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .build();
 
 let mutable_shard = EdgeShard::new(
     Path::new(MUTABLE_SHARD_DIR),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/rust.md
@@ -8,11 +8,11 @@ use qdrant_client::qdrant::PointStruct;
 use qdrant_edge::EdgeShard;
 use qdrant_edge::internal::SnapshotManifest;
 use qdrant_edge::{
-    Condition, Distance, EdgeConfig, EdgeVectorParams, FieldCondition, Filter,
-    JsonPath, NamedQuery, PointId, PointInsertOperations, PointOperations,
-    PointStruct as EdgePoint, PointStructPersisted, QueryEnum, QueryRequest,
-    Range, ScoringQuery, UpdateOperation, Vectors, WithPayloadInterface,
-    WithVector,
+    Condition, Distance, EdgeConfigBuilder, EdgeVectorParamsBuilder,
+    FieldCondition, Filter, JsonPath, NamedQuery, PointId, PointInsertOperations,
+    PointOperations, PointStruct as EdgePoint, PointStructPersisted, QueryEnum,
+    QueryRequest, Range, ScoringQuery, UpdateOperation, Vectors,
+    WithPayloadInterface, WithVector,
 };
 use serde_json::json;
 
@@ -21,25 +21,15 @@ const VECTOR_DIMENSION: usize = 4;
 const VECTOR_NAME: &str = "my-vector";
 
 fs_err::create_dir_all(MUTABLE_SHARD_DIR)?;
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: Default::default(),
-};
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .build();
 
 let mutable_shard = EdgeShard::new(
     Path::new(MUTABLE_SHARD_DIR),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
@@ -47,6 +47,7 @@ pub async fn main() -> anyhow::Result<()> {
         hnsw_config: Default::default(),
         quantization_config: None,
         optimizers: Default::default(),
+        wal_options: None,
     };
 
     let mutable_shard = EdgeShard::new(

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
@@ -7,11 +7,11 @@ use qdrant_client::qdrant::PointStruct;
 use qdrant_edge::EdgeShard;
 use qdrant_edge::internal::SnapshotManifest;
 use qdrant_edge::{
-    Condition, Distance, EdgeConfig, EdgeVectorParams, FieldCondition, Filter,
-    JsonPath, NamedQuery, PointId, PointInsertOperations, PointOperations,
-    PointStruct as EdgePoint, PointStructPersisted, QueryEnum, QueryRequest,
-    Range, ScoringQuery, UpdateOperation, Vectors, WithPayloadInterface,
-    WithVector,
+    Condition, Distance, EdgeConfigBuilder, EdgeVectorParamsBuilder,
+    FieldCondition, Filter, JsonPath, NamedQuery, PointId, PointInsertOperations,
+    PointOperations, PointStruct as EdgePoint, PointStructPersisted, QueryEnum,
+    QueryRequest, Range, ScoringQuery, UpdateOperation, Vectors,
+    WithPayloadInterface, WithVector,
 };
 use serde_json::json;
 
@@ -29,26 +29,15 @@ pub async fn main() -> anyhow::Result<()> {
     const VECTOR_NAME: &str = "my-vector";
 
     fs_err::create_dir_all(MUTABLE_SHARD_DIR)?;
-    let config = EdgeConfig {
-        on_disk_payload: true,
-        vectors: HashMap::from([(
-            VECTOR_NAME.to_string(),
-            EdgeVectorParams {
-                size: VECTOR_DIMENSION,
-                distance: Distance::Cosine,
-                on_disk: Some(true),
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-                hnsw_config: None,
-            },
-        )]),
-        sparse_vectors: HashMap::new(),
-        hnsw_config: Default::default(),
-        quantization_config: None,
-        optimizers: Default::default(),
-        wal_options: None,
-    };
+    let config = EdgeConfigBuilder::new()
+        .on_disk_payload(true)
+        .vector(
+            VECTOR_NAME,
+            EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, Distance::Cosine)
+                .on_disk(true)
+                .build(),
+        )
+        .build();
 
     let mutable_shard = EdgeShard::new(
         Path::new(MUTABLE_SHARD_DIR),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/initialize-edge-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/initialize-edge-shard/rust.md
@@ -3,25 +3,15 @@ const VECTOR_DIMENSION: usize = 4;
 const VECTOR_NAME: &str = "my-vector";
 
 fs_err::create_dir_all(SHARD_DIRECTORY)?;
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: qdrant_edge::Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: Default::default(),
-};
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, qdrant_edge::Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .build();
 
 let edge_shard = EdgeShard::new(
     Path::new(SHARD_DIRECTORY),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/rust.md
@@ -10,7 +10,7 @@ use qdrant_client::Qdrant;
 use qdrant_edge::EdgeShard;
 use qdrant_edge::internal::SnapshotManifest;
 use qdrant_edge::{
-    EdgeConfig, EdgeVectorParams, PointId, PointInsertOperations,
+    EdgeConfigBuilder, EdgeVectorParamsBuilder, PointId, PointInsertOperations,
     PointOperations, PointStruct as EdgePoint, PointStructPersisted,
     UpdateOperation, Vectors,
 };
@@ -88,25 +88,15 @@ const VECTOR_DIMENSION: usize = 4;
 const VECTOR_NAME: &str = "my-vector";
 
 fs_err::create_dir_all(SHARD_DIRECTORY)?;
-let config = EdgeConfig {
-    on_disk_payload: true,
-    vectors: HashMap::from([(
-        VECTOR_NAME.to_string(),
-        EdgeVectorParams {
-            size: VECTOR_DIMENSION,
-            distance: qdrant_edge::Distance::Cosine,
-            on_disk: Some(true),
-            quantization_config: None,
-            multivector_config: None,
-            datatype: None,
-            hnsw_config: None,
-        },
-    )]),
-    sparse_vectors: HashMap::new(),
-    hnsw_config: Default::default(),
-    quantization_config: None,
-    optimizers: Default::default(),
-};
+let config = EdgeConfigBuilder::new()
+    .on_disk_payload(true)
+    .vector(
+        VECTOR_NAME,
+        EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, qdrant_edge::Distance::Cosine)
+            .on_disk(true)
+            .build(),
+    )
+    .build();
 
 let edge_shard = EdgeShard::new(
     Path::new(SHARD_DIRECTORY),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
@@ -118,6 +118,7 @@ pub async fn main() -> anyhow::Result<()> {
         hnsw_config: Default::default(),
         quantization_config: None,
         optimizers: Default::default(),
+        wal_options: None,
     };
 
     let edge_shard = EdgeShard::new(

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
@@ -9,7 +9,7 @@ use qdrant_client::Qdrant;
 use qdrant_edge::EdgeShard;
 use qdrant_edge::internal::SnapshotManifest;
 use qdrant_edge::{
-    EdgeConfig, EdgeVectorParams, PointId, PointInsertOperations,
+    EdgeConfigBuilder, EdgeVectorParamsBuilder, PointId, PointInsertOperations,
     PointOperations, PointStruct as EdgePoint, PointStructPersisted,
     UpdateOperation, Vectors,
 };
@@ -100,26 +100,15 @@ pub async fn main() -> anyhow::Result<()> {
     const VECTOR_NAME: &str = "my-vector";
 
     fs_err::create_dir_all(SHARD_DIRECTORY)?;
-    let config = EdgeConfig {
-        on_disk_payload: true,
-        vectors: HashMap::from([(
-            VECTOR_NAME.to_string(),
-            EdgeVectorParams {
-                size: VECTOR_DIMENSION,
-                distance: qdrant_edge::Distance::Cosine,
-                on_disk: Some(true),
-                quantization_config: None,
-                multivector_config: None,
-                datatype: None,
-                hnsw_config: None,
-            },
-        )]),
-        sparse_vectors: HashMap::new(),
-        hnsw_config: Default::default(),
-        quantization_config: None,
-        optimizers: Default::default(),
-        wal_options: None,
-    };
+    let config = EdgeConfigBuilder::new()
+        .on_disk_payload(true)
+        .vector(
+            VECTOR_NAME,
+            EdgeVectorParamsBuilder::new(VECTOR_DIMENSION, qdrant_edge::Distance::Cosine)
+                .on_disk(true)
+                .build(),
+        )
+        .build();
 
     let edge_shard = EdgeShard::new(
         Path::new(SHARD_DIRECTORY),


### PR DESCRIPTION
[Preview](https://deploy-preview-2391--condescending-goldwasser-91acf0.netlify.app/documentation/edge/)

- Add new "BM25" page covering native BM25 full-text search support in Edge 0.7
- Add "Modify the Vector Schema" step to the Edge quickstart guide
- Add WAL segment size configuration guidance to the quickstart
- Mention quantization support in the quickstart
- Upgrade all Edge code snippets to reflect the 0.7.2 API