### PR TITLE
Add resilience framing and AZ clarification to distributed deployment docs

### DIFF
--- a/qdrant-landing/content/documentation/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/distributed_deployment.md
@@ -652,6 +652,14 @@ This code sample creates a collection with a total of 6 logical shards backed by
 
 Since a replication factor of "2" would require twice as much storage space, it is advised to make sure the hardware can host the additional shard replicas beforehand.
 
+### Nodes and availability zones
+
+Replication distributes shard copies across nodes, but does not control which availability zones those nodes are placed in. Replication factor and zone placement are independent properties.
+
+Without explicit zone-aware placement, all nodes in a cluster can be co-located in the same availability zone. A zone-level outage would then take down the entire cluster even with replication enabled.
+
+For Qdrant Cloud, zone distribution requires enabling **Multi-AZ** at cluster creation time. Refer to [Creating a Production-Ready Cluster](/documentation/cloud/create-cluster/#creating-a-production-ready-cluster) for details. Note that this option can only be selected during cluster creation and cannot be changed later.
+
 ### Creating new shard replicas
 
 It is possible to create or delete replicas manually on an existing collection using the [Update collection cluster setup API](https://api.qdrant.tech/master/api-reference/distributed/update-collection-cluster). This is usually only necessary if you run Qdrant open-source. In Qdrant Cloud shard replication is handled and updated automatically, matching the configured `replication_factor`.

--- a/qdrant-landing/content/documentation/distributed_deployment.md
+++ b/qdrant-landing/content/documentation/distributed_deployment.md
@@ -15,6 +15,16 @@ aliases:
 Since version v0.8.0 Qdrant supports a distributed deployment mode.
 In this mode, multiple Qdrant services communicate with each other to distribute the data across the peers to extend the storage capabilities and increase stability.
 
+## Resilience
+
+Resilience in Qdrant is determined by two parameters: replication factor and node count. Together, they provide:
+
+- **Data durability**: A `replication_factor` of 2 or more keeps copies of every shard on multiple nodes. If a node is permanently lost, your data survives as long as at least one replica remains intact.
+- **Continued serving during outages**: A 3+ node cluster with all shards replicated to at least 2 nodes keeps all requests (reads, writes, and collection operations) running when one node is down. A 2-node cluster with full replication keeps reads and writes running, but collection operations (create, edit, delete) require a node majority and will be unavailable.
+- **Permanent node loss recovery**: Recovering from the permanent loss of a node goes through [Raft](#raft), which requires more than 50% of nodes to be healthy. This means 3+ node clusters can recover from a single permanent node loss; 2-node clusters cannot.
+
+These properties are not independent systems; they are consequences of the same two settings. Set `replication_factor` ≥ 2 on your collections and run ≥ 3 nodes, and your cluster is resilient on all three dimensions.
+
 ## How many Qdrant nodes should I run?
 
 The ideal number of Qdrant nodes depends on how much you value cost-saving, resilience, and performance/scalability in relation to each other.


### PR DESCRIPTION
## Overview

### [Preview](https://deploy-preview-2448--condescending-goldwasser-91acf0.netlify.app/documentation/distributed_deployment/)

This PR:
* Adds a new `Resilience` section near the top of the distributed deployment page. It names replication factor and node count as the two levers behind all resilience properties and consolidates their consequences in one place, so users have a conceptual map.
* Adds a new `Nodes and availability zones` subsection under `Replication`. States that replication distributes shard copies across nodes, not across availability zones, and that replication factor and zone placement are independent properties. Cross-links to the Multi-AZ guidance in the create-cluster page for Qdrant Cloud users.