### PR TITLE
Set up redirects for nonexistant URLs

### DIFF
--- a/qdrant-landing/static/_redirects
+++ b/qdrant-landing/static/_redirects
@@ -63,3 +63,8 @@
 
 # Deploy tab landing page slug change
 /documentation/cloud-intro/*    /documentation/deploy-intro/:splat    301
+
+# High-traffic missing pages
+/documentation/hybrid-search/   /documentation/search/hybrid-queries/    301
+/documentation/scroll/           /documentation/manage-data/points/#scroll-points       301
+/documentation/discovery/        /documentation/search/explore/           301


### PR DESCRIPTION
We're seeing significant traffic to three documentation URLs that don't exist. This PR sets up redirects for those URLs, so these requests don't result in 404s.

Previews (old URLs that are redirected):
- https://deploy-preview-2425--condescending-goldwasser-91acf0.netlify.app/documentation/hybrid-search
- https://deploy-preview-2425--condescending-goldwasser-91acf0.netlify.app/documentation/scroll
- https://deploy-preview-2425--condescending-goldwasser-91acf0.netlify.app/documentation/discovery