### PR TITLE
Optional code snippet checks for PRs not targeting master

### DIFF
--- a/.github/workflows/snippets.yml
+++ b/.github/workflows/snippets.yml
@@ -25,6 +25,8 @@ jobs:
           fi
 
   typecheck-snippets:
+    if: >
+      !(contains(github.event.pull_request.labels.*.name, 'skip snippet check') && github.event.pull_request.base.ref != 'master')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Code snippet type checks on PRs that target the next release, before the updated clients are published, are expected to fail. Running the checks anyway just adds noise.

This PR makes type checks optional for PRs that do not target `master` (e.g. targeting `version-1.19`). To skip the type check, apply the `skip snippet check` label. 

PRs that target `master` should always be type checked.

Summarizing the change:

- PR targets `master`, label attached → job still runs — the label has no effect on `master`, so the check can't be bypassed there.
- PR targets another branch, label attached → job skipped → counts as passing.
- PR targets another branch (or `master`), no label → job runs normally.
