### PR TITLE
Point Essentials Course Day 4 Colab link at qdrant/examples

### DIFF
--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -133,5 +133,5 @@ This architecture strikes a balance by keeping infrastructure costs low by minim
 > This open-source repository includes full scripts for downloading, processing, and uploading the LAION-400M dataset to Qdrant using efficient, production-ready patterns.
 
 > **Want to try this workflow hands-on?**  
-> Run the [Google Colab notebook](https://colab.research.google.com/drive/1X4EW-nymqcsyhwFYS2ZrmE8MPSnKKj62?usp=sharing) to see large-scale vector ingestion, quantized search, and efficient RAM/disk optimization in action!
+> Run the [Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb) to see large-scale vector ingestion, quantized search, and efficient RAM/disk optimization in action!
 


### PR DESCRIPTION
**[PREVIEW](https://deploy-preview-2508--condescending-goldwasser-91acf0.netlify.app/course/essentials/day-4/large-scale-ingestion/)**

Repoints the **Day 4 (Large-Scale Data Ingestion)** Colab link in the Qdrant Essentials Course from a personal Google Drive notebook to the versioned notebook in `qdrant/examples`.

Before: `.../drive/1X4EW-...`
After: `.../github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb`


Day 4 was the only Essentials Course demo whose notebook wasn't in `qdrant/examples` (days 1, 2, 3, 5 all already are). Now every course notebook is versioned in one repo and referenceable via the Colab `github/` path.

Merge order:

The new Colab URL resolves against `master`, so it 404s until the companion PR merges. **Merge qdrant/examples#109 first** (adds the notebook), then this one.