### PR TITLE
feat: added Capacity Planner page for Qdrant sizing tool

### DIFF
--- a/qdrant-landing/assets/jsconfig.json
+++ b/qdrant-landing/assets/jsconfig.json
@@ -1,6 +1,5 @@
 {
  "compilerOptions": {
-  "baseUrl": ".",
   "paths": {
    "*": [
     "../themes/qdrant-2024/assets/*"

--- a/qdrant-landing/content/capacity-planner/_index.md
+++ b/qdrant-landing/content/capacity-planner/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Qdrant Capacity Planner - Estimate Memory, Storage & CPU"
+description: "Interactive sizing calculator for Qdrant. Estimate the RAM, disk storage, and CPU your deployment needs based on vector count, dimensions, payload, quantization, and HNSW configuration."
+keywords:
+  - qdrant sizing
+  - capacity planning
+  - vector database memory estimation
+  - hnsw memory
+  - quantization
+build:
+  render: always
+hero:
+  label: Tools
+  title: Capacity Planner
+  description: "Estimate the resources your Qdrant deployment needs. Enter your collection parameters and instantly see how much memory, storage, and CPU are required — including the impact of quantization, on-disk storage, and HNSW configuration."
+---

--- a/qdrant-landing/content/headless/menu.md
+++ b/qdrant-landing/content/headless/menu.md
@@ -102,6 +102,10 @@ menuItems:
             name: Documentation
             icon: documentation.svg
             url: /documentation/
+          - id: subMenu-2-6
+            name: Capacity Planner
+            icon: capacity-planner.svg
+            url: /capacity-planner/
           - id: subMenu-2-1
             name: Community
             icon: community.svg

--- a/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
@@ -87,3 +87,4 @@
 @import 'partials/vsd-recap/index';
 @import 'partials/vsd/vsd-agenda';
 @import 'partials/agenda';
+@import 'partials/capacity-planner/index';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/capacity-planner/_index.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/capacity-planner/_index.scss
@@ -1,0 +1,714 @@
+@use '../../helpers/functions' as *;
+
+.capacity-planner-hero {
+  position: relative;
+  overflow: hidden;
+  padding: $spacer * 6 0 $spacer * 4;
+  background-color: $neutral-10;
+  color: $neutral-98;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(60% 120% at 15% 0%, rgba($secondary-violet-50, 0.25) 0%, rgba($secondary-violet-50, 0) 60%),
+      radial-gradient(50% 120% at 90% 10%, rgba($secondary-blue-50, 0.22) 0%, rgba($secondary-blue-50, 0) 55%);
+  }
+
+  > .container {
+    position: relative;
+    z-index: 1;
+  }
+
+  &__label {
+    display: inline-block;
+    margin-bottom: $spacer;
+    font-family: $font-family-monospace;
+    font-size: $font-size-s;
+    font-weight: 500;
+    letter-spacing: pxToRem(2);
+    text-transform: uppercase;
+    color: $secondary-blue-70;
+  }
+
+  &__title {
+    margin: 0 0 $spacer * 1.5;
+    font-size: $h2-font-size;
+    font-weight: 600;
+    line-height: 1.1;
+    letter-spacing: -0.5px;
+  }
+
+  &__description {
+    max-width: pxToRem(720);
+    margin: 0;
+    font-size: $font-size-l;
+    line-height: 1.5;
+    color: $neutral-80;
+  }
+
+  @include media-breakpoint-down(lg) {
+    padding: $spacer * 4 0 $spacer * 3;
+
+    &__title {
+      font-size: $h4-font-size;
+    }
+
+    &__description {
+      font-size: $font-size-md;
+    }
+  }
+}
+
+.capacity-planner {
+  padding: $spacer * 4 0 $spacer * 6;
+  background-color: $neutral-98;
+
+  &__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) pxToRem(380);
+    gap: $spacer * 2;
+    align-items: start;
+  }
+
+  &__inputs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: $spacer * 1.5;
+  }
+
+  &__results {
+    position: sticky;
+    top: $spacer * 5;
+  }
+
+  @include media-breakpoint-down(xl) {
+    &__layout {
+      grid-template-columns: minmax(0, 1fr) pxToRem(340);
+    }
+  }
+
+  @include media-breakpoint-down(lg) {
+    padding: $spacer * 2.5 0 $spacer * 4;
+
+    &__layout {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    &__results {
+      position: static;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    &__inputs {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+}
+
+// ---------------- Input groups ----------------
+
+.cp-group {
+  margin: 0;
+  padding: $spacer * 1.5;
+  border: pxToRem(1) solid $neutral-90;
+  border-radius: $spacer;
+  background-color: $neutral-100;
+
+  // Full-width groups span both columns for a balanced grid.
+  &:nth-of-type(1),
+  &:nth-of-type(2) {
+    grid-column: 1 / -1;
+  }
+
+  &__title {
+    float: none;
+    width: auto;
+    margin: 0 0 $spacer * 1.25;
+    padding: 0;
+    font-family: $font-family-monospace;
+    font-size: $font-size-xs;
+    font-weight: 600;
+    letter-spacing: pxToRem(1.5);
+    text-transform: uppercase;
+    color: $neutral-50;
+  }
+}
+
+.cp-field {
+  & + & {
+    margin-top: $spacer * 1.25;
+  }
+
+  &__label {
+    display: block;
+    margin-bottom: $spacer * 0.5;
+    font-size: $font-size-s;
+    font-weight: 500;
+    color: $neutral-30;
+
+    &--slider {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+  }
+
+  &__value {
+    font-family: $font-family-monospace;
+    font-size: $font-size-s;
+    font-weight: 600;
+    color: $primary-50;
+  }
+
+  &__hint {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: pxToRem(16);
+    height: pxToRem(16);
+    margin-left: pxToRem(4);
+    border-radius: 50%;
+    background-color: $neutral-94;
+    color: $neutral-50;
+    font-size: pxToRem(10);
+    font-weight: 700;
+    cursor: help;
+    vertical-align: middle;
+  }
+
+  &__input {
+    color: $neutral-20;
+  }
+
+  &__combo {
+    display: flex;
+    gap: $spacer * 0.5;
+  }
+
+  &__unit {
+    width: pxToRem(84);
+    flex-shrink: 0;
+  }
+
+  &--switch {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacer;
+
+    .cp-field__label {
+      margin-bottom: 0;
+    }
+  }
+}
+
+// Full-width groups arrange their fields in a responsive multi-column grid
+// so the extra horizontal space is used well.
+.cp-group--grid {
+  @include media-breakpoint-up(sm) {
+    display: grid;
+    align-items: end;
+    grid-template-columns: repeat(var(--cp-cols, 2), minmax(0, 1fr));
+    gap: $spacer * 1.25 $spacer;
+
+    .cp-group__title {
+      grid-column: 1 / -1;
+      margin-bottom: 0;
+    }
+
+    .cp-field + .cp-field {
+      margin-top: 0;
+    }
+
+    // Wide controls read better spanning the full width.
+    .cp-field--span {
+      grid-column: 1 / -1;
+    }
+  }
+}
+
+select.q-input {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.33203 4.66666L7.9987 11.3333L14.6654 4.66666' stroke='%23576280' stroke-width='1.33333' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right pxToRem(10) center;
+  padding-right: $spacer * 2;
+}
+
+// ---------------- Segmented control ----------------
+
+.cp-segmented {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: pxToRem(4);
+  padding: pxToRem(4);
+  border: pxToRem(1) solid $neutral-90;
+  border-radius: $spacer * 0.5;
+  background-color: $neutral-98;
+
+  &__option {
+    margin: 0;
+    cursor: pointer;
+
+    input {
+      position: absolute;
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: pxToRem(6) pxToRem(12);
+      border-radius: pxToRem(6);
+      font-size: $font-size-s;
+      font-weight: 500;
+      color: $neutral-50;
+      white-space: nowrap;
+      transition:
+        background-color 0.15s ease,
+        color 0.15s ease;
+    }
+
+    input:checked + span {
+      background-color: $neutral-20;
+      color: $neutral-100;
+    }
+
+    input:focus-visible + span {
+      box-shadow: 0 0 0 2px rgba($secondary-blue-50, 0.4);
+    }
+
+    &:hover span {
+      color: $neutral-20;
+    }
+  }
+}
+
+// ---------------- Switch ----------------
+
+.cp-switch {
+  position: relative;
+  flex-shrink: 0;
+  width: pxToRem(40);
+  height: pxToRem(22);
+  margin: 0;
+  cursor: pointer;
+
+  input {
+    position: absolute;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    cursor: pointer;
+  }
+
+  &__track {
+    position: absolute;
+    inset: 0;
+    border-radius: pxToRem(22);
+    background-color: $neutral-90;
+    transition: background-color 0.15s ease;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: pxToRem(2);
+      left: pxToRem(2);
+      width: pxToRem(18);
+      height: pxToRem(18);
+      border-radius: 50%;
+      background-color: $neutral-100;
+      box-shadow: 0 1px 2px rgba($neutral-10, 0.25);
+      transition: transform 0.15s ease;
+    }
+  }
+
+  input:checked + &__track {
+    background-color: $primary-50;
+
+    &::after {
+      transform: translateX(pxToRem(18));
+    }
+  }
+
+  input:focus-visible + &__track {
+    box-shadow: 0 0 0 2px rgba($primary-50, 0.35);
+  }
+}
+
+// ---------------- Slider ----------------
+
+.cp-slider {
+  width: 100%;
+  height: pxToRem(4);
+  margin: pxToRem(8) 0;
+  appearance: none;
+  border-radius: pxToRem(4);
+  background-color: $neutral-90;
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    appearance: none;
+    width: pxToRem(18);
+    height: pxToRem(18);
+    border: none;
+    border-radius: 50%;
+    background-color: $primary-50;
+    box-shadow: 0 1px 3px rgba($neutral-10, 0.3);
+    cursor: pointer;
+  }
+
+  &::-moz-range-thumb {
+    width: pxToRem(18);
+    height: pxToRem(18);
+    border: none;
+    border-radius: 50%;
+    background-color: $primary-50;
+    cursor: pointer;
+  }
+}
+
+.cp-reset {
+  grid-column: 1 / -1;
+  justify-self: start;
+  color: $neutral-30;
+}
+
+// ---------------- Effect notes ----------------
+
+.cp-effect {
+  margin-top: $spacer * 0.5;
+  padding: $spacer;
+  border-radius: $spacer * 0.75;
+  background-color: $neutral-98;
+  border: pxToRem(1) solid $neutral-90;
+  border-left: pxToRem(3) solid $secondary-blue-50;
+
+  &[data-mode='binary'] {
+    border-left-color: $secondary-teal-50;
+  }
+  &[data-mode='product'] {
+    border-left-color: $secondary-violet-50;
+  }
+  &[data-mode='none'] {
+    border-left-color: $neutral-60;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: $spacer * 0.5;
+    margin: 0 0 $spacer * 0.75;
+    font-size: $font-size-s;
+    font-weight: 600;
+    color: $neutral-20;
+  }
+
+  &__badge {
+    padding: pxToRem(2) pxToRem(8);
+    border-radius: pxToRem(20);
+    background-color: $secondary-blue-90;
+    color: $secondary-blue-30;
+    font-family: $font-family-monospace;
+    font-size: $font-size-xs;
+    font-weight: 600;
+  }
+
+  &__list {
+    display: grid;
+    gap: $spacer * 0.5;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      display: grid;
+      grid-template-columns: pxToRem(72) 1fr;
+      gap: $spacer * 0.5;
+      font-size: $font-size-s;
+      line-height: 1.4;
+      color: $neutral-40;
+    }
+  }
+
+  &__key {
+    font-weight: 600;
+    color: $neutral-50;
+  }
+
+  &__note {
+    margin: $spacer * 0.75 0 0;
+    font-size: $font-size-s;
+    line-height: 1.5;
+    color: $neutral-50;
+  }
+}
+
+// ---------------- Results ----------------
+
+.capacity-planner__results-inner {
+  padding: $spacer * 1.5;
+  border-radius: $spacer;
+  background-color: $neutral-10;
+  color: $neutral-98;
+}
+
+.cp-results {
+  &__title {
+    margin: 0;
+    font-size: $font-size-xl;
+    font-weight: 600;
+  }
+
+  &__subtitle {
+    margin: pxToRem(2) 0 $spacer * 1.5;
+    font-size: $font-size-s;
+    color: $neutral-70;
+  }
+
+  &__cta {
+    margin-top: $spacer * 1.5;
+
+    .button {
+      width: 100%;
+    }
+  }
+}
+
+.cp-summary {
+  display: flex;
+  flex-direction: column;
+  gap: $spacer * 0.75;
+
+  &__card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacer;
+    padding: $spacer $spacer * 1.25;
+    border-radius: $spacer * 0.75;
+    background-color: $neutral-20;
+    border-left: pxToRem(3) solid $neutral-40;
+
+    &--ram {
+      border-left-color: $secondary-blue-50;
+    }
+    &--storage {
+      border-left-color: $secondary-teal-50;
+    }
+    &--cpu {
+      border-left-color: $secondary-violet-50;
+    }
+  }
+
+  &__head {
+    display: flex;
+    flex-direction: column;
+    gap: pxToRem(2);
+    min-width: 0;
+  }
+
+  &__label {
+    font-size: $font-size-s;
+    font-weight: 500;
+    color: $neutral-90;
+  }
+
+  &__value {
+    flex-shrink: 0;
+    font-family: $font-family-monospace;
+    font-size: $h6-font-size;
+    font-weight: 600;
+    line-height: 1.1;
+    color: $neutral-100;
+    white-space: nowrap;
+    text-align: right;
+  }
+
+  &__note {
+    font-size: pxToRem(11);
+    color: $neutral-60;
+  }
+
+  // On the full-width results panel (stacked mobile layout) show cards
+  // side-by-side to use the extra horizontal space.
+  @include media-breakpoint-down(lg) {
+    flex-direction: row;
+
+    &__card {
+      flex: 1 1 0;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: flex-start;
+      gap: pxToRem(6);
+      border-left: none;
+      border-top: pxToRem(3) solid $neutral-40;
+
+      &--ram {
+        border-top-color: $secondary-blue-50;
+      }
+      &--storage {
+        border-top-color: $secondary-teal-50;
+      }
+      &--cpu {
+        border-top-color: $secondary-violet-50;
+      }
+    }
+
+    &__value {
+      font-size: $font-size-xl;
+      text-align: left;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    flex-direction: column;
+
+    &__card {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    &__value {
+      text-align: right;
+    }
+  }
+}
+
+.cp-breakdown {
+  margin-top: $spacer * 1.5;
+
+  &__title {
+    margin: 0 0 $spacer * 0.5;
+    font-size: $font-size-s;
+    font-weight: 600;
+    color: $neutral-80;
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: $font-size-s;
+
+    th,
+    td {
+      padding: pxToRem(8) pxToRem(4);
+      text-align: right;
+      border-bottom: pxToRem(1) solid $neutral-30;
+    }
+
+    th:first-child,
+    td:first-child {
+      text-align: left;
+    }
+
+    th {
+      font-size: $font-size-xs;
+      font-weight: 500;
+      color: $neutral-60;
+      text-transform: uppercase;
+      letter-spacing: pxToRem(0.5);
+    }
+
+    td {
+      color: $neutral-90;
+    }
+
+    td:not(:first-child) {
+      font-family: $font-family-monospace;
+    }
+
+    tr:last-child td {
+      border-bottom: none;
+    }
+  }
+
+  &__row--muted td {
+    color: $neutral-50;
+  }
+}
+
+.cp-advisories {
+  margin-top: $spacer * 1.5;
+
+  &__title {
+    margin: 0 0 $spacer * 0.75;
+    font-size: $font-size-s;
+    font-weight: 600;
+    color: $neutral-80;
+  }
+}
+
+.cp-advisory {
+  display: flex;
+  gap: $spacer * 0.75;
+  padding: $spacer * 0.75 $spacer;
+  border-radius: $spacer * 0.5;
+  background-color: $neutral-20;
+  font-size: $font-size-s;
+  line-height: 1.45;
+  color: $neutral-90;
+
+  & + & {
+    margin-top: $spacer * 0.5;
+  }
+
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: pxToRem(18);
+    height: pxToRem(18);
+    margin-top: pxToRem(1);
+    border-radius: 50%;
+    font-size: pxToRem(11);
+    font-weight: 700;
+    font-family: $font-family-monospace;
+    text-transform: lowercase;
+    color: $neutral-100;
+  }
+
+  &--tip {
+    border-left: pxToRem(3) solid $secondary-blue-50;
+
+    .cp-advisory__icon {
+      background-color: $secondary-blue-50;
+    }
+  }
+
+  &--warn {
+    border-left: pxToRem(3) solid $warning-50;
+
+    .cp-advisory__icon {
+      background-color: $warning-50;
+    }
+  }
+
+  code {
+    font-family: $font-family-monospace;
+    font-size: $font-size-xs;
+    color: $secondary-blue-70;
+  }
+}
+
+.cp-disclaimer {
+  margin: $spacer * 1.5 0 0;
+  font-size: $font-size-xs;
+  line-height: 1.5;
+  color: $neutral-70;
+
+  .link {
+    color: $secondary-blue-70;
+  }
+}

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/capacity-planner/_index.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/capacity-planner/_index.scss
@@ -166,6 +166,7 @@
   }
 
   &__hint {
+    position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -179,6 +180,62 @@
     font-weight: 700;
     cursor: help;
     vertical-align: middle;
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    // Tooltip bubble + arrow, shown on hover.
+    &::after,
+    &::before {
+      position: absolute;
+      left: 50%;
+      opacity: 0;
+      visibility: hidden;
+      transform: translate(-50%, pxToRem(4));
+      transition:
+        opacity 0.15s ease,
+        transform 0.15s ease;
+      pointer-events: none;
+      z-index: 20;
+    }
+
+    &::after {
+      content: attr(data-tip);
+      bottom: calc(100% + #{pxToRem(9)});
+      width: max-content;
+      max-width: pxToRem(230);
+      padding: pxToRem(9) pxToRem(11);
+      border-radius: pxToRem(8);
+      background-color: $neutral-10;
+      color: $neutral-98;
+      font-size: $font-size-xs;
+      font-weight: 400;
+      line-height: 1.45;
+      letter-spacing: 0;
+      text-align: left;
+      white-space: normal;
+      box-shadow: 0 pxToRem(8) pxToRem(24) rgba($neutral-10, 0.28);
+    }
+
+    &::before {
+      content: '';
+      bottom: calc(100% + #{pxToRem(4)});
+      width: 0;
+      height: 0;
+      border-left: pxToRem(5) solid transparent;
+      border-right: pxToRem(5) solid transparent;
+      border-top: pxToRem(5) solid $neutral-10;
+    }
+
+    &:hover {
+      background-color: $primary-50;
+      color: $neutral-100;
+
+      &::after,
+      &::before {
+        opacity: 1;
+        visibility: visible;
+        transform: translate(-50%, 0);
+      }
+    }
   }
 
   &__input {

--- a/qdrant-landing/themes/qdrant-2024/assets/js/capacity-planner.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/capacity-planner.js
@@ -1,0 +1,421 @@
+// Qdrant Capacity Planner
+// Estimates RAM, disk storage and CPU for a Qdrant deployment.
+// Formulas are based on Qdrant internals documented at
+// https://qdrant.tech/documentation/tutorials-operations/large-scale-search/
+
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.getElementById('capacity-planner');
+  if (!form) return;
+
+  const GiB = 1024 * 1024 * 1024;
+  const LINK_BYTES = 4; // each HNSW connection is a 4-byte integer
+  const STORAGE_OVERHEAD = 1.5; // segment copies, WAL, optimization headroom
+  const RAM_HEADROOM = 1.2; // leave ~15-20% headroom on top of resident data
+  const RAM_BASE_GIB = 0.5; // baseline process/system footprint
+
+  // Per-point cost of the IdTracker (id <-> internal id + version mapping).
+  const ID_OVERHEAD = {
+    integer: 24, // version(4) + internal_to_external(8) + external_to_internal(12)
+    uuid: 40, // version(4) + internal_to_external(16) + external_to_internal(20)
+  };
+
+  // Rough per-point cost of a single payload index (keyword/integer field).
+  const PAYLOAD_INDEX_BYTES_PER_FIELD = 16;
+
+  // Qualitative effects of each quantization mode (memory factor is computed live).
+  const QUANT_INFO = {
+    none: {
+      name: 'No quantization',
+      recall: 'Exact scoring — no recall loss.',
+      speed: 'Baseline. Highest memory bandwidth per query.',
+      best: 'Small collections, or when full precision is required.',
+    },
+    scalar: {
+      name: 'Scalar (int8) quantization',
+      recall: 'Minimal loss — typically ~99% recall retained.',
+      speed: 'Faster: ~4× less data to scan, optional rescoring.',
+      best: 'A safe general-purpose default for most embeddings.',
+    },
+    binary: {
+      name: 'Binary quantization',
+      recall: 'Larger loss on its own — recover with oversampling + rescoring.',
+      speed: 'Fastest: Hamming distance on bit-packed vectors.',
+      best: 'High-dimensional (≥1024d) normalized embeddings (OpenAI, Cohere, etc.).',
+    },
+    product: {
+      name: 'Product quantization',
+      recall: 'Highest loss — always rescore with the original vectors.',
+      speed: 'Fast and very memory-efficient; rescoring adds disk reads.',
+      best: 'Maximum compression when RAM is the primary constraint.',
+    },
+  };
+
+  const el = (id) => document.getElementById(id);
+  const num = (id, fallback = 0) => {
+    const v = parseFloat(el(id).value);
+    return Number.isFinite(v) && v >= 0 ? v : fallback;
+  };
+  const radio = (name) => {
+    const checked = form.querySelector(`input[name="${name}"]:checked`);
+    return checked ? checked.value : null;
+  };
+
+  function formatBytes(bytes) {
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    let i = 0;
+    let value = bytes;
+    while (value >= 1024 && i < units.length - 1) {
+      value /= 1024;
+      i += 1;
+    }
+    const decimals = value >= 100 || i <= 1 ? 0 : value >= 10 ? 1 : 2;
+    return `${value.toFixed(decimals)} ${units[i]}`;
+  }
+
+  function readInputs() {
+    return {
+      vectors: num('cp-vectors'),
+      dims: num('cp-dimensions', 1),
+      vectorsPerPoint: Math.max(1, num('cp-vectors-per-point', 1)),
+      datatypeBytes: parseFloat(radio('cp-datatype')) || 4,
+      vectorsOnDisk: el('cp-vectors-on-disk').checked,
+      quantization: radio('cp-quantization') || 'none',
+      pqRatio: parseFloat(el('cp-pq-ratio').value) || 16,
+      quantInRam: el('cp-quant-ram').checked,
+      hnswM: num('cp-hnsw-m', 16),
+      hnswOnDisk: el('cp-hnsw-on-disk').checked,
+      tenantIndex: el('cp-tenant-index').checked,
+      payloadM: num('cp-payload-m', 16),
+      sparse: el('cp-sparse').checked,
+      sparseNnz: Math.max(1, num('cp-sparse-nnz', 100)),
+      sparseOnDisk: el('cp-sparse-on-disk').checked,
+      fusion: radio('cp-fusion') || 'rrf',
+      payloadBytes: num('cp-payload') * (parseFloat(el('cp-payload-unit').value) || 1),
+      payloadInRam: !el('cp-payload-on-disk').checked,
+      payloadIndexFields: Math.round(num('cp-payload-index-fields')),
+      idType: radio('cp-id-type') || 'integer',
+      replicas: Math.max(1, Math.round(num('cp-replicas', 1))),
+      shards: Math.max(1, Math.round(num('cp-shards', 1))),
+      walMb: parseFloat(el('cp-wal-capacity').value) || 32,
+      qps: num('cp-qps'),
+    };
+  }
+
+  function estimate(cfg) {
+    const n = cfg.vectors;
+    const vectorCount = n * cfg.vectorsPerPoint;
+
+    // Raw (full-precision) vectors — always persisted on disk.
+    const rawVectors = vectorCount * cfg.dims * cfg.datatypeBytes;
+
+    // Quantized vectors (a compressed copy alongside the originals).
+    let quantized = 0;
+    if (cfg.quantization === 'scalar') {
+      quantized = vectorCount * cfg.dims * 1; // int8: 1 byte / dimension
+    } else if (cfg.quantization === 'binary') {
+      quantized = vectorCount * cfg.dims * 0.125; // 1 bit / dimension
+    } else if (cfg.quantization === 'product') {
+      quantized = (vectorCount * cfg.dims * 4) / cfg.pqRatio; // relative to float32
+    }
+    const hasQuant = cfg.quantization !== 'none';
+
+    // HNSW graph: level 0 has 2*m links, each a 4-byte integer.
+    const hnsw = vectorCount * cfg.hnswM * 2 * LINK_BYTES;
+
+    // Tenant payload index (payload_m): extra in-graph links for filtered search.
+    const tenantLinks = cfg.tenantIndex ? n * cfg.payloadM * 2 * LINK_BYTES : 0;
+
+    // Sparse vectors: each non-zero element is stored in the vector (u32 idx + f32
+    // value = 8 B) and once more in the inverted index (u32 id + f32 weight = 8 B).
+    const sparse = cfg.sparse ? n * cfg.sparseNnz * 16 : 0;
+
+    // IdTracker: ids + versions, always in RAM.
+    const idTracker = n * ID_OVERHEAD[cfg.idType];
+
+    // Payload data.
+    const payload = n * cfg.payloadBytes;
+
+    // Payload indexes (always in RAM, used for filtering).
+    const payloadIndex = n * cfg.payloadIndexFields * PAYLOAD_INDEX_BYTES_PER_FIELD;
+
+    // Write-ahead log: reserved on disk per shard, per replica.
+    const wal = cfg.walMb * 1024 * 1024 * cfg.shards;
+
+    // ----- RAM (resident data that must fit in memory) -----
+    const ramRawVectors = cfg.vectorsOnDisk ? 0 : rawVectors;
+    const ramQuantized = hasQuant && cfg.quantInRam ? quantized : 0;
+    const ramHnsw = cfg.hnswOnDisk ? 0 : hnsw;
+    const ramTenant = cfg.hnswOnDisk ? 0 : tenantLinks; // shares HNSW storage location
+    const ramSparse = cfg.sparseOnDisk ? 0 : sparse;
+    const ramPayload = cfg.payloadInRam ? payload : 0;
+    const ramData =
+      ramRawVectors + ramQuantized + ramHnsw + ramTenant + ramSparse + idTracker + ramPayload + payloadIndex;
+    const ramRecommended = ramData * RAM_HEADROOM + RAM_BASE_GIB * GiB;
+
+    // ----- Disk (everything is persisted) -----
+    const diskData =
+      (rawVectors + quantized + hnsw + tenantLinks + sparse + idTracker + payload) * STORAGE_OVERHEAD + wal;
+
+    // ----- CPU (rough guideline) -----
+    const ramGiB = ramData / GiB;
+    const cpuFromRam = ramGiB * 0.25; // ~1 vCPU per 4 GB of resident data
+    const cpuFromQps = cfg.qps > 0 ? cfg.qps / 250 : 0; // ~250 simple queries/sec per core
+    const cpuPerReplica = Math.max(2, Math.ceil(Math.max(cpuFromRam, cpuFromQps)));
+
+    const r = cfg.replicas;
+
+    return {
+      replicas: r,
+      ramRecommended: ramRecommended * r,
+      diskData: diskData * r,
+      cpu: cpuPerReplica * r,
+      // Raw components (single copy) used for effect notes & advisories.
+      parts: {
+        hasQuant,
+        rawVectors,
+        quantized,
+        hnsw,
+        tenantLinks,
+        sparse,
+        wal,
+        ramRawVectors,
+        ramQuantized,
+        ramHnsw,
+        ramSparse,
+      },
+      breakdown: [
+        { name: 'Original vectors', ram: ramRawVectors * r, disk: rawVectors * STORAGE_OVERHEAD * r },
+        {
+          name: hasQuant ? 'Quantized vectors' : 'Quantized vectors (off)',
+          ram: ramQuantized * r,
+          disk: quantized * STORAGE_OVERHEAD * r,
+          muted: !hasQuant,
+        },
+        { name: 'HNSW index', ram: ramHnsw * r, disk: hnsw * STORAGE_OVERHEAD * r },
+        {
+          name: cfg.tenantIndex ? 'Tenant links (payload_m)' : 'Tenant links (off)',
+          ram: ramTenant * r,
+          disk: tenantLinks * STORAGE_OVERHEAD * r,
+          muted: !cfg.tenantIndex,
+        },
+        {
+          name: cfg.sparse ? 'Sparse vectors + index' : 'Sparse vectors (off)',
+          ram: ramSparse * r,
+          disk: sparse * STORAGE_OVERHEAD * r,
+          muted: !cfg.sparse,
+        },
+        { name: 'IDs & versions', ram: idTracker * r, disk: idTracker * STORAGE_OVERHEAD * r },
+        { name: 'Payload', ram: ramPayload * r, disk: payload * STORAGE_OVERHEAD * r },
+        {
+          name: cfg.payloadIndexFields > 0 ? 'Payload indexes' : 'Payload indexes (off)',
+          ram: payloadIndex * r,
+          disk: 0,
+          muted: cfg.payloadIndexFields === 0,
+        },
+        { name: 'Write-ahead log', ram: 0, disk: wal * r },
+      ],
+    };
+  }
+
+  function render(result) {
+    el('cp-out-ram').textContent = formatBytes(result.ramRecommended);
+    el('cp-out-storage').textContent = formatBytes(result.diskData);
+    el('cp-out-cpu').textContent = result.cpu;
+
+    const note = el('cp-out-ram-note');
+    note.textContent = result.replicas > 1 ? `recommended · ${result.replicas} replicas` : 'recommended';
+
+    const body = el('cp-breakdown-body');
+    body.innerHTML = result.breakdown
+      .filter((row) => row.ram > 0 || row.disk > 0)
+      .map(
+        (row) => `
+        <tr${row.muted ? ' class="cp-breakdown__row--muted"' : ''}>
+          <td>${row.name}</td>
+          <td>${row.ram > 0 ? formatBytes(row.ram) : '—'}</td>
+          <td>${row.disk > 0 ? formatBytes(row.disk) : '—'}</td>
+        </tr>`
+      )
+      .join('');
+  }
+
+  function syncConditionalFields(cfg) {
+    const isProduct = cfg.quantization === 'product';
+    const hasQuant = cfg.quantization !== 'none';
+    el('cp-pq-ratio-field').hidden = !isProduct;
+    el('cp-quant-ram-field').hidden = !hasQuant;
+    el('cp-payload-m-field').hidden = !cfg.tenantIndex;
+    el('cp-sparse-nnz-field').hidden = !cfg.sparse;
+    el('cp-sparse-on-disk-field').hidden = !cfg.sparse;
+    el('cp-fusion-field').hidden = !cfg.sparse;
+  }
+
+  function renderQuantEffect(cfg) {
+    const info = QUANT_INFO[cfg.quantization] || QUANT_INFO.none;
+    // Compression factor relative to the chosen storage datatype.
+    let factor = '1×';
+    if (cfg.quantization === 'scalar') {
+      factor = `${(cfg.datatypeBytes / 1).toFixed(0)}×`;
+    } else if (cfg.quantization === 'binary') {
+      factor = `${(cfg.datatypeBytes * 8).toFixed(0)}×`;
+    } else if (cfg.quantization === 'product') {
+      factor = `${(cfg.pqRatio / (4 / cfg.datatypeBytes)).toFixed(0)}×`;
+    }
+    el('cp-quant-effect-name').textContent = info.name;
+    el('cp-quant-effect-factor').textContent =
+      cfg.quantization === 'none' ? '1× memory' : `${factor} smaller vectors`;
+    el('cp-quant-effect-recall').textContent = info.recall;
+    el('cp-quant-effect-speed').textContent = info.speed;
+    el('cp-quant-effect-best').textContent = info.best;
+    el('cp-quant-effect').dataset.mode = cfg.quantization;
+  }
+
+  function renderHnswEffect(cfg, ef) {
+    let recall = 'balanced recall';
+    if (cfg.hnswM <= 8) recall = 'lower recall, leanest index';
+    else if (cfg.hnswM >= 32) recall = 'high recall, heaviest index';
+    let text =
+      `m=${cfg.hnswM} → ${recall}. Index memory scales linearly with m. ` +
+      `ef_construct=${ef} controls build quality and time (no steady-state memory impact).`;
+    if (cfg.tenantIndex) {
+      text += ` Tenant index adds payload_m=${cfg.payloadM} links per point for isolated multitenant search.`;
+    }
+    el('cp-hnsw-effect').textContent = text;
+  }
+
+  const FUSION_INFO = {
+    rrf: 'Reciprocal Rank Fusion combines results by rank only — robust and score-scale agnostic. Qdrant default. Negligible resource cost.',
+    dbsf: 'Distribution-Based Score Fusion normalizes and sums raw scores — can rank better when score distributions are comparable. Negligible resource cost.',
+  };
+
+  function renderFusionEffect(cfg) {
+    const note = el('cp-fusion-effect');
+    if (!cfg.sparse) {
+      note.textContent = '';
+      return;
+    }
+    note.textContent = FUSION_INFO[cfg.fusion] || FUSION_INFO.rrf;
+  }
+
+  function renderAdvisories(cfg, parts) {
+    const items = [];
+
+    if (parts.hasQuant && parts.ramRawVectors > 0) {
+      items.push({
+        type: 'tip',
+        text: `You're keeping full-precision vectors in RAM alongside quantized copies. Storing originals on disk (memmap) would free ~${formatBytes(parts.ramRawVectors * cfg.replicas)} of RAM — the recommended setup with quantization.`,
+      });
+    }
+
+    if (parts.hasQuant && cfg.vectorsOnDisk) {
+      items.push({
+        type: 'tip',
+        text: 'Quantized search rescopes top candidates against the original on-disk vectors. Provision spare RAM for OS page cache so rescoring stays fast.',
+      });
+    }
+
+    if (cfg.quantization === 'binary' && cfg.dims < 1024) {
+      items.push({
+        type: 'warn',
+        text: `Binary quantization works best on high-dimensional embeddings (≥1024d). At ${cfg.dims}d expect noticeable recall loss unless you use query-time oversampling.`,
+      });
+    }
+
+    if (cfg.quantization === 'product') {
+      items.push({
+        type: 'warn',
+        text: `Product quantization (x${cfg.pqRatio}) gives the most compression but the largest accuracy loss. Always enable rescoring with the original vectors.`,
+      });
+    }
+
+    if (cfg.hnswOnDisk && parts.hnsw > 0) {
+      items.push({
+        type: 'tip',
+        text: 'HNSW on disk frees RAM but relies on the OS page cache. Leave headroom above the resident figure or first-touch queries will be slower.',
+      });
+    }
+
+    if (cfg.tenantIndex && parts.tenantLinks > 0) {
+      items.push({
+        type: 'tip',
+        text: `Tenant index (payload_m=${cfg.payloadM}) adds ~${formatBytes(
+          parts.tenantLinks * cfg.replicas
+        )} of graph links but makes per-tenant filtered search dramatically faster. Pair it with a keyword payload index on the tenant field.`,
+      });
+    }
+
+    if (cfg.payloadIndexFields > 0 && !cfg.tenantIndex) {
+      items.push({
+        type: 'tip',
+        text: 'For strict per-tenant isolation, enable the tenant payload index (payload_m) above — it builds an isolated subgraph per tenant for much faster filtered search.',
+      });
+    }
+
+    if (cfg.sparse) {
+      items.push({
+        type: 'tip',
+        text: `Sparse vectors (~${cfg.sparseNnz} non-zeros each) use an inverted index, not HNSW. Its size scales with total non-zero values${
+          cfg.sparseOnDisk ? '; it is memory-mapped on disk here' : '; keep it in RAM for fastest lookups'
+        }.`,
+      });
+      items.push({
+        type: 'tip',
+        text: `Hybrid search with ${cfg.fusion.toUpperCase()} fuses dense + sparse results at query time — this is CPU-only with negligible memory or storage impact.`,
+      });
+    }
+
+    if (cfg.walMb >= 256) {
+      items.push({
+        type: 'warn',
+        text: `A large WAL (${cfg.walMb} MB × ${cfg.shards} shard${cfg.shards > 1 ? 's' : ''} × ${
+          cfg.replicas
+        } replica${cfg.replicas > 1 ? 's' : ''}) reserves ${formatBytes(
+          parts.wal * cfg.replicas
+        )} on disk. Increase only for very high write throughput.`,
+      });
+    }
+
+    const container = el('cp-advisories');
+    if (!items.length) {
+      container.hidden = true;
+      container.innerHTML = '';
+      return;
+    }
+    container.hidden = false;
+    container.innerHTML =
+      '<p class="cp-advisories__title">Things to consider</p>' +
+      items
+        .map(
+          (it) =>
+            `<div class="cp-advisory cp-advisory--${it.type}"><span class="cp-advisory__icon">${
+              it.type === 'warn' ? '!' : 'i'
+            }</span><span>${it.text}</span></div>`
+        )
+        .join('');
+  }
+
+  function update() {
+    const cfg = readInputs();
+    syncConditionalFields(cfg);
+    const ef = Math.round(num('cp-hnsw-ef', 100));
+    el('cp-hnsw-m-value').textContent = cfg.hnswM;
+    el('cp-hnsw-ef-value').textContent = ef;
+    el('cp-payload-m-value').textContent = cfg.payloadM;
+    renderQuantEffect(cfg);
+    renderHnswEffect(cfg, ef);
+    renderFusionEffect(cfg);
+    const result = estimate(cfg);
+    render(result);
+    renderAdvisories(cfg, result.parts);
+  }
+
+  form.addEventListener('input', update);
+  form.addEventListener('change', update);
+  form.addEventListener('reset', () => {
+    // Let the browser reset values first, then recompute.
+    setTimeout(update, 0);
+  });
+
+  update();
+});

--- a/qdrant-landing/themes/qdrant-2024/layouts/capacity-planner/list.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/capacity-planner/list.html
@@ -1,0 +1,390 @@
+{{ define "main" }}
+  {{ partial "site-header" . }}
+
+  <section class="capacity-planner-hero">
+    <div class="container">
+      <p class="capacity-planner-hero__label">{{ .Params.hero.label }}</p>
+      <h1 class="capacity-planner-hero__title">{{ .Params.hero.title }}</h1>
+      <p class="capacity-planner-hero__description">{{ .Params.hero.description }}</p>
+    </div>
+  </section>
+
+  <section class="capacity-planner">
+    <div class="container">
+      <form class="capacity-planner__layout" id="capacity-planner" autocomplete="off" novalidate>
+        <div class="capacity-planner__inputs">
+          {{/* ---------------- Data ---------------- */}}
+          <fieldset class="cp-group cp-group--grid" style="--cp-cols: 3">
+            <legend class="cp-group__title">Your data</legend>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-vectors">
+                Number of vectors
+                <span class="cp-field__hint" title="Total number of points (rows) you plan to store in the collection.">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-vectors" min="0" step="1000" value="1000000" />
+            </div>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-dimensions">
+                Vector dimensions
+                <span class="cp-field__hint" title="Dimensionality of a single dense vector (e.g. 768, 1536).">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-dimensions" min="1" step="1" value="768" />
+            </div>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-vectors-per-point">
+                Named vectors per point
+                <span class="cp-field__hint" title="How many named dense vectors each point stores (e.g. a text + an image embedding). Usually 1.">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-vectors-per-point" min="1" step="1" value="1" />
+            </div>
+          </fieldset>
+
+          {{/* ---------------- Vector storage & quantization ---------------- */}}
+          <fieldset class="cp-group cp-group--grid" style="--cp-cols: 2">
+            <legend class="cp-group__title">Vector storage &amp; quantization</legend>
+
+            <div class="cp-field cp-field--span">
+              <span class="cp-field__label">Vector datatype
+                <span class="cp-field__hint" title="Storage precision of each dense vector element. float32 is default; float16 halves size with minimal accuracy loss; uint8 is for pre-quantized integer vectors.">?</span>
+              </span>
+              <div class="cp-segmented" data-cp-name="datatype">
+                <label class="cp-segmented__option"><input type="radio" name="cp-datatype" value="4" checked /><span>float32</span></label>
+                <label class="cp-segmented__option"><input type="radio" name="cp-datatype" value="2" /><span>float16</span></label>
+                <label class="cp-segmented__option"><input type="radio" name="cp-datatype" value="1" /><span>uint8</span></label>
+              </div>
+            </div>
+
+            <div class="cp-field cp-field--switch">
+              <label class="cp-field__label" for="cp-vectors-on-disk">
+                Store original vectors on disk
+                <span class="cp-field__hint" title="Keeps full-precision vectors on disk (memmap) instead of RAM. Recommended together with quantization.">?</span>
+              </label>
+              <label class="cp-switch">
+                <input type="checkbox" id="cp-vectors-on-disk" />
+                <span class="cp-switch__track"></span>
+              </label>
+            </div>
+
+            <div class="cp-field cp-field--span">
+              <span class="cp-field__label">Quantization
+                <span class="cp-field__hint" title="Compresses vectors to save memory. Scalar (int8) ~4× with tiny recall loss; Binary ~32× for high-dim embeddings; Product up to 64× with more accuracy loss. Originals are kept for rescoring.">?</span>
+              </span>
+              <div class="cp-segmented" data-cp-name="quantization">
+                <label class="cp-segmented__option"><input type="radio" name="cp-quantization" value="none" checked /><span>None</span></label>
+                <label class="cp-segmented__option"><input type="radio" name="cp-quantization" value="scalar" /><span>Scalar (int8)</span></label>
+                <label class="cp-segmented__option"><input type="radio" name="cp-quantization" value="binary" /><span>Binary</span></label>
+                <label class="cp-segmented__option"><input type="radio" name="cp-quantization" value="product" /><span>Product</span></label>
+              </div>
+            </div>
+
+            <div class="cp-field" id="cp-pq-ratio-field" hidden>
+              <label class="cp-field__label" for="cp-pq-ratio">
+                Product quantization compression
+                <span class="cp-field__hint" title="Compression ratio relative to float32 vectors.">?</span>
+              </label>
+              <select class="q-input q-input_light-bg cp-field__input" id="cp-pq-ratio">
+                <option value="4">x4</option>
+                <option value="8">x8</option>
+                <option value="16" selected>x16</option>
+                <option value="32">x32</option>
+                <option value="64">x64</option>
+              </select>
+            </div>
+
+            <div class="cp-field cp-field--switch" id="cp-quant-ram-field" hidden>
+              <label class="cp-field__label" for="cp-quant-ram">
+                Keep quantized vectors in RAM
+                <span class="cp-field__hint" title="Quantized vectors are small and are usually kept in RAM (always_ram) for fast search.">?</span>
+              </label>
+              <label class="cp-switch">
+                <input type="checkbox" id="cp-quant-ram" checked />
+                <span class="cp-switch__track"></span>
+              </label>
+            </div>
+
+            <div class="cp-field cp-field--span">
+              <div class="cp-effect" id="cp-quant-effect">
+                <p class="cp-effect__title">
+                  <span id="cp-quant-effect-name">No quantization</span>
+                  <span class="cp-effect__badge" id="cp-quant-effect-factor">1× memory</span>
+                </p>
+                <ul class="cp-effect__list">
+                  <li><span class="cp-effect__key">Recall</span><span id="cp-quant-effect-recall">–</span></li>
+                  <li><span class="cp-effect__key">Speed</span><span id="cp-quant-effect-speed">–</span></li>
+                  <li><span class="cp-effect__key">Best for</span><span id="cp-quant-effect-best">–</span></li>
+                </ul>
+              </div>
+            </div>
+          </fieldset>
+
+          {{/* ---------------- HNSW index ---------------- */}}
+          <fieldset class="cp-group">
+            <legend class="cp-group__title">HNSW index</legend>
+
+            <div class="cp-field">
+              <label class="cp-field__label cp-field__label--slider" for="cp-hnsw-m">
+                <span>Graph connections (m)
+                  <span class="cp-field__hint" title="Edges per node. Higher m improves recall but increases index memory.">?</span>
+                </span>
+                <output class="cp-field__value" id="cp-hnsw-m-value">16</output>
+              </label>
+              <input class="cp-slider" type="range" id="cp-hnsw-m" min="4" max="64" step="2" value="16" />
+            </div>
+
+            <div class="cp-field">
+              <label class="cp-field__label cp-field__label--slider" for="cp-hnsw-ef">
+                <span>ef_construct
+                  <span class="cp-field__hint" title="Beam size during index build. Affects build time and recall, not steady-state memory.">?</span>
+                </span>
+                <output class="cp-field__value" id="cp-hnsw-ef-value">100</output>
+              </label>
+              <input class="cp-slider" type="range" id="cp-hnsw-ef" min="16" max="512" step="4" value="100" />
+            </div>
+
+            <div class="cp-field cp-field--switch">
+              <label class="cp-field__label" for="cp-hnsw-on-disk">
+                Store HNSW index on disk (on_disk)
+                <span class="cp-field__hint" title="Stores the graph as a memory-mapped file. Frees RAM but relies on OS page cache for speed.">?</span>
+              </label>
+              <label class="cp-switch">
+                <input type="checkbox" id="cp-hnsw-on-disk" />
+                <span class="cp-switch__track"></span>
+              </label>
+            </div>
+
+            <div class="cp-field cp-field--switch">
+              <label class="cp-field__label" for="cp-tenant-index">
+                Tenant payload index (payload_m)
+                <span class="cp-field__hint" title="Builds additional in-graph HNSW links per tenant for fast, isolated multitenant search. Adds memory.">?</span>
+              </label>
+              <label class="cp-switch">
+                <input type="checkbox" id="cp-tenant-index" />
+                <span class="cp-switch__track"></span>
+              </label>
+            </div>
+
+            <div class="cp-field" id="cp-payload-m-field" hidden>
+              <label class="cp-field__label cp-field__label--slider" for="cp-payload-m">
+                <span>payload_m
+                  <span class="cp-field__hint" title="Edges per node in the tenant subgraph. Higher = faster filtered search, more memory.">?</span>
+                </span>
+                <output class="cp-field__value" id="cp-payload-m-value">16</output>
+              </label>
+              <input class="cp-slider" type="range" id="cp-payload-m" min="4" max="64" step="2" value="16" />
+            </div>
+
+            <p class="cp-effect__note" id="cp-hnsw-effect"></p>
+          </fieldset>
+
+          {{/* ---------------- Sparse vectors & hybrid search ---------------- */}}
+          <fieldset class="cp-group">
+            <legend class="cp-group__title">Sparse vectors &amp; hybrid search</legend>
+
+            <div class="cp-field cp-field--switch">
+              <label class="cp-field__label" for="cp-sparse">
+                Enable sparse vectors
+                <span class="cp-field__hint" title="Adds a sparse vector (e.g. BM25/SPLADE) per point for keyword-style matching and hybrid search.">?</span>
+              </label>
+              <label class="cp-switch">
+                <input type="checkbox" id="cp-sparse" />
+                <span class="cp-switch__track"></span>
+              </label>
+            </div>
+
+            <div class="cp-field" id="cp-sparse-nnz-field" hidden>
+              <label class="cp-field__label" for="cp-sparse-nnz">
+                Avg non-zero values per sparse vector
+                <span class="cp-field__hint" title="Number of non-zero dimensions in a typical sparse vector. Drives sparse index size.">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-sparse-nnz" min="1" step="1" value="100" />
+            </div>
+
+            <div class="cp-field cp-field--switch" id="cp-sparse-on-disk-field" hidden>
+              <label class="cp-field__label" for="cp-sparse-on-disk">
+                Store sparse index on disk (on_disk)
+                <span class="cp-field__hint" title="Keeps the sparse inverted index memory-mapped on disk instead of RAM.">?</span>
+              </label>
+              <label class="cp-switch">
+                <input type="checkbox" id="cp-sparse-on-disk" />
+                <span class="cp-switch__track"></span>
+              </label>
+            </div>
+
+            <div class="cp-field" id="cp-fusion-field" hidden>
+              <span class="cp-field__label">Hybrid fusion method
+                <span class="cp-field__hint" title="How dense and sparse results are combined at query time. RRF (Reciprocal Rank Fusion) merges by rank and is score-scale agnostic; DBSF (Distribution-Based Score Fusion) normalizes and sums raw scores. Query-time only — no memory impact.">?</span>
+              </span>
+              <div class="cp-segmented" data-cp-name="fusion">
+                <label class="cp-segmented__option"><input type="radio" name="cp-fusion" value="rrf" checked /><span>RRF</span></label>
+                <label class="cp-segmented__option"><input type="radio" name="cp-fusion" value="dbsf" /><span>DBSF</span></label>
+              </div>
+            </div>
+
+            <p class="cp-effect__note" id="cp-fusion-effect"></p>
+          </fieldset>
+
+          {{/* ---------------- Payload ---------------- */}}
+          <fieldset class="cp-group">
+            <legend class="cp-group__title">Payload &amp; identifiers</legend>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-payload">
+                Average payload size per point
+                <span class="cp-field__hint" title="Average size of the JSON metadata stored with each point.">?</span>
+              </label>
+              <div class="cp-field__combo">
+                <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-payload" min="0" step="0.1" value="1" />
+                <select class="q-input q-input_light-bg cp-field__unit" id="cp-payload-unit">
+                  <option value="1">B</option>
+                  <option value="1024" selected>KB</option>
+                  <option value="1048576">MB</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="cp-field cp-field--switch">
+              <label class="cp-field__label" for="cp-payload-on-disk">
+                Store payload on disk (on_disk)
+                <span class="cp-field__hint" title="On by default. Turn off to keep payload in RAM for faster access at the cost of memory.">?</span>
+              </label>
+              <label class="cp-switch">
+                <input type="checkbox" id="cp-payload-on-disk" checked />
+                <span class="cp-switch__track"></span>
+              </label>
+            </div>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-payload-index-fields">
+                Indexed payload fields
+                <span class="cp-field__hint" title="Number of payload fields with a payload index for filtering. Each adds in-RAM structures.">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-payload-index-fields" min="0" step="1" value="0" />
+            </div>
+
+            <div class="cp-field">
+              <span class="cp-field__label">Point ID type
+                <span class="cp-field__hint" title="Type of point identifiers. UUIDs cost more RAM in the ID tracker (~40 B/point) than integers (~24 B/point).">?</span>
+              </span>
+              <div class="cp-segmented" data-cp-name="id-type">
+                <label class="cp-segmented__option"><input type="radio" name="cp-id-type" value="integer" checked /><span>Integer</span></label>
+                <label class="cp-segmented__option"><input type="radio" name="cp-id-type" value="uuid" /><span>UUID</span></label>
+              </div>
+            </div>
+          </fieldset>
+
+          {{/* ---------------- Deployment ---------------- */}}
+          <fieldset class="cp-group">
+            <legend class="cp-group__title">Deployment</legend>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-replicas">
+                Replication factor
+                <span class="cp-field__hint" title="Number of copies of the data across the cluster for high availability.">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-replicas" min="1" step="1" value="1" />
+            </div>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-shards">
+                Shards
+                <span class="cp-field__hint" title="Shards per collection. Each shard keeps its own write-ahead log.">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-shards" min="1" step="1" value="1" />
+            </div>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-wal-capacity">
+                WAL capacity per shard (wal_capacity_mb)
+                <span class="cp-field__hint" title="Write-ahead log size reserved on disk per shard. Qdrant default is 32 MB.">?</span>
+              </label>
+              <select class="q-input q-input_light-bg cp-field__input" id="cp-wal-capacity">
+                <option value="32" selected>32 MB (default)</option>
+                <option value="64">64 MB</option>
+                <option value="128">128 MB</option>
+                <option value="256">256 MB</option>
+                <option value="512">512 MB</option>
+                <option value="1024">1024 MB</option>
+              </select>
+            </div>
+
+            <div class="cp-field">
+              <label class="cp-field__label" for="cp-qps">
+                Expected search throughput (queries/sec)
+                <span class="cp-field__hint" title="Optional. Used only to refine the CPU recommendation. Leave 0 to size CPU by data volume.">?</span>
+              </label>
+              <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-qps" min="0" step="10" value="0" />
+            </div>
+          </fieldset>
+
+          <button type="reset" class="button button_outlined button_md cp-reset" id="cp-reset">Reset to defaults</button>
+        </div>
+
+        {{/* ---------------- Results ---------------- */}}
+        <aside class="capacity-planner__results">
+          <div class="capacity-planner__results-inner">
+            <p class="cp-results__title">Estimated resources</p>
+            <p class="cp-results__subtitle">Total across all replicas</p>
+
+            <div class="cp-summary">
+              <div class="cp-summary__card cp-summary__card--ram">
+                <div class="cp-summary__head">
+                  <span class="cp-summary__label">Memory (RAM)</span>
+                  <span class="cp-summary__note" id="cp-out-ram-note">recommended</span>
+                </div>
+                <span class="cp-summary__value" id="cp-out-ram">–</span>
+              </div>
+              <div class="cp-summary__card cp-summary__card--storage">
+                <div class="cp-summary__head">
+                  <span class="cp-summary__label">Disk storage</span>
+                  <span class="cp-summary__note">with overhead</span>
+                </div>
+                <span class="cp-summary__value" id="cp-out-storage">–</span>
+              </div>
+              <div class="cp-summary__card cp-summary__card--cpu">
+                <div class="cp-summary__head">
+                  <span class="cp-summary__label">vCPU</span>
+                  <span class="cp-summary__note">guideline</span>
+                </div>
+                <span class="cp-summary__value" id="cp-out-cpu">–</span>
+              </div>
+            </div>
+
+            <div class="cp-advisories" id="cp-advisories" hidden></div>
+
+            <div class="cp-breakdown">
+              <p class="cp-breakdown__title">Breakdown</p>
+              <table class="cp-breakdown__table">
+                <thead>
+                  <tr>
+                    <th>Component</th>
+                    <th>RAM</th>
+                    <th>Disk</th>
+                  </tr>
+                </thead>
+                <tbody id="cp-breakdown-body">
+                  <!-- rows injected by JS -->
+                </tbody>
+              </table>
+            </div>
+
+            <p class="cp-disclaimer">
+              These figures are estimates to help you plan. Real usage depends on your data
+              distribution, segment layout, and Qdrant version. For production sizing, benchmark
+              with your own dataset. See the
+              <a href="/documentation/guides/capacity-planning/" class="link">capacity planning guide</a>.
+            </p>
+
+            <div class="cp-results__cta">
+              <a href="https://cloud.qdrant.io/signup" class="button button_contained button_lg" target="_blank" rel="noopener">Try Qdrant Cloud</a>
+            </div>
+          </div>
+        </aside>
+      </form>
+    </div>
+  </section>
+
+  {{ partial "get-started" . }}
+{{ end }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/capacity-planner/list.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/capacity-planner/list.html
@@ -20,7 +20,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-vectors">
                 Number of vectors
-                <span class="cp-field__hint" title="Total number of points (rows) you plan to store in the collection.">?</span>
+                <span class="cp-field__hint" data-tip="How many points (records) you expect to store in this collection.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-vectors" min="0" step="1000" value="1000000" />
             </div>
@@ -28,7 +28,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-dimensions">
                 Vector dimensions
-                <span class="cp-field__hint" title="Dimensionality of a single dense vector (e.g. 768, 1536).">?</span>
+                <span class="cp-field__hint" data-tip="The length of each embedding — for example, 768 for many BERT models or 1536 for OpenAI embeddings.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-dimensions" min="1" step="1" value="768" />
             </div>
@@ -36,7 +36,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-vectors-per-point">
                 Named vectors per point
-                <span class="cp-field__hint" title="How many named dense vectors each point stores (e.g. a text + an image embedding). Usually 1.">?</span>
+                <span class="cp-field__hint" data-tip="Most collections use one vector per point. Increase this only if each point holds several embeddings, such as text and image together.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-vectors-per-point" min="1" step="1" value="1" />
             </div>
@@ -48,7 +48,7 @@
 
             <div class="cp-field cp-field--span">
               <span class="cp-field__label">Vector datatype
-                <span class="cp-field__hint" title="Storage precision of each dense vector element. float32 is default; float16 halves size with minimal accuracy loss; uint8 is for pre-quantized integer vectors.">?</span>
+                <span class="cp-field__hint" data-tip="How precisely each vector value is stored. float32 is the safe default, float16 halves the size with almost no accuracy loss, and uint8 suits vectors that are already integers.">?</span>
               </span>
               <div class="cp-segmented" data-cp-name="datatype">
                 <label class="cp-segmented__option"><input type="radio" name="cp-datatype" value="4" checked /><span>float32</span></label>
@@ -60,7 +60,7 @@
             <div class="cp-field cp-field--switch">
               <label class="cp-field__label" for="cp-vectors-on-disk">
                 Store original vectors on disk
-                <span class="cp-field__hint" title="Keeps full-precision vectors on disk (memmap) instead of RAM. Recommended together with quantization.">?</span>
+                <span class="cp-field__hint" data-tip="Keep the full-precision vectors on disk instead of in memory. Usually worth turning on whenever you use quantization.">?</span>
               </label>
               <label class="cp-switch">
                 <input type="checkbox" id="cp-vectors-on-disk" />
@@ -70,7 +70,7 @@
 
             <div class="cp-field cp-field--span">
               <span class="cp-field__label">Quantization
-                <span class="cp-field__hint" title="Compresses vectors to save memory. Scalar (int8) ~4× with tiny recall loss; Binary ~32× for high-dim embeddings; Product up to 64× with more accuracy loss. Originals are kept for rescoring.">?</span>
+                <span class="cp-field__hint" data-tip="Compress vectors to fit more in memory. Scalar (int8) shrinks them about 4× with barely any accuracy loss, Binary up to 32× for large embeddings, and Product up to 64× with a bigger trade-off. The originals are always kept so results can be re-scored.">?</span>
               </span>
               <div class="cp-segmented" data-cp-name="quantization">
                 <label class="cp-segmented__option"><input type="radio" name="cp-quantization" value="none" checked /><span>None</span></label>
@@ -83,7 +83,7 @@
             <div class="cp-field" id="cp-pq-ratio-field" hidden>
               <label class="cp-field__label" for="cp-pq-ratio">
                 Product quantization compression
-                <span class="cp-field__hint" title="Compression ratio relative to float32 vectors.">?</span>
+                <span class="cp-field__hint" data-tip="How aggressively Product quantization compresses each vector, measured against its full float32 size.">?</span>
               </label>
               <select class="q-input q-input_light-bg cp-field__input" id="cp-pq-ratio">
                 <option value="4">x4</option>
@@ -97,7 +97,7 @@
             <div class="cp-field cp-field--switch" id="cp-quant-ram-field" hidden>
               <label class="cp-field__label" for="cp-quant-ram">
                 Keep quantized vectors in RAM
-                <span class="cp-field__hint" title="Quantized vectors are small and are usually kept in RAM (always_ram) for fast search.">?</span>
+                <span class="cp-field__hint" data-tip="Quantized vectors are small, so keeping them in memory (always_ram) makes search noticeably faster.">?</span>
               </label>
               <label class="cp-switch">
                 <input type="checkbox" id="cp-quant-ram" checked />
@@ -127,7 +127,7 @@
             <div class="cp-field">
               <label class="cp-field__label cp-field__label--slider" for="cp-hnsw-m">
                 <span>Graph connections (m)
-                  <span class="cp-field__hint" title="Edges per node. Higher m improves recall but increases index memory.">?</span>
+                  <span class="cp-field__hint" data-tip="How many neighbours each node links to in the graph. Higher values improve recall but use more memory.">?</span>
                 </span>
                 <output class="cp-field__value" id="cp-hnsw-m-value">16</output>
               </label>
@@ -137,7 +137,7 @@
             <div class="cp-field">
               <label class="cp-field__label cp-field__label--slider" for="cp-hnsw-ef">
                 <span>ef_construct
-                  <span class="cp-field__hint" title="Beam size during index build. Affects build time and recall, not steady-state memory.">?</span>
+                  <span class="cp-field__hint" data-tip="How thoroughly the graph is built. Higher values give better recall and slower builds, but don't change memory once the index is ready.">?</span>
                 </span>
                 <output class="cp-field__value" id="cp-hnsw-ef-value">100</output>
               </label>
@@ -147,7 +147,7 @@
             <div class="cp-field cp-field--switch">
               <label class="cp-field__label" for="cp-hnsw-on-disk">
                 Store HNSW index on disk (on_disk)
-                <span class="cp-field__hint" title="Stores the graph as a memory-mapped file. Frees RAM but relies on OS page cache for speed.">?</span>
+                <span class="cp-field__hint" data-tip="Keep the graph on disk as a memory-mapped file. This frees up RAM but leans on the operating system's cache for speed.">?</span>
               </label>
               <label class="cp-switch">
                 <input type="checkbox" id="cp-hnsw-on-disk" />
@@ -158,7 +158,7 @@
             <div class="cp-field cp-field--switch">
               <label class="cp-field__label" for="cp-tenant-index">
                 Tenant payload index (payload_m)
-                <span class="cp-field__hint" title="Builds additional in-graph HNSW links per tenant for fast, isolated multitenant search. Adds memory.">?</span>
+                <span class="cp-field__hint" data-tip="For multitenant setups: builds a separate graph per tenant so filtered searches stay fast. Uses extra memory.">?</span>
               </label>
               <label class="cp-switch">
                 <input type="checkbox" id="cp-tenant-index" />
@@ -169,7 +169,7 @@
             <div class="cp-field" id="cp-payload-m-field" hidden>
               <label class="cp-field__label cp-field__label--slider" for="cp-payload-m">
                 <span>payload_m
-                  <span class="cp-field__hint" title="Edges per node in the tenant subgraph. Higher = faster filtered search, more memory.">?</span>
+                  <span class="cp-field__hint" data-tip="Neighbours per node within each tenant's graph. Higher means faster filtered search but more memory.">?</span>
                 </span>
                 <output class="cp-field__value" id="cp-payload-m-value">16</output>
               </label>
@@ -186,7 +186,7 @@
             <div class="cp-field cp-field--switch">
               <label class="cp-field__label" for="cp-sparse">
                 Enable sparse vectors
-                <span class="cp-field__hint" title="Adds a sparse vector (e.g. BM25/SPLADE) per point for keyword-style matching and hybrid search.">?</span>
+                <span class="cp-field__hint" data-tip="Add a sparse vector (such as BM25 or SPLADE) to each point for keyword-style matching and hybrid search.">?</span>
               </label>
               <label class="cp-switch">
                 <input type="checkbox" id="cp-sparse" />
@@ -197,7 +197,7 @@
             <div class="cp-field" id="cp-sparse-nnz-field" hidden>
               <label class="cp-field__label" for="cp-sparse-nnz">
                 Avg non-zero values per sparse vector
-                <span class="cp-field__hint" title="Number of non-zero dimensions in a typical sparse vector. Drives sparse index size.">?</span>
+                <span class="cp-field__hint" data-tip="Roughly how many non-zero values a typical sparse vector has. This is the main driver of the sparse index size.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-sparse-nnz" min="1" step="1" value="100" />
             </div>
@@ -205,7 +205,7 @@
             <div class="cp-field cp-field--switch" id="cp-sparse-on-disk-field" hidden>
               <label class="cp-field__label" for="cp-sparse-on-disk">
                 Store sparse index on disk (on_disk)
-                <span class="cp-field__hint" title="Keeps the sparse inverted index memory-mapped on disk instead of RAM.">?</span>
+                <span class="cp-field__hint" data-tip="Keep the sparse inverted index on disk instead of in memory.">?</span>
               </label>
               <label class="cp-switch">
                 <input type="checkbox" id="cp-sparse-on-disk" />
@@ -215,7 +215,7 @@
 
             <div class="cp-field" id="cp-fusion-field" hidden>
               <span class="cp-field__label">Hybrid fusion method
-                <span class="cp-field__hint" title="How dense and sparse results are combined at query time. RRF (Reciprocal Rank Fusion) merges by rank and is score-scale agnostic; DBSF (Distribution-Based Score Fusion) normalizes and sums raw scores. Query-time only — no memory impact.">?</span>
+                <span class="cp-field__hint" data-tip="How dense and sparse results are merged. RRF combines them by rank and ignores score scale; DBSF normalises and adds the raw scores. This happens at query time, so it has no memory cost.">?</span>
               </span>
               <div class="cp-segmented" data-cp-name="fusion">
                 <label class="cp-segmented__option"><input type="radio" name="cp-fusion" value="rrf" checked /><span>RRF</span></label>
@@ -233,7 +233,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-payload">
                 Average payload size per point
-                <span class="cp-field__hint" title="Average size of the JSON metadata stored with each point.">?</span>
+                <span class="cp-field__hint" data-tip="The typical size of the JSON metadata you attach to each point.">?</span>
               </label>
               <div class="cp-field__combo">
                 <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-payload" min="0" step="0.1" value="1" />
@@ -248,7 +248,7 @@
             <div class="cp-field cp-field--switch">
               <label class="cp-field__label" for="cp-payload-on-disk">
                 Store payload on disk (on_disk)
-                <span class="cp-field__hint" title="On by default. Turn off to keep payload in RAM for faster access at the cost of memory.">?</span>
+                <span class="cp-field__hint" data-tip="On by default. Turn it off to keep payload in memory for faster access, at the cost of more RAM.">?</span>
               </label>
               <label class="cp-switch">
                 <input type="checkbox" id="cp-payload-on-disk" checked />
@@ -259,14 +259,14 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-payload-index-fields">
                 Indexed payload fields
-                <span class="cp-field__hint" title="Number of payload fields with a payload index for filtering. Each adds in-RAM structures.">?</span>
+                <span class="cp-field__hint" data-tip="How many payload fields you index for filtering. Each index adds a little in-memory data.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-payload-index-fields" min="0" step="1" value="0" />
             </div>
 
             <div class="cp-field">
               <span class="cp-field__label">Point ID type
-                <span class="cp-field__hint" title="Type of point identifiers. UUIDs cost more RAM in the ID tracker (~40 B/point) than integers (~24 B/point).">?</span>
+                <span class="cp-field__hint" data-tip="The kind of IDs your points use. UUIDs take more memory per point (about 40 bytes) than plain integers (about 24 bytes).">?</span>
               </span>
               <div class="cp-segmented" data-cp-name="id-type">
                 <label class="cp-segmented__option"><input type="radio" name="cp-id-type" value="integer" checked /><span>Integer</span></label>
@@ -282,7 +282,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-replicas">
                 Replication factor
-                <span class="cp-field__hint" title="Number of copies of the data across the cluster for high availability.">?</span>
+                <span class="cp-field__hint" data-tip="How many copies of the data you keep across the cluster for high availability.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-replicas" min="1" step="1" value="1" />
             </div>
@@ -290,7 +290,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-shards">
                 Shards
-                <span class="cp-field__hint" title="Shards per collection. Each shard keeps its own write-ahead log.">?</span>
+                <span class="cp-field__hint" data-tip="How many shards the collection is split into. Each shard keeps its own write-ahead log.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-shards" min="1" step="1" value="1" />
             </div>
@@ -298,7 +298,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-wal-capacity">
                 WAL capacity per shard (wal_capacity_mb)
-                <span class="cp-field__hint" title="Write-ahead log size reserved on disk per shard. Qdrant default is 32 MB.">?</span>
+                <span class="cp-field__hint" data-tip="Disk space reserved for the write-ahead log on each shard. Qdrant's default is 32 MB.">?</span>
               </label>
               <select class="q-input q-input_light-bg cp-field__input" id="cp-wal-capacity">
                 <option value="32" selected>32 MB (default)</option>
@@ -313,7 +313,7 @@
             <div class="cp-field">
               <label class="cp-field__label" for="cp-qps">
                 Expected search throughput (queries/sec)
-                <span class="cp-field__hint" title="Optional. Used only to refine the CPU recommendation. Leave 0 to size CPU by data volume.">?</span>
+                <span class="cp-field__hint" data-tip="Optional. Helps refine the CPU estimate. Leave it at 0 to size CPU from data volume alone.">?</span>
               </label>
               <input class="q-input q-input_light-bg cp-field__input" type="number" id="cp-qps" min="0" step="10" value="0" />
             </div>

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
@@ -54,6 +54,11 @@
   <script src="{{ $pricingTableJs.RelPermalink }}"></script>
 {{ end }}
 
+{{ if eq .Section "capacity-planner" }}
+  {{ $capacityPlannerJs := resources.Get "/js/capacity-planner.js" | js.Build | minify | resources.Fingerprint "sha512" }}
+  <script src="{{ $capacityPlannerJs.RelPermalink }}"></script>
+{{ end }}
+
 {{ if .IsHome }}
   {{ $homeAnimationsJs := resources.Get "/js/home-animations.js" | js.Build | minify | resources.Fingerprint "sha512" }}
   <script src="{{ $homeAnimationsJs.RelPermalink }}"></script>

--- a/qdrant-landing/themes/qdrant-2024/static/img/menu/capacity-planner.svg
+++ b/qdrant-landing/themes/qdrant-2024/static/img/menu/capacity-planner.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3.5 1C2.67157 1 2 1.67157 2 2.5V13.5C2 14.3284 2.67157 15 3.5 15H12.5C13.3284 15 14 14.3284 14 13.5V2.5C14 1.67157 13.3284 1 12.5 1H3.5ZM3 2.5C3 2.22386 3.22386 2 3.5 2H12.5C12.7761 2 13 2.22386 13 2.5V13.5C13 13.7761 12.7761 14 12.5 14H3.5C3.22386 14 3 13.7761 3 13.5V2.5Z" fill="#DC244C"/>
+<rect x="4" y="3.25" width="8" height="2" rx="0.5" fill="#DC244C"/>
+<circle cx="5" cy="7.75" r="0.75" fill="#DC244C"/>
+<circle cx="8" cy="7.75" r="0.75" fill="#DC244C"/>
+<circle cx="11" cy="7.75" r="0.75" fill="#DC244C"/>
+<circle cx="5" cy="10.5" r="0.75" fill="#DC244C"/>
+<circle cx="8" cy="10.5" r="0.75" fill="#DC244C"/>
+<circle cx="11" cy="10.5" r="0.75" fill="#DC244C"/>
+</svg>


### PR DESCRIPTION
## Add Capacity Planner — Qdrant sizing tool

Adds an interactive **Capacity Planner** page at `/capacity-planner/` that estimates the **RAM, disk storage, and vCPU** a Qdrant deployment needs from its collection config. Built on the existing `qdrant-2024` theme patterns (section layout, SCSS partials, per-section JS, existing components).

### Screenshot
<img width="3018" height="6695" alt="image" src="https://github.com/user-attachments/assets/468481e6-1e0c-40ff-9aec-c0475fb4c57c" />


### Highlights
- Live, no-backend calculator — updates instantly on every change.
- **Inputs:** vector count, dimensions, datatype, quantization (scalar/binary/product), HNSW `m`/`ef_construct`, `on_disk` toggles, `payload_m`, sparse vectors, hybrid fusion (RRF/DBSF), payload, replicas, shards, WAL, QPS.
- **Outputs:** recommended RAM, disk, vCPU + per-component breakdown (RAM vs. disk).
- Per-field tooltips, dynamic effect panels (recall/speed/memory trade-offs), and contextual advisories.
- Added to the **Developers** nav dropdown with a matching icon.

Formulas are based on Qdrant's documented internals and validated against the docs' worked example (quantized/HNSW figures match exactly; totals are slightly conservative for provisioning). Estimates are planning aids — real usage varies, so users are pointed to the capacity-planning guide.

### Test plan
- [x] `/capacity-planner/` loads with styles/JS; values update live.
- [x] Toggling quantization / on_disk / sparse / tenant index updates breakdown + advisories.
- [x] Responsive on laptop/tablet/mobile; link shows in Developers nav.