### PR TITLE
docs: clarify Raft quorum for small clusters

### DIFF
--- a/qdrant-landing/content/documentation/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/distributed_deployment.md
@@ -163,6 +163,8 @@ In practice, it means that Qdrant does not guarantee atomic distributed updates 
 Operations on collections, on the contrary, are part of the consensus which guarantees that all operations are durable and eventually executed by all nodes.
 In practice it means that a majority of nodes agree on what operations should be applied before the service will perform them.
 
+For high availability, run at least three voting nodes. A two-node cluster cannot form a majority if either node is unavailable, so Raft cannot elect or confirm a leader until both nodes can communicate again.
+
 Practically, it means that if the cluster is in a transition state - either electing a new leader after a failure or starting up, the collection update operations will be denied.
 
 You may use the cluster [REST API](https://api.qdrant.tech/master/api-reference/distributed/cluster-status) to check the state of the consensus.


### PR DESCRIPTION
## Summary
- add a Raft quorum note to the distributed deployment guide
- clarify why at least three voting nodes are required for high availability
- call out that a two-node cluster cannot form a majority if one node is unavailable

Closes #314

## Validation
- `git diff --check HEAD~1 HEAD`
