### PR TITLE
Improve rendering of Markdownified docs

### DIFF
--- a/qdrant-landing/layouts/_default/list.markdown.md
+++ b/qdrant-landing/layouts/_default/list.markdown.md
@@ -1,4 +1,6 @@
 {{- $content := .RenderShortcodes -}}
+{{- if not (strings.TrimSpace $content) }}# {{ .Title }}
+{{ end -}}
 {{- /* Rewrite internal absolute links: ](/path/to/page/) → ](https://qdrant.tech/path/to/page/index.md) */}}
 {{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](https://qdrant.tech${1}index.md${2}` $content -}}
 {{- /* Rewrite internal relative links: ](../page/) or (./page/) → same with index.md */}}

--- a/qdrant-landing/layouts/_default/list.markdown.md
+++ b/qdrant-landing/layouts/_default/list.markdown.md
@@ -1,8 +1,6 @@
-# {{ .Title }}
-
 {{- $content := .RenderShortcodes -}}
-{{- /* Rewrite internal absolute links: ](/path/to/page/) → ](/path/to/page/index.md) */}}
-{{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](${1}index.md${2}` $content -}}
+{{- /* Rewrite internal absolute links: ](/path/to/page/) → ](https://qdrant.tech/path/to/page/index.md) */}}
+{{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](https://qdrant.tech${1}index.md${2}` $content -}}
 {{- /* Rewrite internal relative links: ](../page/) or (./page/) → same with index.md */}}
-{{- $content = replaceRE `\]\((\.\.?/[^):]*/)([\)#?])` `](${1}index.md${2}` $content -}}
+{{- $content = replaceRE `\]\((\.\.?/[^):]*/)([\)#?])` `](https://qdrant.tech/${1}index.md${2}` $content -}}
 {{ $content }}

--- a/qdrant-landing/layouts/_default/single.markdown.md
+++ b/qdrant-landing/layouts/_default/single.markdown.md
@@ -1,4 +1,6 @@
 {{- $content := .RenderShortcodes -}}
+{{- if not (strings.TrimSpace $content) }}# {{ .Title }}
+{{ end -}}
 {{- /* Rewrite internal absolute links: ](/path/to/page/) → ](https://qdrant.tech/path/to/page/index.md) */}}
 {{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](https://qdrant.tech${1}index.md${2}` $content -}}
 {{- /* Rewrite internal relative links: ](../page/) or (./page/) → same with index.md */}}

--- a/qdrant-landing/layouts/_default/single.markdown.md
+++ b/qdrant-landing/layouts/_default/single.markdown.md
@@ -1,8 +1,6 @@
-# {{ .Title }}
-
 {{- $content := .RenderShortcodes -}}
-{{- /* Rewrite internal absolute links: ](/path/to/page/) → ](/path/to/page/index.md) */}}
-{{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](${1}index.md${2}` $content -}}
+{{- /* Rewrite internal absolute links: ](/path/to/page/) → ](https://qdrant.tech/path/to/page/index.md) */}}
+{{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](https://qdrant.tech${1}index.md${2}` $content -}}
 {{- /* Rewrite internal relative links: ](../page/) or (./page/) → same with index.md */}}
-{{- $content = replaceRE `\]\((\.\.?/[^):]*/)([\)#?])` `](${1}index.md${2}` $content -}}
+{{- $content = replaceRE `\]\((\.\.?/[^):]*/)([\)#?])` `](https://qdrant.tech/${1}index.md${2}` $content -}}
 {{ $content }}


### PR DESCRIPTION
[Preview](https://deploy-preview-2420--condescending-goldwasser-91acf0.netlify.app/documentation/manage-data/index.md)

Improves rendering of the Markdownified docs:

- Remove duplicate H1 title (antipattern)
- Render links as absolute links instead of relative links (a best practice for agents; they generally don't have a stable base URL to resolve relative links against when processing documentation)