### PR TITLE
Document `max_disk_usage_percent` for Strict Mode

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/_description.md
@@ -1,0 +1,1 @@
+This code snippet sets `max_disk_usage_percent` on the strict mode configuration to reject disk-consuming write operations (upsert, set/overwrite payload, update vectors) when filesystem usage exceeds the given percentage. Delete operations remain allowed so it is still possible to free disk space.

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/bash.sh
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/bash.sh
@@ -1,0 +1,8 @@
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "max_disk_usage_percent": 90
+    }
+  }'

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/csharp.cs
@@ -1,0 +1,15 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.CreateCollectionAsync(
+		  collectionName: "{collection_name}",
+		  strictModeConfig: new StrictModeConfig { Enabled = true, MaxDiskUsagePercent = 90 }
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/bash.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/bash.md
@@ -1,0 +1,10 @@
+```bash
+curl -X PUT http://localhost:6333/collections/{collection_name} \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "strict_mode_config": {
+      "enabled": true,
+      "max_disk_usage_percent": 90
+    }
+  }'
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/csharp.md
@@ -1,0 +1,11 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.CreateCollectionAsync(
+  collectionName: "{collection_name}",
+  strictModeConfig: new StrictModeConfig { Enabled = true, MaxDiskUsagePercent = 90 }
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/go.md
@@ -1,0 +1,20 @@
+```go
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+  Host: "localhost",
+  Port: 6334,
+})
+
+client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+  CollectionName: "{collection_name}",
+  StrictModeConfig: &qdrant.StrictModeConfig{
+    Enabled: qdrant.PtrOf(true),
+    MaxDiskUsagePercent: qdrant.PtrOf(uint32(90)),
+  },
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/java.md
@@ -1,0 +1,18 @@
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client
+    .createCollectionAsync(
+        CreateCollection.newBuilder()
+            .setCollectionName("{collection_name}")
+            .setStrictModeConfig(
+                StrictModeConfig.newBuilder().setEnabled(true).setMaxDiskUsagePercent(90).build())
+            .build())
+    .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/python.md
@@ -1,0 +1,10 @@
+```python
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, max_disk_usage_percent=90),
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/rust.md
@@ -1,0 +1,13 @@
+```rust
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+client
+    .create_collection(
+        CreateCollectionBuilder::new("{collection_name}")
+            .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).max_disk_usage_percent(90u32)),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/generated/typescript.md
@@ -1,0 +1,12 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    max_disk_usage_percent: 90,
+  },
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/go.go
@@ -1,0 +1,24 @@
+package snippet
+
+import (
+  "context"
+
+  "github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+	  Host: "localhost",
+	  Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
+	  CollectionName: "{collection_name}",
+	  StrictModeConfig: &qdrant.StrictModeConfig{
+	    Enabled: qdrant.PtrOf(true),
+	    MaxDiskUsagePercent: qdrant.PtrOf(uint32(90)),
+	  },
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/http.md
@@ -1,0 +1,9 @@
+```http
+PUT /collections/{collection_name}
+{
+    "strict_mode_config": {
+        "enabled": true,
+        "max_disk_usage_percent": 90
+    }
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/java.java
@@ -1,0 +1,22 @@
+package com.example.snippets_amalgamation;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.CreateCollection;
+import io.qdrant.client.grpc.Collections.StrictModeConfig;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client
+                    .createCollectionAsync(
+                        CreateCollection.newBuilder()
+                            .setCollectionName("{collection_name}")
+                            .setStrictModeConfig(
+                                StrictModeConfig.newBuilder().setEnabled(true).setMaxDiskUsagePercent(90).build())
+                            .build())
+                    .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/python.py
@@ -1,0 +1,8 @@
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(url="http://localhost:6333")
+
+client.create_collection(
+    collection_name="{collection_name}",
+    strict_mode_config=models.StrictModeConfig(enabled=True, max_disk_usage_percent=90),
+)

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/rust.rs
@@ -1,0 +1,15 @@
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, StrictModeConfigBuilder};
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    client
+        .create_collection(
+            CreateCollectionBuilder::new("{collection_name}")
+                .strict_mode_config(StrictModeConfigBuilder::default().enabled(true).max_disk_usage_percent(90u32)),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/strict-mode/max-disk-usage-percent/typescript.ts
@@ -1,0 +1,10 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.createCollection("{collection_name}", {
+  strict_mode_config: {
+    enabled: true,
+    max_disk_usage_percent: 90,
+  },
+});

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -187,6 +187,16 @@ Setting `max_collection_vector_size_bytes` and/or `max_collection_payload_size_b
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/max-collection-storage-size-bytes/" >}}
 
+### Maximum Disk Usage
+
+*Available as of v1.19.0*
+
+When a node is running low on disk space, new write operations can destabilize the cluster.
+
+Setting `max_disk_usage_percent` rejects disk-consuming write operations (such as upsert, set/overwrite payload, and update vectors) when filesystem usage exceeds the given percentage. Delete operations are not affected, so callers can still free disk space. Accepts values in the range 1–100.
+
+{{< code-snippet path="/documentation/headless/snippets/strict-mode/max-disk-usage-percent/" >}}
+
 ### Maximum Resident Memory Usage
 
 When a node is under memory pressure, new write operations can destabilize the cluster.

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -193,7 +193,7 @@ Setting `max_collection_vector_size_bytes` and/or `max_collection_payload_size_b
 
 When a node is running low on disk space, new write operations can destabilize the cluster.
 
-Setting `max_disk_usage_percent` rejects disk-consuming write operations (such as upsert, set/overwrite payload, and update vectors) when filesystem usage exceeds the given percentage. Delete operations are not affected, so callers can still free disk space. Accepts values in the range 1–100.
+Setting `max_disk_usage_percent` rejects disk-consuming write operations (such as upsert, set/overwrite payload, and update vectors) when filesystem usage exceeds the given percentage. Delete operations are not affected, so it is still possible to free disk space. Accepts values in the range 1–100.
 
 {{< code-snippet path="/documentation/headless/snippets/strict-mode/max-disk-usage-percent/" >}}
 


### PR DESCRIPTION
## Overview

### [Preivew](https://deploy-preview-2504--condescending-goldwasser-91acf0.netlify.app/documentation/ops-configuration/administration/#maximum-disk-usage)

This PR documents the new `max_disk_usage_percent` strict mode guardrail for `1.19` that rejects disk-consuming write operations once filesystem usage exceeds the configured percentage. Adds a "Maximum Disk Usage" subsection to the Strict Mode admin docs and a runnable code-snippet set across the clients.