### PR TITLE
Document per-shard fusion in distributed collections

### DIFF
--- a/qdrant-landing/content/documentation/search/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/search/hybrid-queries.md
@@ -117,6 +117,12 @@ For a deeper breakdown of when to prefer each, see the [FAQ on RRF vs. DBSF](/do
 <aside role="status">A common request is "alpha-weighted linear combination of dense and sparse scores." This is unreliable without first normalizing the scores: dense (cosine, bounded) and sparse (BM25, unbounded) scores live on different scales that also shift per query, so a fixed alpha over raw scores tends to be dominated by whichever retriever has larger raw magnitudes on a given query. RRF sidesteps this by using ranks. DBSF sidesteps it by normalizing distributions.</aside>
 
 
+### Fusion in Distributed Collections
+
+In a multi-shard collection, a fusion merges results across all shards only when it is the main query. A fusion nested inside a prefetch runs independently on each shard and fuses that shard's local results, so the ranking is per shard rather than global. A fusion is nested whenever the main query is something else, such as a formula query or an outer fusion.
+
+To fuse across shards, make the fusion the main query, as in the [RRF](#reciprocal-rank-fusion-rrf) and [DBSF](#distribution-based-score-fusion-dbsf) examples above. A main query runs a single operation, so keeping a formula rescore over a fused result requires a single shard.
+
 ## Multi-Stage Queries
 
 In general, larger vector representations give more accurate search results, but makes them more expensive to compute.
@@ -162,6 +168,8 @@ A formula query lets you compose a final score from prefetch scores (`$score`), 
 <aside role="status">Calibrate the decay weight against the scale of your fused <code>$score</code>. RRF scores are small (sums of <code>1/(k+rank)</code> terms), while decay functions return values in <code>[0, 1]</code>, so an unweighted decay term will dominate the fused score unless you multiply it by a smaller coefficient. Wrap the decay in a multiplication expression with a coefficient tuned to your workload.</aside>
 
 The [Choosing a Fusion Method notebook](https://githubtocolab.com/qdrant/examples/blob/master/fusion-methods/Choosing_a_Fusion_Method.ipynb) shows this pattern end-to-end with exponential decay on a `published_at` payload field. For full formula query and decay function syntax, see the [Search Relevance reference](/documentation/search/search-relevance/).
+
+<aside role="status">Because this pattern puts the fusion inside a prefetch, multi-shard collections compute that fusion per shard, not globally. See <a href="#fusion-in-distributed-collections">Fusion in Distributed Collections</a>.</aside>
 
 ## Grouping
 

--- a/qdrant-landing/content/documentation/search/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/search/hybrid-queries.md
@@ -117,12 +117,6 @@ For a deeper breakdown of when to prefer each, see the [FAQ on RRF vs. DBSF](/do
 <aside role="status">A common request is "alpha-weighted linear combination of dense and sparse scores." This is unreliable without first normalizing the scores: dense (cosine, bounded) and sparse (BM25, unbounded) scores live on different scales that also shift per query, so a fixed alpha over raw scores tends to be dominated by whichever retriever has larger raw magnitudes on a given query. RRF sidesteps this by using ranks. DBSF sidesteps it by normalizing distributions.</aside>
 
 
-### Fusion in Distributed Collections
-
-In a multi-shard collection, a fusion merges results across all shards only when it is the main query. A fusion nested inside a prefetch runs independently on each shard and fuses that shard's local results, so the ranking is per shard rather than global. A fusion is nested whenever the main query is something else, such as a formula query or an outer fusion.
-
-To fuse across shards, make the fusion the main query, as in the [RRF](#reciprocal-rank-fusion-rrf) and [DBSF](#distribution-based-score-fusion-dbsf) examples above. A main query runs a single operation, so keeping a formula rescore over a fused result requires a single shard.
-
 ## Multi-Stage Queries
 
 In general, larger vector representations give more accurate search results, but makes them more expensive to compute.
@@ -169,7 +163,11 @@ A formula query lets you compose a final score from prefetch scores (`$score`), 
 
 The [Choosing a Fusion Method notebook](https://githubtocolab.com/qdrant/examples/blob/master/fusion-methods/Choosing_a_Fusion_Method.ipynb) shows this pattern end-to-end with exponential decay on a `published_at` payload field. For full formula query and decay function syntax, see the [Search Relevance reference](/documentation/search/search-relevance/).
 
-<aside role="status">Because this pattern puts the fusion inside a prefetch, multi-shard collections compute that fusion per shard, not globally. See <a href="#fusion-in-distributed-collections">Fusion in Distributed Collections</a>.</aside>
+### Fusion in Distributed Collections
+
+The previous example puts the fusion inside a prefetch. In a multi-shard collection, a fusion merges results across all shards only when it is the main query, held in the top-level `query` field with the retrievers as its prefetches, as in the [RRF](#reciprocal-rank-fusion-rrf) and [DBSF](#distribution-based-score-fusion-dbsf) examples. When it instead sits inside a prefetch, each shard computes the fusion on its local results, so the fused ranking is per shard rather than global.
+
+To fuse across shards, make the fusion the main query. A main query is a single operation, so it cannot be both a fusion and a formula. To keep a formula rescore over fused results, use a single shard.
 
 ## Grouping
 


### PR DESCRIPTION
**Preview:** https://deploy-preview-2500--condescending-goldwasser-91acf0.netlify.app/documentation/search/hybrid-queries/#fusion-in-distributed-collections

Adds a note to the Hybrid Queries page: in a multi-shard collection, a fusion merges globally only when it's the main query. Nested inside a prefetch, it runs per shard on that shard's local results.

```json
// Global: fusion is the main query, so it merges over global positions
{ "prefetch": [ dense, bm25 ],
  "query": { "rrf": {} } }

// Per shard: fusion nested under another main query, so it runs inside each shard
{ "prefetch": {
    "prefetch": [ dense, bm25 ],
    "query": { "rrf": {} }
  },
  "query": { "formula": { /* rescore */ } } }
```

A formula is the common reason to nest a fusion, but it isn't the cause: any nested fusion runs per shard, including under an outer fusion or a vector rescore.

**Why:** documents current behavior (only the top-level fusion is merged across shards) that the docs don't cover today, and that can change ranking on the fusion-under-formula pattern the page itself shows.

New `### Fusion in Distributed Collections` subsection, placed right after the formula example that nests a fusion in a prefetch.

Repro + diagram: https://claude.ai/code/artifact/14e4a5e9-0925-45d7-b928-28a1840e776a

🤖 Generated with [Claude Code](https://claude.com/claude-code)