### PR TITLE
Advise match any over should for multivalue filtering

### DIFF
--- a/qdrant-landing/content/documentation/search/filtering.md
+++ b/qdrant-landing/content/documentation/search/filtering.md
@@ -75,6 +75,8 @@ Filtered points would be:
 ]
 ```
 
+<aside role="status">If all conditions inside <code>should</code> target the same field, use <a href="#match-any"><code>match any</code></a> instead. It's faster, especially when filtering on a large number of values.</aside>
+
 ### Must Not
 
 When using `must_not`, the clause becomes `true` if none of the conditions listed inside `must_not` is satisfied.
@@ -158,8 +160,7 @@ Example:
 
 In this example, the condition will be satisfied if the stored value is either `black` or `yellow`.
 
-If the stored value is an array, it should have at least one value matching any of the given values. E.g. if the stored value is `["black", "green"]`, the condition will be satisfied, because `"black"` is in `["black", "yellow"]`.
-
+If the stored value is an array, it should have at least one value matching any of the given values. For example, if the stored value is `["black", "green"]`, the condition will be satisfied, because `"black"` is in `["black", "yellow"]`.
 
 ### Match Except
 


### PR DESCRIPTION
[Preview](https://deploy-preview-2408--condescending-goldwasser-91acf0.netlify.app/documentation/search/filtering/#should)

Users have observed the undocumented behavior that, when filtering over multiple values of the same field, `match any` is faster than `should`. This is because `match any` is a single condition with a fast lookup, while `should` evaluates each value as a separate condition.

This PR adds a small note to the `should` section pointing users to `match any` when all `should` conditions target the same field.