### PR TITLE
Add scale-ceiling note to incremental embedding updates tutorial

### DIFF
--- a/qdrant-landing/content/documentation/tutorials-operations/incremental-embedding-updates.md
+++ b/qdrant-landing/content/documentation/tutorials-operations/incremental-embedding-updates.md
@@ -33,6 +33,11 @@ The pattern applies when your chunking is deterministic and enumerating the curr
 
 The tutorial has an accompanying [notebook](https://github.com/qdrant/examples/blob/master/temporal-data-drift/sync_raw_data_to_embeddings.ipynb).
 
+<aside role="alert">
+<p><strong>Scale note.</strong> This design re-reads the whole collection every run: it pulls every point's hash and diffs the full stored set against the incoming one, so per-run cost scales with corpus size, not with what changed. Around 100k chunks it stays cheap. By ~1M points each run moves hundreds of MB and hits Qdrant's 32 MB request cap (<a href="/documentation/ops-configuration/configuration/"><code>max_request_size_mb</code></a>); batching only splits the same full scan into more round trips. You scan the whole corpus to update a handful of chunks.</p>
+<p>A follow-up edition will cover a version that groups chunks into hash buckets and checks only the buckets that changed, so cost stays flat as the corpus grows.</p>
+</aside>
+
 ## Prerequisites
 
 Install the [Qdrant client of your choice](/documentation/interfaces/#client-libraries).

--- a/qdrant-landing/content/documentation/tutorials-operations/incremental-embedding-updates.md
+++ b/qdrant-landing/content/documentation/tutorials-operations/incremental-embedding-updates.md
@@ -34,8 +34,9 @@ The pattern applies when your chunking is deterministic and enumerating the curr
 The tutorial has an accompanying [notebook](https://github.com/qdrant/examples/blob/master/temporal-data-drift/sync_raw_data_to_embeddings.ipynb).
 
 <aside role="alert">
-<p><strong>Scale note.</strong> This design re-reads the whole collection every run: it pulls every point's hash and diffs the full stored set against the incoming one, so per-run cost scales with corpus size, not with what changed. Around 100k chunks it stays cheap. By ~1M points each run moves hundreds of MB and hits Qdrant's 32 MB request cap (<a href="/documentation/ops-configuration/configuration/"><code>max_request_size_mb</code></a>); batching only splits the same full scan into more round trips. You scan the whole corpus to update a handful of chunks.</p>
-<p>A follow-up edition will cover a version that groups chunks into hash buckets and checks only the buckets that changed, so cost stays flat as the corpus grows.</p>
+<p><strong>Scale note.</strong>  This design re-reads the whole collection on every run: it pulls every point's hash and diffs the full stored set against the incoming one. Per-run cost scales with corpus size, not with what actually changed.</p>
+<p>At around 100,000 points, this stays cheap. By around 1 million points, each run moves hundreds of MB and hits Qdrant's 32 MB request cap (<a href="/documentation/ops-configuration/configuration/"><code>max_request_size_mb</code></a>). Batching doesn't help — it just splits the same full scan into more round trips. The result: a full corpus scan to update a handful of chunks.</p>
+<p>A follow-up post will cover a version that groups chunks into hash buckets and checks only the buckets that changed, so cost stays flat as the corpus grows.</p>
 </aside>
 
 ## Prerequisites


### PR DESCRIPTION
Adds a scale note after the intro: the whole-corpus-per-run design is fine to ~100k chunks and hits Qdrant's 32 MB request cap (`max_request_size_mb`) around ~1M points; flags a bucketed follow-up edition. Companion notebook note: qdrant/examples PR on branch incremental-embedding-updates-scale-note.