### PR TITLE
Fix `ServiceMonitor` resource config for Prometheus

### DIFF
--- a/qdrant-landing/content/documentation/ops-monitoring/hybrid-cloud-prometheus.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/hybrid-cloud-prometheus.md
@@ -47,7 +47,7 @@ metadata:
 spec:
   endpoints:
   - honorLabels: true
-    interval: 30s
+    interval: 60s
     port: metrics
     scheme: http
     scrapeTimeout: 55s

--- a/qdrant-landing/content/documentation/ops-monitoring/hybrid-cloud-prometheus.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/hybrid-cloud-prometheus.md
@@ -70,7 +70,7 @@ metadata:
 spec:
   endpoints:
   - honorLabels: true
-    interval: 30s
+    interval: 60s
     port: metrics
     scheme: http
     scrapeTimeout: 55s

--- a/qdrant-landing/content/documentation/ops-monitoring/managed-cloud-prometheus.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/managed-cloud-prometheus.md
@@ -55,7 +55,7 @@ metadata:
     release: prometheus
 spec:
   metricsPath: /sys_metrics
-  scrapeInterval: 30s
+  scrapeInterval: 60s
   scheme: HTTPS
   authorization:
     type: Bearer


### PR DESCRIPTION
## Overview

### [Preview](https://deploy-preview-2457--condescending-goldwasser-91acf0.netlify.app/documentation/ops-monitoring/hybrid-cloud-prometheus/)

This PR increases the `interval` param of the `ServiceMonitor` config from `30s` to `60s`, so `scrapeTimeout` (55s) is less than the `interval` which is required by Prometheus.