### PR TITLE
docs: remove Getting Started webinar promo from Overview page

### DIFF
--- a/qdrant-landing/content/documentation/overview/_index.md
+++ b/qdrant-landing/content/documentation/overview/_index.md
@@ -11,11 +11,6 @@ aliases:
 partition: develop
 ---
 
-<aside role="status">
-  Qdrant offers a bi-weekly "Getting Started" live webinar with experts. 
-  Register for an upcoming session <a href="https://tinyurl.com/qdrant-onboarding" target="_blank" rel="noopener noreferrer">here</a>!
-</aside>
-
 # Qdrant Overview
 
 ## Welcome! {#welcome}


### PR DESCRIPTION
## [PREVIEW](https://deploy-preview-2561--condescending-goldwasser-91acf0.netlify.app/documentation/overview/)

Removes the `<aside>` at the top of the documentation Overview page promoting the bi-weekly "Getting Started" live webinar and its `tinyurl.com/qdrant-onboarding` registration link. The page now opens directly with the "Qdrant Overview" heading. This was the only reference to it in the repo — no generated files or anchors pointed at the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)