### PR TITLE
remove unused mailchimp config

### DIFF
--- a/qdrant-landing/config.toml
+++ b/qdrant-landing/config.toml
@@ -62,12 +62,6 @@ disableKinds = ["taxonomy", "term"]
   email = "info@qdrant.tech"
   location = "Berlin"
 
-  mailchimp_contact_form = "https://qdrant.to/contact-us"
-
-  mailchimp_subscribe = "https://tech.us1.list-manage.com/subscribe/post?u=69617d79374ac6280dd2230b2&amp;id=acb2b876fc"
-
-  mailchimp_subscribe_id = "b_69617d79374ac6280dd2230b2_acb2b876fc"
-
   prices_contact_form = "https://share-eu1.hsforms.com/1olUNSzuRRWWXxKJevWfxiA2b46ng"
 
   gdpr = "We use cookies to learn more about you. At any time you can delete or block cookies through your browser settings."


### PR DESCRIPTION
potentially could be used to send submissions by bots etc.