### PR TITLE
docs(embeddings): use current query_points API in OpenAI example

### DIFF
--- a/qdrant-landing/content/documentation/embeddings/openai.md
+++ b/qdrant-landing/content/documentation/embeddings/openai.md
@@ -80,9 +80,9 @@ client.upsert(collection_name, points)
 Once the documents are indexed, you can search for the most relevant documents using the same model.
 
 ```python
-client.search(
+client.query_points(
     collection_name=collection_name,
-    query_vector=openai_client.embeddings.create(
+    query=openai_client.embeddings.create(
         input=["What is the best to use for vector search scaling?"],
         model=embedding_model,
     )


### PR DESCRIPTION
## What

The **Searching for documents with Qdrant** example on `embeddings/openai.md` uses `client.search(..., query_vector=...)`, which is deprecated in recent `qdrant-client` releases in favor of `client.query_points(..., query=...)`. This PR updates that single example to the current API.

```diff
-client.search(
+client.query_points(
     collection_name=collection_name,
-    query_vector=openai_client.embeddings.create(
+    query=openai_client.embeddings.create(
```

## Why

- `query_points` is the supported replacement for `search`; no behavior change.
- **Consistency:** the sibling embedding page `embeddings/cohere.md` already uses `client.query_points(...)`, so this brings the OpenAI page in line with the rest of the section.

Verified against the current file on `master`.