### PR TITLE
Include imports in Edge Rust snippets

### DIFF
--- a/automation/snippets/lib/languages/rust.py
+++ b/automation/snippets/lib/languages/rust.py
@@ -67,7 +67,7 @@ class LanguageRust(Language):
 
     RE_CODE = re.compile(
         r"""
-        (?P<uses> (?:use\s[^;]+;\n|\n)* )
+        (?P<uses> (?:use\s[^;]+;\n|//[^\n]*\n|\n)* )
         pub\s+async\s+fn\s+main\(\)\s*->\s*anyhow::Result<\(\)>\s*\{\n
         (?P<body> .*? )
         \s*Ok\(\(\)\)\n

--- a/qdrant-landing/content/documentation/edge/edge-data-synchronization-patterns.md
+++ b/qdrant-landing/content/documentation/edge/edge-data-synchronization-patterns.md
@@ -18,15 +18,11 @@ Instead of starting with an empty Edge Shard, you may want to initialize it with
 
 When creating a snapshot for synchronization, specify the applicable server-side shard ID in the snapshot URL. This allows for a single collection to serve multiple independent users or devices, each with its own Edge Shard. Read more about Qdrant's sharding strategy in the [Tiered Multitenancy Documentation](/documentation/manage-data/multitenancy/#tiered-multitenancy).
 
-First, craft a snapshot URL:
-
-{{< code-snippet path="/documentation/headless/snippets/edge/synchronization-patterns/" block="snapshot-url" >}}
-
-Note that this example uses shard ID `0`.
-
-Using the snapshot URL, you can download the snapshot to the local disk and use its data to initialize a new Edge Shard.
+First, craft a snapshot URL and use the URL to download the snapshot to the local disk. Next, use the snapshot to initialize a new Edge Shard.
 
 {{< code-snippet path="/documentation/headless/snippets/edge/synchronization-patterns/" block="restore-snapshot" >}}
+
+Note that this example uses shard ID `0`.
 
 This code first downloads the snapshot to a temporary directory. Next, `EdgeShard.unpack_snapshot` unpacks the downloaded snapshot into the data directory, and an EdgeShard is initialized using the unpacked data and configuration.
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/rust.md
@@ -1,16 +1,8 @@
 ```rust
-use std::path::Path;
-
-use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
-use qdrant_edge::external::serde_json::json;
-use qdrant_edge::{
-    EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParamsBuilder, Modifier,
-    NamedQuery, PointInsertOperations, PointOperations, PointStruct,
-    QueryEnum, QueryRequest, ScoringQuery, UpdateOperation,
-    VectorInternal, Vectors, WithPayloadInterface, WithVector,
-};
-
 const SHARD_DIRECTORY: &str = "./qdrant-edge-bm25";
+
+use std::path::*;
+use qdrant_edge::*;
 
 let config = EdgeConfigBuilder::new()
     .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/configure-bm25-shard/rust.md
@@ -1,4 +1,17 @@
 ```rust
+use std::path::Path;
+
+use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
+use qdrant_edge::external::serde_json::json;
+use qdrant_edge::{
+    EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParamsBuilder, Modifier,
+    NamedQuery, PointInsertOperations, PointOperations, PointStruct,
+    QueryEnum, QueryRequest, ScoringQuery, UpdateOperation,
+    VectorInternal, Vectors, WithPayloadInterface, WithVector,
+};
+
+const SHARD_DIRECTORY: &str = "./qdrant-edge-bm25";
+
 let config = EdgeConfigBuilder::new()
     .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()
         .modifier(Modifier::Idf)

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/create-bm25/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/create-bm25/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::bm25_embed::*;
+
 let bm25 = EdgeBm25::new(EdgeBm25Config {
     language: Some("english".to_string()),
     ..Default::default()

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/embed-and-upsert/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/embed-and-upsert/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use qdrant_edge::external::serde_json::json;
+use qdrant_edge::*;
+
 let docs = [
     (1u64, "the quick brown fox", "Article 1"),
     (2,    "a lazy dog sleeps",   "Article 2"),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 let query_vector = bm25.embed_query("clever fox");
 
 let results = shard.query(QueryRequest {

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/rust.md
@@ -1,16 +1,8 @@
 ```rust
-use std::path::Path;
-
-use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
-use qdrant_edge::external::serde_json::json;
-use qdrant_edge::{
-    EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParamsBuilder, Modifier,
-    NamedQuery, PointInsertOperations, PointOperations, PointStruct,
-    QueryEnum, QueryRequest, ScoringQuery, UpdateOperation,
-    VectorInternal, Vectors, WithPayloadInterface, WithVector,
-};
-
 const SHARD_DIRECTORY: &str = "./qdrant-edge-bm25";
+
+use std::path::*;
+use qdrant_edge::*;
 
 let config = EdgeConfigBuilder::new()
     .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()
@@ -20,10 +12,15 @@ let config = EdgeConfigBuilder::new()
 
 let shard = EdgeShard::new(Path::new(SHARD_DIRECTORY), config)?;
 
+use qdrant_edge::bm25_embed::*;
+
 let bm25 = EdgeBm25::new(EdgeBm25Config {
     language: Some("english".to_string()),
     ..Default::default()
 })?;
+
+use qdrant_edge::external::serde_json::json;
+use qdrant_edge::*;
 
 let docs = [
     (1u64, "the quick brown fox", "Article 1"),
@@ -43,6 +40,8 @@ shard.update(UpdateOperation::PointOperation(
     PointOperations::UpsertPoints(PointInsertOperations::PointsList(points)),
 ))?;
 shard.optimize()?;
+
+use qdrant_edge::*;
 
 let query_vector = bm25.embed_query("clever fox");
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
@@ -1,18 +1,10 @@
 // @block-start configure-bm25-shard
-use std::path::Path;
-
-use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
-use qdrant_edge::external::serde_json::json;
-use qdrant_edge::{
-    EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParamsBuilder, Modifier,
-    NamedQuery, PointInsertOperations, PointOperations, PointStruct,
-    QueryEnum, QueryRequest, ScoringQuery, UpdateOperation,
-    VectorInternal, Vectors, WithPayloadInterface, WithVector,
-};
-
 pub async fn main() -> anyhow::Result<()> {
     const SHARD_DIRECTORY: &str = "./qdrant-edge-bm25";
     fs_err::create_dir_all(SHARD_DIRECTORY)?; // @hide
+
+    use std::path::*;
+    use qdrant_edge::*;
 
     let config = EdgeConfigBuilder::new()
         .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()
@@ -24,6 +16,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end configure-bm25-shard
 
     // @block-start create-bm25
+    use qdrant_edge::bm25_embed::*;
+
     let bm25 = EdgeBm25::new(EdgeBm25Config {
         language: Some("english".to_string()),
         ..Default::default()
@@ -31,6 +25,9 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end create-bm25
 
     // @block-start embed-and-upsert
+    use qdrant_edge::external::serde_json::json;
+    use qdrant_edge::*;
+
     let docs = [
         (1u64, "the quick brown fox", "Article 1"),
         (2,    "a lazy dog sleeps",   "Article 2"),
@@ -52,6 +49,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end embed-and-upsert
 
     // @block-start query-with-bm25
+    use qdrant_edge::*;
+
     let query_vector = bm25.embed_query("clever fox");
 
     let results = shard.query(QueryRequest {

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
@@ -1,3 +1,4 @@
+// @block-start configure-bm25-shard
 use std::path::Path;
 
 use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
@@ -13,7 +14,6 @@ pub async fn main() -> anyhow::Result<()> {
     const SHARD_DIRECTORY: &str = "./qdrant-edge-bm25";
     fs_err::create_dir_all(SHARD_DIRECTORY)?; // @hide
 
-    // @block-start configure-bm25-shard
     let config = EdgeConfigBuilder::new()
         .sparse_vector("text", EdgeSparseVectorParamsBuilder::new()
             .modifier(Modifier::Idf)

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-edge-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-edge-shard/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 const VECTOR_NAME: &str = "my-vector";
 const VECTOR_DIMENSION: usize = 4;
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-optimizer/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/configure-optimizer/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 let config = EdgeConfigBuilder::new()
     .on_disk_payload(true)
     .vector(

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/create-payload-index/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/create-payload-index/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 edge_shard.update(UpdateOperation::FieldIndexOperation(
     FieldIndexOperations::CreateIndex(CreateIndex {
         field_name: "color".try_into().unwrap(),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/create-storage-directory/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/create-storage-directory/rust.md
@@ -1,18 +1,4 @@
 ```rust
-use std::path::Path;
-
-use qdrant_edge::{
-    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder, EdgeShard,
-    EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
-    FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
-    PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,
-    PointOperations, PointStruct, PointStructPersisted, QueryEnum, QueryRequest,
-    ScoringQuery, SparseVectorConfig, UpdateOperation, ValueVariants,
-    VectorNameConfig, VectorNameOperations, Vectors, WalOptions,
-    WithPayloadInterface, WithVector,
-};
-use serde_json::json;
-
 const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
 
 fs_err::create_dir_all(SHARD_DIRECTORY)?;

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/create-storage-directory/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/create-storage-directory/rust.md
@@ -1,4 +1,18 @@
 ```rust
+use std::path::Path;
+
+use qdrant_edge::{
+    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder, EdgeShard,
+    EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
+    FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
+    PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,
+    PointOperations, PointStruct, PointStructPersisted, QueryEnum, QueryRequest,
+    ScoringQuery, SparseVectorConfig, UpdateOperation, ValueVariants,
+    VectorNameConfig, VectorNameOperations, Vectors, WalOptions,
+    WithPayloadInterface, WithVector,
+};
+use serde_json::json;
+
 const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
 
 fs_err::create_dir_all(SHARD_DIRECTORY)?;

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/facet/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/facet/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 let facet_response = edge_shard.facet(FacetRequest {
     key: "color".try_into().unwrap(),
     limit: 10,

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/filter/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/filter/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 let filter = Filter {
     should: None,
     min_should: None,

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/initialize-edge-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/initialize-edge-shard/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use std::path::*;
+use qdrant_edge::*;
+
 let edge_shard = EdgeShard::new(
     Path::new(SHARD_DIRECTORY),
     config,

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/load-edge-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/load-edge-shard/rust.md
@@ -1,3 +1,6 @@
 ```rust
+use std::path::*;
+use qdrant_edge::*;
+
 let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), None)?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/modify-vector-schema/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/modify-vector-schema/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 edge_shard.update(UpdateOperation::VectorNameOperation(
     VectorNameOperations::CreateVectorName(CreateVectorName {
         vector_name: "text".to_string(),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/query-points/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/query-points/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 let results = edge_shard.query(QueryRequest {
     prefetches: vec![],
     query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/retrieve-point/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/retrieve-point/rust.md
@@ -1,4 +1,6 @@
 ```rust
+use qdrant_edge::*;
+
 let retrieved = edge_shard.retrieve(
     &[PointId::NumId(1)],
     Some(WithPayloadInterface::Bool(true)),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
@@ -1,21 +1,9 @@
 ```rust
-use std::path::Path;
-
-use qdrant_edge::{
-    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder, EdgeShard,
-    EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
-    FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
-    PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,
-    PointOperations, PointStruct, PointStructPersisted, QueryEnum, QueryRequest,
-    ScoringQuery, SparseVectorConfig, UpdateOperation, ValueVariants,
-    VectorNameConfig, VectorNameOperations, Vectors, WalOptions,
-    WithPayloadInterface, WithVector,
-};
-use serde_json::json;
-
 const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
 
 fs_err::create_dir_all(SHARD_DIRECTORY)?;
+
+use qdrant_edge::*;
 
 const VECTOR_NAME: &str = "my-vector";
 const VECTOR_DIMENSION: usize = 4;
@@ -30,10 +18,16 @@ let config = EdgeConfigBuilder::new()
     )
     .build();
 
+use std::path::*;
+use qdrant_edge::*;
+
 let edge_shard = EdgeShard::new(
     Path::new(SHARD_DIRECTORY),
     config,
 )?;
+
+use serde_json::json;
+use qdrant_edge::*;
 
 let points: Vec<PointStructPersisted> = vec![
     PointStruct::new(
@@ -50,11 +44,15 @@ edge_shard.update(UpdateOperation::PointOperation(
     ),
 ))?;
 
+use qdrant_edge::*;
+
 let retrieved = edge_shard.retrieve(
     &[PointId::NumId(1)],
     Some(WithPayloadInterface::Bool(true)),
     Some(WithVector::Bool(false)),
 )?;
+
+use qdrant_edge::*;
 
 edge_shard.update(UpdateOperation::VectorNameOperation(
     VectorNameOperations::CreateVectorName(CreateVectorName {
@@ -65,6 +63,8 @@ edge_shard.update(UpdateOperation::VectorNameOperation(
         }),
     }),
 ))?;
+
+use qdrant_edge::*;
 
 let results = edge_shard.query(QueryRequest {
     prefetches: vec![],
@@ -80,6 +80,8 @@ let results = edge_shard.query(QueryRequest {
     with_vector: WithVector::Bool(false),
     with_payload: WithPayloadInterface::Bool(true),
 })?;
+
+use qdrant_edge::*;
 
 let filter = Filter {
     should: None,
@@ -108,6 +110,8 @@ let results = edge_shard.query(QueryRequest {
     with_payload: WithPayloadInterface::Bool(true),
 })?;
 
+use qdrant_edge::*;
+
 let facet_response = edge_shard.facet(FacetRequest {
     key: "color".try_into().unwrap(),
     limit: 10,
@@ -116,6 +120,8 @@ let facet_response = edge_shard.facet(FacetRequest {
 })?;
 
 edge_shard.optimize()?;
+
+use qdrant_edge::*;
 
 let config = EdgeConfigBuilder::new()
     .on_disk_payload(true)
@@ -133,6 +139,8 @@ let config = EdgeConfigBuilder::new()
     })
     .build();
 
+use qdrant_edge::*;
+
 edge_shard.update(UpdateOperation::FieldIndexOperation(
     FieldIndexOperations::CreateIndex(CreateIndex {
         field_name: "color".try_into().unwrap(),
@@ -144,7 +152,13 @@ edge_shard.update(UpdateOperation::FieldIndexOperation(
 
 drop(edge_shard);
 
+use std::path::*;
+use qdrant_edge::*;
+
 let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), None)?;
+
+use std::path::*;
+use qdrant_edge::*;
 
 let config = EdgeConfigBuilder::new()
     .wal_options(WalOptions {

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
@@ -1,9 +1,8 @@
 ```rust
 use std::path::Path;
 
-use qdrant_edge::EdgeShard;
 use qdrant_edge::{
-    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder,
+    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder, EdgeShard,
     EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
     FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
     PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/upsert-points/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/upsert-points/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use serde_json::json;
+use qdrant_edge::*;
+
 let points: Vec<PointStructPersisted> = vec![
     PointStruct::new(
         1u64,

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/wal-options/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/wal-options/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use std::path::*;
+use qdrant_edge::*;
+
 let config = EdgeConfigBuilder::new()
     .wal_options(WalOptions {
         segment_capacity: 4 * 1024 * 1024,

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
@@ -1,8 +1,8 @@
+// @block-start create-storage-directory
 use std::path::Path;
 
-use qdrant_edge::EdgeShard;
 use qdrant_edge::{
-    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder,
+    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder, EdgeShard,
     EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
     FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
     PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,
@@ -14,7 +14,7 @@ use qdrant_edge::{
 use serde_json::json;
 
 pub async fn main() -> anyhow::Result<()> {
-    // @block-start create-storage-directory
+
     const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
 
     fs_err::create_dir_all(SHARD_DIRECTORY)?;

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
@@ -1,18 +1,4 @@
 // @block-start create-storage-directory
-use std::path::Path;
-
-use qdrant_edge::{
-    Condition, CreateIndex, CreateVectorName, Distance, EdgeConfigBuilder, EdgeShard,
-    EdgeOptimizersConfig, EdgeVectorParamsBuilder, FacetRequest, FieldCondition,
-    FieldIndexOperations, Filter, Match, MatchValue, Modifier, NamedQuery,
-    PayloadFieldSchema, PayloadSchemaType, PointId, PointInsertOperations,
-    PointOperations, PointStruct, PointStructPersisted, QueryEnum, QueryRequest,
-    ScoringQuery, SparseVectorConfig, UpdateOperation, ValueVariants,
-    VectorNameConfig, VectorNameOperations, Vectors, WalOptions,
-    WithPayloadInterface, WithVector,
-};
-use serde_json::json;
-
 pub async fn main() -> anyhow::Result<()> {
 
     const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
@@ -21,6 +7,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end create-storage-directory
 
     // @block-start configure-edge-shard
+    use qdrant_edge::*;
+
     const VECTOR_NAME: &str = "my-vector";
     const VECTOR_DIMENSION: usize = 4;
 
@@ -36,6 +24,9 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end configure-edge-shard
 
     // @block-start initialize-edge-shard
+    use std::path::*;
+    use qdrant_edge::*;
+
     let edge_shard = EdgeShard::new(
         Path::new(SHARD_DIRECTORY),
         config,
@@ -43,6 +34,9 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end initialize-edge-shard
 
     // @block-start upsert-points
+    use serde_json::json;
+    use qdrant_edge::*;
+
     let points: Vec<PointStructPersisted> = vec![
         PointStruct::new(
             1u64,
@@ -60,6 +54,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end upsert-points
 
     // @block-start retrieve-point
+    use qdrant_edge::*;
+
     let retrieved = edge_shard.retrieve(
         &[PointId::NumId(1)],
         Some(WithPayloadInterface::Bool(true)),
@@ -68,6 +64,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end retrieve-point
 
     // @block-start modify-vector-schema
+    use qdrant_edge::*;
+
     edge_shard.update(UpdateOperation::VectorNameOperation(
         VectorNameOperations::CreateVectorName(CreateVectorName {
             vector_name: "text".to_string(),
@@ -80,6 +78,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end modify-vector-schema
 
     // @block-start query-points
+    use qdrant_edge::*;
+
     let results = edge_shard.query(QueryRequest {
         prefetches: vec![],
         query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
@@ -97,6 +97,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end query-points
 
     // @block-start filter
+    use qdrant_edge::*;
+
     let filter = Filter {
         should: None,
         min_should: None,
@@ -126,6 +128,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end filter
 
     // @block-start facet
+    use qdrant_edge::*;
+
     let facet_response = edge_shard.facet(FacetRequest {
         key: "color".try_into().unwrap(),
         limit: 10,
@@ -139,6 +143,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end optimize
 
     // @block-start configure-optimizer
+    use qdrant_edge::*;
+
     let config = EdgeConfigBuilder::new()
         .on_disk_payload(true)
         .vector(
@@ -157,6 +163,8 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end configure-optimizer
 
     // @block-start create-payload-index
+    use qdrant_edge::*;
+
     edge_shard.update(UpdateOperation::FieldIndexOperation(
         FieldIndexOperations::CreateIndex(CreateIndex {
             field_name: "color".try_into().unwrap(),
@@ -172,10 +180,16 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end close-edge-shard
 
     // @block-start load-edge-shard
+    use std::path::*;
+    use qdrant_edge::*;
+
     let edge_shard = EdgeShard::load(Path::new(SHARD_DIRECTORY), None)?;
     // @block-end load-edge-shard
 
     // @block-start wal-options
+    use std::path::*;
+    use qdrant_edge::*;
+
     let config = EdgeConfigBuilder::new()
         .wal_options(WalOptions {
             segment_capacity: 4 * 1024 * 1024,

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/delete-synced-points/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/delete-synced-points/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use ordered_float::*;
+use qdrant_edge::*;
+
 let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
     SYNC_TIMESTAMP_KEY.parse::<JsonPath>().unwrap(),
     Range {

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/dual-write/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/dual-write/rust.md
@@ -1,4 +1,9 @@
 ```rust
+use std::collections::*;
+use std::time::*;
+use serde_json::json;
+use qdrant_edge::*;
+
 const SYNC_TIMESTAMP_KEY: &str = "timestamp";
 let id = 2u64;
 let vector = vec![0.4f32, 0.3, 0.2, 0.1];
@@ -12,7 +17,7 @@ let payload = json!({
 });
 
 let edge_points: Vec<PointStructPersisted> = vec![
-    EdgePoint::new(
+    qdrant_edge::PointStruct::new(
         PointId::NumId(id),
         Vectors::new_named([(VECTOR_NAME, vector.clone())]),
         payload.clone(),
@@ -25,7 +30,7 @@ mutable_shard.update(UpdateOperation::PointOperation(
     ),
 ))?;
 
-let rest_point = PointStruct::new(
+let rest_point = ::qdrant_client::qdrant::PointStruct::new(
     id,
     HashMap::from([(VECTOR_NAME.to_string(), vector)]),
     payload.as_object().cloned().unwrap_or_default(),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-immutable-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-immutable-shard/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use std::path::*;
+use qdrant_edge::*;
+
 const COLLECTION_NAME: &str = "edge-collection";
 let snapshot_url = format!(
     "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-mutable-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-mutable-shard/rust.md
@@ -1,4 +1,21 @@
 ```rust
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ordered_float::OrderedFloat;
+use qdrant_client::qdrant::PointStruct;
+use qdrant_edge::EdgeShard;
+use qdrant_edge::internal::SnapshotManifest;
+use qdrant_edge::{
+    Condition, Distance, EdgeConfigBuilder, EdgeVectorParamsBuilder,
+    FieldCondition, Filter, JsonPath, NamedQuery, PointId, PointInsertOperations,
+    PointOperations, PointStruct as EdgePoint, PointStructPersisted, QueryEnum,
+    QueryRequest, Range, ScoringQuery, UpdateOperation, Vectors,
+    WithPayloadInterface, WithVector,
+};
+use serde_json::json;
+
 const MUTABLE_SHARD_DIR: &str = "./qdrant-edge-directory/mutable";
 const VECTOR_DIMENSION: usize = 4;
 const VECTOR_NAME: &str = "my-vector";

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-mutable-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/initialize-mutable-shard/rust.md
@@ -1,20 +1,6 @@
 ```rust
-use std::collections::HashMap;
-use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use ordered_float::OrderedFloat;
-use qdrant_client::qdrant::PointStruct;
-use qdrant_edge::EdgeShard;
-use qdrant_edge::internal::SnapshotManifest;
-use qdrant_edge::{
-    Condition, Distance, EdgeConfigBuilder, EdgeVectorParamsBuilder,
-    FieldCondition, Filter, JsonPath, NamedQuery, PointId, PointInsertOperations,
-    PointOperations, PointStruct as EdgePoint, PointStructPersisted, QueryEnum,
-    QueryRequest, Range, ScoringQuery, UpdateOperation, Vectors,
-    WithPayloadInterface, WithVector,
-};
-use serde_json::json;
+use std::path::*;
+use qdrant_edge::*;
 
 const MUTABLE_SHARD_DIR: &str = "./qdrant-edge-directory/mutable";
 const VECTOR_DIMENSION: usize = 4;

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/query-both-shards/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/query-both-shards/rust.md
@@ -1,4 +1,8 @@
 ```rust
+use std::cmp::*;
+use std::collections::*;
+use qdrant_edge::*;
+
 let query = QueryRequest {
     prefetches: vec![],
     query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
@@ -20,10 +24,10 @@ all_results.extend(immutable_shard.query(query)?);
 all_results.sort_by(|a, b| {
     b.score
         .partial_cmp(&a.score)
-        .unwrap_or(std::cmp::Ordering::Equal)
+        .unwrap_or(Ordering::Equal)
 });
 
-let mut seen_ids = std::collections::HashSet::new();
+let mut seen_ids = HashSet::new();
 let results: Vec<_> = all_results
     .into_iter()
     .filter(|p| seen_ids.insert(p.id.clone()))

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/rust.md
@@ -1,20 +1,6 @@
 ```rust
-use std::collections::HashMap;
-use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use ordered_float::OrderedFloat;
-use qdrant_client::qdrant::PointStruct;
-use qdrant_edge::EdgeShard;
-use qdrant_edge::internal::SnapshotManifest;
-use qdrant_edge::{
-    Condition, Distance, EdgeConfigBuilder, EdgeVectorParamsBuilder,
-    FieldCondition, Filter, JsonPath, NamedQuery, PointId, PointInsertOperations,
-    PointOperations, PointStruct as EdgePoint, PointStructPersisted, QueryEnum,
-    QueryRequest, Range, ScoringQuery, UpdateOperation, Vectors,
-    WithPayloadInterface, WithVector,
-};
-use serde_json::json;
+use std::path::*;
+use qdrant_edge::*;
 
 const MUTABLE_SHARD_DIR: &str = "./qdrant-edge-directory/mutable";
 const VECTOR_DIMENSION: usize = 4;
@@ -35,6 +21,9 @@ let mutable_shard = EdgeShard::new(
     Path::new(MUTABLE_SHARD_DIR),
     config,
 )?;
+
+use std::path::*;
+use qdrant_edge::*;
 
 const COLLECTION_NAME: &str = "edge-collection";
 let snapshot_url = format!(
@@ -68,6 +57,11 @@ EdgeShard::unpack_snapshot(&snapshot_path, data_dir)?;
 
 let immutable_shard = EdgeShard::load(data_dir, None)?;
 
+use std::collections::*;
+use std::time::*;
+use serde_json::json;
+use qdrant_edge::*;
+
 const SYNC_TIMESTAMP_KEY: &str = "timestamp";
 let id = 2u64;
 let vector = vec![0.4f32, 0.3, 0.2, 0.1];
@@ -81,7 +75,7 @@ let payload = json!({
 });
 
 let edge_points: Vec<PointStructPersisted> = vec![
-    EdgePoint::new(
+    qdrant_edge::PointStruct::new(
         PointId::NumId(id),
         Vectors::new_named([(VECTOR_NAME, vector.clone())]),
         payload.clone(),
@@ -94,12 +88,16 @@ mutable_shard.update(UpdateOperation::PointOperation(
     ),
 ))?;
 
-let rest_point = PointStruct::new(
+let rest_point = ::qdrant_client::qdrant::PointStruct::new(
     id,
     HashMap::from([(VECTOR_NAME.to_string(), vector)]),
     payload.as_object().cloned().unwrap_or_default(),
 );
 upload_queue.push_back(rest_point);
+
+use std::time::*;
+use qdrant_edge::*;
+use qdrant_edge::internal::*;
 
 let sync_timestamp = SystemTime::now()
     .duration_since(UNIX_EPOCH)
@@ -141,6 +139,9 @@ let immutable_shard = EdgeShard::recover_partial_snapshot(
     &snapshot_manifest,
 )?;
 
+use ordered_float::*;
+use qdrant_edge::*;
+
 let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
     SYNC_TIMESTAMP_KEY.parse::<JsonPath>().unwrap(),
     Range {
@@ -152,6 +153,10 @@ let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
 mutable_shard.update(UpdateOperation::PointOperation(
     PointOperations::DeletePointsByFilter(filter),
 ))?;
+
+use std::cmp::*;
+use std::collections::*;
+use qdrant_edge::*;
 
 let query = QueryRequest {
     prefetches: vec![],
@@ -174,10 +179,10 @@ all_results.extend(immutable_shard.query(query)?);
 all_results.sort_by(|a, b| {
     b.score
         .partial_cmp(&a.score)
-        .unwrap_or(std::cmp::Ordering::Equal)
+        .unwrap_or(Ordering::Equal)
 });
 
-let mut seen_ids = std::collections::HashSet::new();
+let mut seen_ids = HashSet::new();
 let results: Vec<_> = all_results
     .into_iter()
     .filter(|p| seen_ids.insert(p.id.clone()))

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/update-immutable-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/update-immutable-shard/rust.md
@@ -1,4 +1,8 @@
 ```rust
+use std::time::*;
+use qdrant_edge::*;
+use qdrant_edge::internal::*;
+
 let sync_timestamp = SystemTime::now()
     .duration_since(UNIX_EPOCH)
     .unwrap()

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
@@ -1,3 +1,4 @@
+// @block-start initialize-mutable-shard
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -23,7 +24,6 @@ pub async fn main() -> anyhow::Result<()> {
         std::collections::VecDeque::new();
     // @hide-end
 
-    // @block-start initialize-mutable-shard
     const MUTABLE_SHARD_DIR: &str = "./qdrant-edge-directory/mutable";
     const VECTOR_DIMENSION: usize = 4;
     const VECTOR_NAME: &str = "my-vector";

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
@@ -1,28 +1,14 @@
 // @block-start initialize-mutable-shard
-use std::collections::HashMap;
-use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use ordered_float::OrderedFloat;
-use qdrant_client::qdrant::PointStruct;
-use qdrant_edge::EdgeShard;
-use qdrant_edge::internal::SnapshotManifest;
-use qdrant_edge::{
-    Condition, Distance, EdgeConfigBuilder, EdgeVectorParamsBuilder,
-    FieldCondition, Filter, JsonPath, NamedQuery, PointId, PointInsertOperations,
-    PointOperations, PointStruct as EdgePoint, PointStructPersisted, QueryEnum,
-    QueryRequest, Range, ScoringQuery, UpdateOperation, Vectors,
-    WithPayloadInterface, WithVector,
-};
-use serde_json::json;
-
 pub async fn main() -> anyhow::Result<()> {
     // @hide-start
     const QDRANT_URL: &str = "";
     const QDRANT_API_KEY: &str = "";
-    let mut upload_queue: std::collections::VecDeque<PointStruct> =
+    let mut upload_queue: std::collections::VecDeque<::qdrant_client::qdrant::PointStruct> =
         std::collections::VecDeque::new();
     // @hide-end
+
+    use std::path::*;
+    use qdrant_edge::*;
 
     const MUTABLE_SHARD_DIR: &str = "./qdrant-edge-directory/mutable";
     const VECTOR_DIMENSION: usize = 4;
@@ -46,6 +32,9 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end initialize-mutable-shard
 
     // @block-start initialize-immutable-shard
+    use std::path::*;
+    use qdrant_edge::*;
+
     const COLLECTION_NAME: &str = "edge-collection";
     let snapshot_url = format!(
         "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
@@ -80,6 +69,11 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end initialize-immutable-shard
 
     // @block-start dual-write
+    use std::collections::*;
+    use std::time::*;
+    use serde_json::json;
+    use qdrant_edge::*;
+
     const SYNC_TIMESTAMP_KEY: &str = "timestamp";
     let id = 2u64;
     let vector = vec![0.4f32, 0.3, 0.2, 0.1];
@@ -93,7 +87,7 @@ pub async fn main() -> anyhow::Result<()> {
     });
 
     let edge_points: Vec<PointStructPersisted> = vec![
-        EdgePoint::new(
+        qdrant_edge::PointStruct::new(
             PointId::NumId(id),
             Vectors::new_named([(VECTOR_NAME, vector.clone())]),
             payload.clone(),
@@ -106,7 +100,7 @@ pub async fn main() -> anyhow::Result<()> {
         ),
     ))?;
 
-    let rest_point = PointStruct::new(
+    let rest_point = ::qdrant_client::qdrant::PointStruct::new(
         id,
         HashMap::from([(VECTOR_NAME.to_string(), vector)]),
         payload.as_object().cloned().unwrap_or_default(),
@@ -115,6 +109,10 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end dual-write
 
     // @block-start update-immutable-shard
+    use std::time::*;
+    use qdrant_edge::*;
+    use qdrant_edge::internal::*;
+
     let sync_timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -157,6 +155,9 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end update-immutable-shard
 
     // @block-start delete-synced-points
+    use ordered_float::*;
+    use qdrant_edge::*;
+
     let filter = Filter::new_must(Condition::Field(FieldCondition::new_range(
         SYNC_TIMESTAMP_KEY.parse::<JsonPath>().unwrap(),
         Range {
@@ -171,6 +172,10 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end delete-synced-points
 
     // @block-start query-both-shards
+    use std::cmp::*;
+    use std::collections::*;
+    use qdrant_edge::*;
+
     let query = QueryRequest {
         prefetches: vec![],
         query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
@@ -192,10 +197,10 @@ pub async fn main() -> anyhow::Result<()> {
     all_results.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .unwrap_or(Ordering::Equal)
     });
 
-    let mut seen_ids = std::collections::HashSet::new();
+    let mut seen_ids = HashSet::new();
     let results: Vec<_> = all_results
         .into_iter()
         .filter(|p| seen_ids.insert(p.id.clone()))

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/create-upload-queue/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/create-upload-queue/rust.md
@@ -1,6 +1,7 @@
 ```rust
+use std::collections::*;
+
 // This is an in-memory queue.
 // For production use cases consider persisting changes.
-let mut upload_queue: std::collections::VecDeque<PointStruct> =
-    std::collections::VecDeque::new();
+let mut upload_queue: VecDeque<::qdrant_client::qdrant::PointStruct> = VecDeque::new();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/initialize-edge-shard/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/initialize-edge-shard/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use std::path::*;
+use qdrant_edge::*;
+
 const VECTOR_DIMENSION: usize = 4;
 const VECTOR_NAME: &str = "my-vector";
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/initialize-server-client/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/initialize-server-client/rust.md
@@ -1,4 +1,8 @@
 ```rust
+use ::qdrant_client::*;
+use ::qdrant_client::qdrant::*;
+use ::qdrant_client::qdrant::Distance;
+
 let server_client = Qdrant::from_url(QDRANT_URL)
     .api_key(QDRANT_API_KEY)
     .build()?;

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/process-upload-queue/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/process-upload-queue/rust.md
@@ -1,6 +1,8 @@
 ```rust
+use ::qdrant_client::qdrant::*;
+
 const BATCH_SIZE: usize = 10;
-let points_to_upload: Vec<PointStruct> = upload_queue
+let points_to_upload: Vec<::qdrant_client::qdrant::PointStruct> = upload_queue
     .drain(..BATCH_SIZE.min(upload_queue.len()))
     .collect();
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/python.md
@@ -1,13 +1,13 @@
 ```python
-COLLECTION_NAME="edge-collection"
-
-snapshot_url = f"{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
-
 from pathlib import Path
 from qdrant_edge import EdgeShard
 import requests
 import shutil
 import tempfile
+
+COLLECTION_NAME="edge-collection"
+
+snapshot_url = f"{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
 
 SHARD_DIRECTORY = "./qdrant-edge-directory"
 data_dir = Path(SHARD_DIRECTORY)

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/restore-snapshot/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/restore-snapshot/python.md
@@ -5,6 +5,10 @@ import requests
 import shutil
 import tempfile
 
+COLLECTION_NAME="edge-collection"
+
+snapshot_url = f"{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
+
 SHARD_DIRECTORY = "./qdrant-edge-directory"
 data_dir = Path(SHARD_DIRECTORY)
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/restore-snapshot/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/restore-snapshot/rust.md
@@ -1,28 +1,14 @@
 ```rust
-use std::collections::HashMap;
-use std::path::Path;
-
-use qdrant_client::qdrant::{
-    CreateCollectionBuilder, Distance, PointStruct, UpsertPointsBuilder,
-    VectorParamsBuilder,
-};
-use qdrant_client::Qdrant;
-use qdrant_edge::EdgeShard;
-use qdrant_edge::internal::SnapshotManifest;
-use qdrant_edge::{
-    EdgeConfigBuilder, EdgeVectorParamsBuilder, PointId, PointInsertOperations,
-    PointOperations, PointStruct as EdgePoint, PointStructPersisted,
-    UpdateOperation, Vectors,
-};
-use serde_json::json;
-
 const COLLECTION_NAME: &str = "edge-collection";
+const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
+
+use std::path::*;
+use qdrant_edge::*;
 
 let snapshot_url = format!(
     "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
 );
 
-const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
 let data_dir = Path::new(SHARD_DIRECTORY);
 
 let restore_dir = tempfile::Builder::new()

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/restore-snapshot/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/restore-snapshot/rust.md
@@ -1,4 +1,27 @@
 ```rust
+use std::collections::HashMap;
+use std::path::Path;
+
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, Distance, PointStruct, UpsertPointsBuilder,
+    VectorParamsBuilder,
+};
+use qdrant_client::Qdrant;
+use qdrant_edge::EdgeShard;
+use qdrant_edge::internal::SnapshotManifest;
+use qdrant_edge::{
+    EdgeConfigBuilder, EdgeVectorParamsBuilder, PointId, PointInsertOperations,
+    PointOperations, PointStruct as EdgePoint, PointStructPersisted,
+    UpdateOperation, Vectors,
+};
+use serde_json::json;
+
+const COLLECTION_NAME: &str = "edge-collection";
+
+let snapshot_url = format!(
+    "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
+);
+
 const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
 let data_dir = Path::new(SHARD_DIRECTORY);
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/rust.md
@@ -1,28 +1,14 @@
 ```rust
-use std::collections::HashMap;
-use std::path::Path;
-
-use qdrant_client::qdrant::{
-    CreateCollectionBuilder, Distance, PointStruct, UpsertPointsBuilder,
-    VectorParamsBuilder,
-};
-use qdrant_client::Qdrant;
-use qdrant_edge::EdgeShard;
-use qdrant_edge::internal::SnapshotManifest;
-use qdrant_edge::{
-    EdgeConfigBuilder, EdgeVectorParamsBuilder, PointId, PointInsertOperations,
-    PointOperations, PointStruct as EdgePoint, PointStructPersisted,
-    UpdateOperation, Vectors,
-};
-use serde_json::json;
-
 const COLLECTION_NAME: &str = "edge-collection";
+const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
+
+use std::path::*;
+use qdrant_edge::*;
 
 let snapshot_url = format!(
     "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
 );
 
-const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
 let data_dir = Path::new(SHARD_DIRECTORY);
 
 let restore_dir = tempfile::Builder::new()
@@ -48,6 +34,9 @@ fs_err::create_dir_all(data_dir)?;
 EdgeShard::unpack_snapshot(&snapshot_path, data_dir)?;
 
 let edge_shard = EdgeShard::load(data_dir, None)?;
+
+use qdrant_edge::*;
+use qdrant_edge::internal::*;
 
 let current_manifest = edge_shard.snapshot_manifest()?;
 
@@ -84,6 +73,9 @@ let edge_shard = EdgeShard::recover_partial_snapshot(
     &snapshot_manifest,
 )?;
 
+use std::path::*;
+use qdrant_edge::*;
+
 const VECTOR_DIMENSION: usize = 4;
 const VECTOR_NAME: &str = "my-vector";
 
@@ -103,6 +95,10 @@ let edge_shard = EdgeShard::new(
     config,
 )?;
 
+use ::qdrant_client::*;
+use ::qdrant_client::qdrant::*;
+use ::qdrant_client::qdrant::Distance;
+
 let server_client = Qdrant::from_url(QDRANT_URL)
     .api_key(QDRANT_API_KEY)
     .build()?;
@@ -120,17 +116,25 @@ if !server_client.collection_exists(COLLECTION_NAME).await? {
         .await?;
 }
 
+use std::collections::*;
+
 // This is an in-memory queue.
 // For production use cases consider persisting changes.
-let mut upload_queue: std::collections::VecDeque<PointStruct> =
-    std::collections::VecDeque::new();
+let mut upload_queue: VecDeque<::qdrant_client::qdrant::PointStruct> = VecDeque::new();
+
+use std::collections::*;
+use serde_json::json;
+use qdrant_edge::{
+    PointInsertOperations, PointOperations,
+    PointStructPersisted, PointId, UpdateOperation, Vectors,
+};
 
 let id = 1u64;
 let vector = vec![0.1f32, 0.2, 0.3, 0.4];
 let payload = json!({"color": "red"});
 
 let edge_points: Vec<PointStructPersisted> = vec![
-    EdgePoint::new(
+    qdrant_edge::PointStruct::new(
         PointId::NumId(id),
         Vectors::new_named([(VECTOR_NAME, vector.clone())]),
         payload.clone(),
@@ -143,15 +147,17 @@ edge_shard.update(UpdateOperation::PointOperation(
     ),
 ))?;
 
-let server_point = PointStruct::new(
+let server_point = ::qdrant_client::qdrant::PointStruct::new(
     id,
     HashMap::from([(VECTOR_NAME.to_string(), vector)]),
     payload.as_object().cloned().unwrap_or_default(),
 );
 upload_queue.push_back(server_point);
 
+use ::qdrant_client::qdrant::*;
+
 const BATCH_SIZE: usize = 10;
-let points_to_upload: Vec<PointStruct> = upload_queue
+let points_to_upload: Vec<::qdrant_client::qdrant::PointStruct> = upload_queue
     .drain(..BATCH_SIZE.min(upload_queue.len()))
     .collect();
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/snapshot-url/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/snapshot-url/python.md
@@ -1,5 +1,0 @@
-```python
-COLLECTION_NAME="edge-collection"
-
-snapshot_url = f"{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
-```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/snapshot-url/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/snapshot-url/rust.md
@@ -1,7 +1,0 @@
-```rust
-const COLLECTION_NAME: &str = "edge-collection";
-
-let snapshot_url = format!(
-    "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
-);
-```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/update-from-snapshot/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/update-from-snapshot/rust.md
@@ -1,4 +1,7 @@
 ```rust
+use qdrant_edge::*;
+use qdrant_edge::internal::*;
+
 let current_manifest = edge_shard.snapshot_manifest()?;
 
 let update_url = format!(

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/upsert-point/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/generated/upsert-point/rust.md
@@ -1,10 +1,17 @@
 ```rust
+use std::collections::*;
+use serde_json::json;
+use qdrant_edge::{
+    PointInsertOperations, PointOperations,
+    PointStructPersisted, PointId, UpdateOperation, Vectors,
+};
+
 let id = 1u64;
 let vector = vec![0.1f32, 0.2, 0.3, 0.4];
 let payload = json!({"color": "red"});
 
 let edge_points: Vec<PointStructPersisted> = vec![
-    EdgePoint::new(
+    qdrant_edge::PointStruct::new(
         PointId::NumId(id),
         Vectors::new_named([(VECTOR_NAME, vector.clone())]),
         payload.clone(),
@@ -17,7 +24,7 @@ edge_shard.update(UpdateOperation::PointOperation(
     ),
 ))?;
 
-let server_point = PointStruct::new(
+let server_point = ::qdrant_client::qdrant::PointStruct::new(
     id,
     HashMap::from([(VECTOR_NAME.to_string(), vector)]),
     payload.as_object().cloned().unwrap_or_default(),

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/python.py
@@ -4,18 +4,16 @@ QDRANT_URL=""
 QDRANT_API_KEY=""
 # @hide-end
 
-# @block-start snapshot-url
-COLLECTION_NAME="edge-collection"
-
-snapshot_url = f"{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
-# @block-end snapshot-url
-
 # @block-start restore-snapshot
 from pathlib import Path
 from qdrant_edge import EdgeShard
 import requests
 import shutil
 import tempfile
+
+COLLECTION_NAME="edge-collection"
+
+snapshot_url = f"{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
 
 SHARD_DIRECTORY = "./qdrant-edge-directory"
 data_dir = Path(SHARD_DIRECTORY)

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
@@ -1,21 +1,4 @@
 // @block-start restore-snapshot
-use std::collections::HashMap;
-use std::path::Path;
-
-use qdrant_client::qdrant::{
-    CreateCollectionBuilder, Distance, PointStruct, UpsertPointsBuilder,
-    VectorParamsBuilder,
-};
-use qdrant_client::Qdrant;
-use qdrant_edge::EdgeShard;
-use qdrant_edge::internal::SnapshotManifest;
-use qdrant_edge::{
-    EdgeConfigBuilder, EdgeVectorParamsBuilder, PointId, PointInsertOperations,
-    PointOperations, PointStruct as EdgePoint, PointStructPersisted,
-    UpdateOperation, Vectors,
-};
-use serde_json::json;
-
 pub async fn main() -> anyhow::Result<()> {
     // @hide-start
     const QDRANT_URL: &str = "";
@@ -23,12 +6,15 @@ pub async fn main() -> anyhow::Result<()> {
     // @hide-end
 
     const COLLECTION_NAME: &str = "edge-collection";
+    const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
+
+    use std::path::*;
+    use qdrant_edge::*;
 
     let snapshot_url = format!(
         "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
     );
 
-    const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
     let data_dir = Path::new(SHARD_DIRECTORY);
 
     let restore_dir = tempfile::Builder::new()
@@ -57,6 +43,9 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end restore-snapshot
 
     // @block-start update-from-snapshot
+    use qdrant_edge::*;
+    use qdrant_edge::internal::*;
+
     let current_manifest = edge_shard.snapshot_manifest()?;
 
     let update_url = format!(
@@ -94,6 +83,9 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end update-from-snapshot
 
     // @block-start initialize-edge-shard
+    use std::path::*;
+    use qdrant_edge::*;
+
     const VECTOR_DIMENSION: usize = 4;
     const VECTOR_NAME: &str = "my-vector";
 
@@ -115,6 +107,10 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end initialize-edge-shard
 
     // @block-start initialize-server-client
+    use ::qdrant_client::*;
+    use ::qdrant_client::qdrant::*;
+    use ::qdrant_client::qdrant::Distance;
+
     let server_client = Qdrant::from_url(QDRANT_URL)
         .api_key(QDRANT_API_KEY)
         .build()?;
@@ -134,19 +130,27 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end initialize-server-client
 
     // @block-start create-upload-queue
+    use std::collections::*;
+
     // This is an in-memory queue.
     // For production use cases consider persisting changes.
-    let mut upload_queue: std::collections::VecDeque<PointStruct> =
-        std::collections::VecDeque::new();
+    let mut upload_queue: VecDeque<::qdrant_client::qdrant::PointStruct> = VecDeque::new();
     // @block-end create-upload-queue
 
     // @block-start upsert-point
+    use std::collections::*;
+    use serde_json::json;
+    use qdrant_edge::{
+        PointInsertOperations, PointOperations,
+        PointStructPersisted, PointId, UpdateOperation, Vectors,
+    };
+
     let id = 1u64;
     let vector = vec![0.1f32, 0.2, 0.3, 0.4];
     let payload = json!({"color": "red"});
 
     let edge_points: Vec<PointStructPersisted> = vec![
-        EdgePoint::new(
+        qdrant_edge::PointStruct::new(
             PointId::NumId(id),
             Vectors::new_named([(VECTOR_NAME, vector.clone())]),
             payload.clone(),
@@ -159,7 +163,7 @@ pub async fn main() -> anyhow::Result<()> {
         ),
     ))?;
 
-    let server_point = PointStruct::new(
+    let server_point = ::qdrant_client::qdrant::PointStruct::new(
         id,
         HashMap::from([(VECTOR_NAME.to_string(), vector)]),
         payload.as_object().cloned().unwrap_or_default(),
@@ -168,8 +172,10 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-end upsert-point
 
     // @block-start process-upload-queue
+    use ::qdrant_client::qdrant::*;
+
     const BATCH_SIZE: usize = 10;
-    let points_to_upload: Vec<PointStruct> = upload_queue
+    let points_to_upload: Vec<::qdrant_client::qdrant::PointStruct> = upload_queue
         .drain(..BATCH_SIZE.min(upload_queue.len()))
         .collect();
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-patterns/rust.rs
@@ -1,3 +1,4 @@
+// @block-start restore-snapshot
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -21,15 +22,12 @@ pub async fn main() -> anyhow::Result<()> {
     const QDRANT_API_KEY: &str = "";
     // @hide-end
 
-    // @block-start snapshot-url
     const COLLECTION_NAME: &str = "edge-collection";
 
     let snapshot_url = format!(
         "{QDRANT_URL}/collections/{COLLECTION_NAME}/shards/0/snapshot"
     );
-    // @block-end snapshot-url
 
-    // @block-start restore-snapshot
     const SHARD_DIRECTORY: &str = "./qdrant-edge-directory";
     let data_dir = Path::new(SHARD_DIRECTORY);
 


### PR DESCRIPTION
[Preview](https://deploy-preview-2437--condescending-goldwasser-91acf0.netlify.app/documentation/edge/edge-quickstart/)

Closes https://github.com/qdrant/landing_page/issues/2436

Adds `use` statements for the Edge Rust snippets.

This required a change in the regex that checks whether a code snippet is correctly formatted (https://github.com/qdrant/landing_page/commit/79c30d690d5323912fbd158335efc30cb8a246db): Rust code snippets are now also allowed start with a comment line.

I also changed the "Data Synchronization Patterns" guide flow slightly, so it doesn't start with a small trivial code snippet with a huge set of `use`s.