### PR TITLE
Revert jsconfig.json edit

### DIFF
--- a/qdrant-landing/assets/jsconfig.json
+++ b/qdrant-landing/assets/jsconfig.json
@@ -1,5 +1,6 @@
 {
  "compilerOptions": {
+  "baseUrl": ".",
   "paths": {
    "*": [
     "../themes/qdrant-2024/assets/*"


### PR DESCRIPTION
https://github.com/qdrant/landing_page/commit/fe826d1ca6815f2dbc1ed410303b708896bcb7db (https://github.com/qdrant/landing_page/pull/2416) has edited the `qdrant-landing/assets/jsconfig.json` file. The line that was removed should be there for the file to be valid, and the change causes VS Code to automatically add it, when making unrelated changes in this repo.

Assuming the edit was accidental, this PR reverts the change.