### PR TITLE
Match table text color with regular text color

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-article.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/documentation/_documentation-article.scss
@@ -160,6 +160,17 @@ article.documentation-article {
 
 }
 
+[data-theme='dark'] {
+  .documentation-article {
+    .table-responsive {
+      th,
+      td {
+        color: $neutral-70;
+      }
+    }
+  }
+}
+
 [data-theme='light'] {
   .documentation-article {
     h1,


### PR DESCRIPTION
[Preview](https://deploy-preview-2422--condescending-goldwasser-91acf0.netlify.app/documentation/manage-data/points/#vectors)

In dark mode, the text color in tables doesn't match the regular text color. This PR changes the table text color to match that of regular text.

Before:
<img width="768" height="365" alt="image" src="https://github.com/user-attachments/assets/91eb67f7-279a-4114-b94f-425fad2b098f" />

After:
<img width="749" height="372" alt="image" src="https://github.com/user-attachments/assets/523280e7-6390-451a-952a-1898a6b72538" />
