### PR TITLE
Update Qdrant Setup video and fix course landing order

### DIFF
--- a/qdrant-landing/content/course/essentials/_index.md
+++ b/qdrant-landing/content/course/essentials/_index.md
@@ -3,6 +3,7 @@ title: "Qdrant Essentials Course"
 page_title: Qdrant Essentials Course
 short_description: "Build production vector search skills in seven days: hybrid retrieval, multivector reranking, quantization, sharding, and multitenancy."
 description: Learn hybrid search, multivectors, and production deployment in 7 days. Build and ship a docs search engine.
+weight: 10
 content:
   sidebarTitle: Qdrant Essentials
   menuTitle:

--- a/qdrant-landing/content/course/essentials/day-0/qdrant-cloud.md
+++ b/qdrant-landing/content/course/essentials/day-0/qdrant-cloud.md
@@ -12,7 +12,7 @@ isLesson: true
 
 <div class="video">
 <iframe 
-  src="https://www.youtube.com/embed/9JBlgNBQoOY?si=7t3LAvMsUUtlUMN7&rel=0"
+  src="https://www.youtube.com/embed/-8TpooWX8kE?rel=0"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerpolicy="strict-origin-when-cross-origin"

--- a/qdrant-landing/content/course/multi-vector-search/_index.md
+++ b/qdrant-landing/content/course/multi-vector-search/_index.md
@@ -3,6 +3,7 @@ title: "Multi-Vector Search Course"
 page_title: "Qdrant Multi-Vector Search Course"
 short_description: "Master multi-vector search with ColBERT and ColPali: late interaction, MaxSim scoring, multi-stage retrieval, MUVERA indexing, and evaluation."
 description: Master late interaction models, ColPali, and production optimization. Build scalable multi-vector search pipelines.
+weight: 20
 content:
   sidebarTitle: "Multi-Vector Search Course"
   menuTitle:

--- a/qdrant-landing/content/course/multi-vector-search/module-0/qdrant-setup.md
+++ b/qdrant-landing/content/course/multi-vector-search/module-0/qdrant-setup.md
@@ -10,6 +10,18 @@ isLesson: true
 
 # Qdrant Setup
 
+<div class="video">
+<iframe
+  src="https://www.youtube.com/embed/-8TpooWX8kE?rel=0"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerpolicy="strict-origin-when-cross-origin"
+  allowfullscreen>
+</iframe>
+</div>
+
+<br/>
+
 Before diving into multi-vector search, you need a running Qdrant instance. Whether you choose Qdrant Cloud for a managed solution or a local deployment, this lesson will get you up and running.
 
 Multi-vector search requires specific collection configurations that differ from traditional single-vector setups. We'll cover the essentials to prepare your environment.


### PR DESCRIPTION
- Swap the Qdrant Setup video in the Essentials course, and add the same video to Multi-Vector Search's Qdrant Setup lesson (previously had none)
- Add explicit weight to Essentials and Multi-Vector Search course sections so Essentials always sorts first in the course sidebar, instead of relying on date as a tiebreaker