### PR TITLE
docs: Remove redundant section from /documentation/embeddings/_index.md

### DIFF
--- a/qdrant-landing/content/documentation/embeddings/_index.md
+++ b/qdrant-landing/content/documentation/embeddings/_index.md
@@ -10,12 +10,6 @@ partition: ecosystem
 
 Qdrant supports all available text and multimodal dense vector embedding models as well as vector embedding services without any limitations.
 
-## Some of the Embeddings you can use with Qdrant
-
-SentenceTransformers, BERT, SBERT, Clip, OpenClip, Open AI, Vertex AI, Azure AI, AWS Bedrock, Jina AI, Upstage AI, Mistral AI, Cohere AI, Voyage AI, Aleph Alpha, Baidu Qianfan, BGE, Instruct, Watsonx Embeddings, Snowflake Embeddings, NVIDIA NeMo, Nomic, OCI Embeddings, Ollama Embeddings, MixedBread, Together AI, Clarifai, Databricks Embeddings, GPT4All Embeddings, John Snow Labs Embeddings.
-
-Additionally, [any open-source embeddings from HuggingFace](https://huggingface.co/spaces/mteb/leaderboard) can be used with Qdrant.
-
 ## Code samples
 
 | Embeddings Providers                                  | Description                                                      |


### PR DESCRIPTION
Resolves https://github.com/qdrant/documentation/issues/63

The section this PR removes is redundant since there's a more elaborate table with similar info below it.

Also, we don't mention Vertex Embeddings anywhere else. It's Gemini Embeddings.