### PR TITLE
Add query decomposition for multi-hop questions

### DIFF
--- a/qdrant-landing/content/documentation/improve-search/_index.md
+++ b/qdrant-landing/content/documentation/improve-search/_index.md
@@ -12,3 +12,4 @@ partition: ecosystem
 | :--- | :--- | :--- | :--- | :--- |
 | [Measuring Retrieval Relevance](/documentation/improve-search/retrieval-relevance/) | Build a labeled golden set and score retrieval relevance with ranx. | <span class="pill">Python</span> | 40m | <span class="text-yellow">Intermediate</span> |
 | [Evaluating Pipeline Output Quality](/documentation/improve-search/pipeline-output-quality/) | Score a RAG pipeline with Ragas and isolate retrieval vs generation failures. | <span class="pill">Python</span> | 45m | <span class="text-yellow">Intermediate</span> |
+| [Query Decomposition for Multi-Hop Questions](/documentation/improve-search/query-decomposition/) | Answer multi-hop questions by retrieving in steps, with an LLM asking the next sub-question. | <span class="pill">Python</span> | 15m | <span class="text-yellow">Intermediate</span> |

--- a/qdrant-landing/content/documentation/improve-search/query-decomposition.md
+++ b/qdrant-landing/content/documentation/improve-search/query-decomposition.md
@@ -1,6 +1,6 @@
 ---
 title: Query Decomposition for Multi-Hop Questions
-short_description: "Answer multi-hop questions by retrieving in steps: an LLM asks each follow-up sub-question, then Qdrant fuses the results with RRF."
+short_description: "Answer multi-hop questions by retrieving in steps: an LLM asks each follow-up sub-question, then fuse the per-hop results with RRF."
 description: "Answer multi-hop questions in Qdrant: decompose the query into retrieval steps, let an LLM ask each follow-up, and fuse results with RRF."
 weight: 8
 partition: ecosystem
@@ -13,13 +13,13 @@ partition: ecosystem
 
 A multi-hop question chains two facts: the second depends on the answer to the first. "Where was the director of the film Inception born?" needs the director, then that person's birthplace. A single query retrieves chunks about the film, but the birthplace sits in a chunk about Christopher Nolan that never mentions Inception. Reranking and fusion only reorder what one query already retrieved, so they can't recover evidence that was never in the candidate set.
 
-Decomposition fetches it: search for the question, let an LLM read the results and ask the next sub-question, search again, and repeat until nothing is missing. Each hop's query is informed by what the last hop found. The approach builds on [Self-Ask](https://arxiv.org/abs/2210.03350), where the model asks itself follow-up questions, and [IRCoT](https://arxiv.org/abs/2212.10509), which interleaves retrieval with the model's reasoning across steps.
+Decomposition fetches it: search for the question, let an LLM read the results and ask the next sub-question, search again, and repeat until nothing is missing. The approach builds on [Self-Ask](https://arxiv.org/abs/2210.03350), where the model asks itself follow-up questions, and [IRCoT](https://arxiv.org/abs/2212.10509), which interleaves retrieval with the model's reasoning across steps.
 
 **Prerequisites.** A populated Qdrant collection, an embedding model to encode queries, and Python with `qdrant-client` and `openai`.
 
 ## How It Works
 
-The flow is: retrieve for the question, ask the LLM what's still missing, retrieve for that, repeat, then fuse everything. Start with the clients and a cap on the number of hops.
+Start with the clients and a cap on the number of hops.
 
 ```python
 from openai import OpenAI
@@ -29,7 +29,7 @@ from your_embedding_model import embed  # must match the model your collection u
 
 llm = OpenAI(api_key="<your-api-key>")
 # QdrantClient(url="https://<id>.cloud.qdrant.io", api_key="...") for Qdrant Cloud
-client = QdrantClient("http://localhost:6333")  
+client = QdrantClient("http://localhost:6333")
 
 MODEL = "gpt-5-mini"    # small, fast, cheap; swap for any chat model you prefer
 MAX_HOPS = 3            # cap the follow-up hops so the loop always terminates
@@ -53,8 +53,12 @@ After each hop, the LLM reads the results so far and names the one fact still mi
 ```python
 def next_subquestion(question, hops):
     """Ask the LLM what to retrieve next, or return None when nothing is missing."""
-    # top 3 chunks from every hop so far
-    context = "\n".join(hit.payload.get("text", "") for hits in hops for hit in hits[:3])
+    # the top 3 chunks from each hop so far
+    context = "\n".join(
+        hit.payload.get("text", "")
+        for hits in hops
+        for hit in hits[:3]
+    )
     prompt = (
         f"Question: {question}\n\n"
         f"Results so far:\n{context}\n\n"
@@ -66,46 +70,53 @@ def next_subquestion(question, hops):
         messages=[{"role": "user", "content": prompt}],
     )
     answer = response.choices[0].message.content.strip()
-    return None if answer == "DONE" else answer
+    return None if answer.upper().startswith("DONE") else answer
 ```
 
-Once every sub-question is known, one request retrieves for all of them and fuses the results. Fusing every hop matters: a multi-hop question is a chain and each hop retrieves one link, so keeping only the last query would lose the evidence that ties the answer back to the original question.
+The loop already has every hop's results. Fuse all of them, not just the last: each hop retrieves one link of the chain, so dropping the earlier hops loses the evidence that ties the answer back to the question.
 
 ```python
-def fused_retrieve(queries, limit=10):
-    """Retrieve for every sub-question and let Qdrant merge them with built-in Reciprocal Rank Fusion (RRF)."""
-    response = client.query_points(
-        collection_name="{collection_name}",
-        prefetch=[
-            models.Prefetch(query=embed(q), using="dense", limit=limit)
-            for q in queries
-        ],
-        query=models.RrfQuery(rrf=models.Rrf()),
-        limit=limit,
-    )
-    return response.points
+def rrf_fuse(hops, k=2, limit=10):
+    """Merge the per-hop results with Reciprocal Rank Fusion (RRF)."""
+    scores, points = {}, {}
+    for hits in hops:
+        for rank, hit in enumerate(hits):
+            scores[hit.id] = scores.get(hit.id, 0) + 1 / (k + rank)
+            points.setdefault(hit.id, hit)
+    ranked = sorted(scores, key=scores.get, reverse=True)
+    return [points[i] for i in ranked[:limit]]
 ```
 
-We use [Reciprocal Rank Fusion](/documentation/search/hybrid-queries/#reciprocal-rank-fusion-rrf): each list scores a chunk as `1 / (k + rank)` for a small constant `k` (2 by default in Qdrant), and those scores sum across the lists, so a chunk ranked high in any hop rises, and one that appears in several hops rises further. It combines by rank rather than raw score because similarity scores from different query vectors aren't comparable, but ranks are.
+Reciprocal Rank Fusion scores each chunk by its rank in every hop, `1 / (k + rank)`, and sums across hops, so a chunk ranked high in any hop rises and one ranked high in several rises further. For more on RRF, see the [hybrid queries reference](/documentation/search/hybrid-queries/#reciprocal-rank-fusion-rrf). We fuse in Python because the loop already holds each hop's results; to fuse inside a single request instead, Qdrant runs RRF server-side with `RrfQuery`.
 
 Tie the pieces together: loop until the LLM is satisfied, then fuse.
 
 ```python
 question = "Where was the director of the film Inception born?"
-queries = [question]         # every sub-question we retrieve for
-hops = [retrieve(question)]  # their results, used to steer the LLM
+hops = [retrieve(question)]  # each hop's results, also used to steer the LLM
 
 for _ in range(MAX_HOPS):
     follow_up = next_subquestion(question, hops)
     if follow_up is None:
         break
-    queries.append(follow_up)
+    print("follow-up:", follow_up)
     hops.append(retrieve(follow_up))
 
-pool = fused_retrieve(queries)  # Qdrant fuses all sub-questions with built-in RRF
+pool = rrf_fuse(hops)  # fuse every hop's results; no extra queries
+for point in pool[:3]:
+    print(point.payload["text"])
 ```
 
-The per-hop retrievals inside the loop only feed the LLM's choice of the next sub-question. `fused_retrieve` produces the final `pool`, running every sub-question through Qdrant's RRF in one request. Pass that `pool` to your answer step: the LLM call that reads the chunks and writes the answer.
+The loop prints the follow-up the LLM generates, then `rrf_fuse` reuses the hops to build `pool`. With a small, synthetic film-and-director collection, it prints:
+
+```text
+follow-up: Where was Christopher Nolan born?
+Christopher Nolan was born on 30 July 1970 in London, England. He developed an interest in filmmaking as a child.
+Inception is a 2010 science fiction film written and directed by Christopher Nolan. It follows a thief who steals corporate secrets through dream-sharing technology.
+Christopher Nolan studied English literature at University College London before starting his film career.
+```
+
+The birthplace chunk never mentions Inception, so only the follow-up surfaces it. In this run, RRF brings both links to the top of `pool`. Pass that `pool` to your answer step: the LLM call that reads the chunks and writes the answer.
 
 ## When to Use It
 

--- a/qdrant-landing/content/documentation/improve-search/query-decomposition.md
+++ b/qdrant-landing/content/documentation/improve-search/query-decomposition.md
@@ -1,0 +1,112 @@
+---
+title: Query Decomposition for Multi-Hop Questions
+short_description: "Answer multi-hop questions by retrieving in steps: an LLM asks each follow-up sub-question, then Qdrant fuses the results with RRF."
+description: "Answer multi-hop questions in Qdrant: decompose the query into retrieval steps, let an LLM ask each follow-up, and fuse results with RRF."
+weight: 8
+partition: ecosystem
+---
+
+# Query Decomposition for Multi-Hop Questions
+
+| Time: 15 min | Level: Intermediate |  |    |
+|--------------|---------------------|--|----|
+
+A multi-hop question chains two facts: the second depends on the answer to the first. "Where was the director of the film Inception born?" needs the director, then that person's birthplace. A single query retrieves chunks about the film, but the birthplace sits in a chunk about Christopher Nolan that never mentions Inception. Reranking and fusion only reorder what one query already retrieved, so they can't recover evidence that was never in the candidate set.
+
+Decomposition fetches it: search for the question, let an LLM read the results and ask the next sub-question, search again, and repeat until nothing is missing. Each hop's query is informed by what the last hop found. The approach builds on [Self-Ask](https://arxiv.org/abs/2210.03350), where the model asks itself follow-up questions, and [IRCoT](https://arxiv.org/abs/2212.10509), which interleaves retrieval with the model's reasoning across steps.
+
+**Prerequisites.** A populated Qdrant collection, an embedding model to encode queries, and Python with `qdrant-client` and `openai`.
+
+## How It Works
+
+The flow is: retrieve for the question, ask the LLM what's still missing, retrieve for that, repeat, then fuse everything. Start with the clients and a cap on the number of hops.
+
+```python
+from openai import OpenAI
+from qdrant_client import QdrantClient, models
+
+from your_embedding_model import embed  # must match the model your collection uses
+
+llm = OpenAI(api_key="<your-api-key>")
+# QdrantClient(url="https://<id>.cloud.qdrant.io", api_key="...") for Qdrant Cloud
+client = QdrantClient("http://localhost:6333")  
+
+MODEL = "gpt-5-mini"    # small, fast, cheap; swap for any chat model you prefer
+MAX_HOPS = 3            # cap the follow-up hops so the loop always terminates
+```
+
+Each hop is an ordinary similarity search:
+
+```python
+def retrieve(text, limit=10):
+    response = client.query_points(
+        collection_name="{collection_name}",
+        query=embed(text),
+        using="dense",  # your vector's name; omit if unnamed
+        limit=limit,
+    )
+    return response.points
+```
+
+After each hop, the LLM reads the results so far and names the one fact still missing, or replies `DONE`. Picking the next sub-question is a light task, so a small, fast model handles it well:
+
+```python
+def next_subquestion(question, hops):
+    """Ask the LLM what to retrieve next, or return None when nothing is missing."""
+    # top 3 chunks from every hop so far
+    context = "\n".join(hit.payload.get("text", "") for hits in hops for hit in hits[:3])
+    prompt = (
+        f"Question: {question}\n\n"
+        f"Results so far:\n{context}\n\n"
+        "What single follow-up question still needs answering? "
+        "Reply with only the question, or DONE if the results already answer it."
+    )
+    response = llm.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    answer = response.choices[0].message.content.strip()
+    return None if answer == "DONE" else answer
+```
+
+Once every sub-question is known, one request retrieves for all of them and fuses the results. Fusing every hop matters: a multi-hop question is a chain and each hop retrieves one link, so keeping only the last query would lose the evidence that ties the answer back to the original question.
+
+```python
+def fused_retrieve(queries, limit=10):
+    """Retrieve for every sub-question and let Qdrant merge them with built-in Reciprocal Rank Fusion (RRF)."""
+    response = client.query_points(
+        collection_name="{collection_name}",
+        prefetch=[
+            models.Prefetch(query=embed(q), using="dense", limit=limit)
+            for q in queries
+        ],
+        query=models.RrfQuery(rrf=models.Rrf()),
+        limit=limit,
+    )
+    return response.points
+```
+
+We use [Reciprocal Rank Fusion](/documentation/search/hybrid-queries/#reciprocal-rank-fusion-rrf): each list scores a chunk as `1 / (k + rank)` for a small constant `k` (2 by default in Qdrant), and those scores sum across the lists, so a chunk ranked high in any hop rises, and one that appears in several hops rises further. It combines by rank rather than raw score because similarity scores from different query vectors aren't comparable, but ranks are.
+
+Tie the pieces together: loop until the LLM is satisfied, then fuse.
+
+```python
+question = "Where was the director of the film Inception born?"
+queries = [question]         # every sub-question we retrieve for
+hops = [retrieve(question)]  # their results, used to steer the LLM
+
+for _ in range(MAX_HOPS):
+    follow_up = next_subquestion(question, hops)
+    if follow_up is None:
+        break
+    queries.append(follow_up)
+    hops.append(retrieve(follow_up))
+
+pool = fused_retrieve(queries)  # Qdrant fuses all sub-questions with built-in RRF
+```
+
+The per-hop retrievals inside the loop only feed the LLM's choice of the next sub-question. `fused_retrieve` produces the final `pool`, running every sub-question through Qdrant's RRF in one request. Pass that `pool` to your answer step: the LLM call that reads the chunks and writes the answer.
+
+## When to Use It
+
+Decomposition adds an LLM call and a query per hop, so reach for it only when a question spans multiple facts. For single-fact questions, one query is faster and just as accurate. To confirm it helps on your data, compare `recall@k` for single-pass against decomposition on a small set of multi-hop questions; the [Measuring Retrieval Relevance](/documentation/improve-search/retrieval-relevance/) tutorial covers the setup.

--- a/qdrant-landing/content/documentation/improve-search/query-decomposition.md
+++ b/qdrant-landing/content/documentation/improve-search/query-decomposition.md
@@ -116,7 +116,7 @@ Inception is a 2010 science fiction film written and directed by Christopher Nol
 Christopher Nolan studied English literature at University College London before starting his film career.
 ```
 
-The birthplace chunk never mentions Inception, so only the follow-up surfaces it. In this run, RRF brings both links to the top of `pool`. Pass that `pool` to your answer step: the LLM call that reads the chunks and writes the answer.
+The birthplace chunk never mentions Inception, so the original question won't surface it; only the follow-up does. Here, RRF ranks both the film chunk and the birthplace chunk at the top of `pool`. Pass that `pool` to your answer step: the LLM call that reads the chunks and writes the answer.
 
 ## When to Use It
 

--- a/qdrant-landing/content/documentation/search/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/search/hybrid-queries.md
@@ -163,52 +163,6 @@ A formula query lets you compose a final score from prefetch scores (`$score`), 
 
 The [Choosing a Fusion Method notebook](https://githubtocolab.com/qdrant/examples/blob/master/fusion-methods/Choosing_a_Fusion_Method.ipynb) shows this pattern end-to-end with exponential decay on a `published_at` payload field. For full formula query and decay function syntax, see the [Search Relevance reference](/documentation/search/search-relevance/).
 
-### Query Decomposition for Multi-Hop Questions
-
-Multi-stage queries reorder candidates from a single request. A multi-hop question needs more than reordering: the evidence for a later step may never be retrieved by the original query, so there is nothing to rescore. For example, "Where was the director of the film Inception born?" has two steps: first find the director, then find where that person was born.
-
-Decomposition handles this. Retrieve once for the question, let an LLM read those results and ask the next sub-question, then retrieve again and merge both result sets.
-
-```python
-from openai import OpenAI
-from qdrant_client import QdrantClient
-
-llm = OpenAI(api_key="<your-api-key>")
-client = QdrantClient(url="http://localhost:6333")
-
-def retrieve(text):
-    return client.query_points(
-        collection_name="{collection_name}",
-        query=embed(text),  # embed the text with the same model your collection uses
-        using="dense",
-        limit=10,
-    ).points
-
-question = "Where was the director of the film Inception born?"
-
-# Step 1: retrieve for the question as written.
-hits = retrieve(question)
-
-# Step 2: let the model read those results and ask the next sub-question.
-context = "\n".join(hit.payload["text"] for hit in hits[:3])
-follow_up = llm.chat.completions.create(
-    model="gpt-5.5",
-    messages=[{"role": "user", "content":
-        f"Question: {question}\n\nResults so far:\n{context}\n\n"
-        f"What single follow-up question still needs answering? Reply with only the question."}],
-).choices[0].message.content.strip()
-
-# Step 3: retrieve for the follow-up, then merge, keeping the best score per passage.
-merged = {hit.id: hit for hit in hits}
-for hit in retrieve(follow_up):
-    if hit.id not in merged or hit.score > merged[hit.id].score:
-        merged[hit.id] = hit
-
-pool = sorted(merged.values(), key=lambda hit: hit.score, reverse=True)[:10]
-```
-
-`embed()` is your own embedding step, using the same model your collection was indexed with. Merging keeps the best-scoring copy of each passage, so evidence from either step reaches the final pool. For questions with more than two steps, repeat steps 2 and 3 until the model has no further sub-question.
-
 ## Grouping
 
 _Available as of v1.11.0_

--- a/qdrant-landing/content/documentation/search/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/search/hybrid-queries.md
@@ -163,6 +163,52 @@ A formula query lets you compose a final score from prefetch scores (`$score`), 
 
 The [Choosing a Fusion Method notebook](https://githubtocolab.com/qdrant/examples/blob/master/fusion-methods/Choosing_a_Fusion_Method.ipynb) shows this pattern end-to-end with exponential decay on a `published_at` payload field. For full formula query and decay function syntax, see the [Search Relevance reference](/documentation/search/search-relevance/).
 
+### Query Decomposition for Multi-Hop Questions
+
+Multi-stage queries reorder candidates from a single request. A multi-hop question needs more than reordering: the evidence for a later step may never be retrieved by the original query, so there is nothing to rescore. For example, "Where was the director of the film Inception born?" has two steps: first find the director, then find where that person was born.
+
+Decomposition handles this. Retrieve once for the question, let an LLM read those results and ask the next sub-question, then retrieve again and merge both result sets.
+
+```python
+from openai import OpenAI
+from qdrant_client import QdrantClient
+
+llm = OpenAI(api_key="<your-api-key>")
+client = QdrantClient(url="http://localhost:6333")
+
+def retrieve(text):
+    return client.query_points(
+        collection_name="{collection_name}",
+        query=embed(text),  # embed the text with the same model your collection uses
+        using="dense",
+        limit=10,
+    ).points
+
+question = "Where was the director of the film Inception born?"
+
+# Step 1: retrieve for the question as written.
+hits = retrieve(question)
+
+# Step 2: let the model read those results and ask the next sub-question.
+context = "\n".join(hit.payload["text"] for hit in hits[:3])
+follow_up = llm.chat.completions.create(
+    model="gpt-5.5",
+    messages=[{"role": "user", "content":
+        f"Question: {question}\n\nResults so far:\n{context}\n\n"
+        f"What single follow-up question still needs answering? Reply with only the question."}],
+).choices[0].message.content.strip()
+
+# Step 3: retrieve for the follow-up, then merge, keeping the best score per passage.
+merged = {hit.id: hit for hit in hits}
+for hit in retrieve(follow_up):
+    if hit.id not in merged or hit.score > merged[hit.id].score:
+        merged[hit.id] = hit
+
+pool = sorted(merged.values(), key=lambda hit: hit.score, reverse=True)[:10]
+```
+
+`embed()` is your own embedding step, using the same model your collection was indexed with. Merging keeps the best-scoring copy of each passage, so evidence from either step reaches the final pool. For questions with more than two steps, repeat steps 2 and 3 until the model has no further sub-question.
+
 ## Grouping
 
 _Available as of v1.11.0_


### PR DESCRIPTION
Preview: https://deploy-preview-2430--condescending-goldwasser-91acf0.netlify.app/documentation/improve-search/query-decomposition/

Adds **Query Decomposition for Multi-Hop Questions** as a standalone tutorial under Improve Search (`improve-search/query-decomposition.md`) and links it from the section index.

### Why

Multi-stage queries and reranking only improve results already retrieved. For multi-hop questions, the needed information may never be fetched.

Decomposition solves this by iteratively retrieving, having an LLM generate the next sub-question, repeating up to a hop limit, and fusing results with Qdrant's RRF.

I tested this in a retrieval workshop and it improved answers on complex multi-hop queries that single-pass retrieval missed.

  ### Files
  - `improve-search/query-decomposition.md` — new tutorial
  - `improve-search/_index.md` — adds it to the section table

  Workshop: https://github.com/qdrant-labs/self-correcting-loops-workshop