### PR TITLE
Make documentation CTAs configurable

### DIFF
--- a/qdrant-landing/content/documentation/manage-data/collections.md
+++ b/qdrant-landing/content/documentation/manage-data/collections.md
@@ -3,7 +3,7 @@ title: Collections
 short_description: "Create and configure Qdrant collections — named sets of points sharing vector dimensions and a distance metric."
 description: "Configure Qdrant collections, define named vectors with configurable distance metrics, and manage the building blocks of vector search at the collection level."
 weight: 20
-cta: "Create your first collection in Qdrant Cloud. Free, no card needed."
+cta: "Create your first collection in Qdrant Cloud. Free, no payment needed."
 aliases:
   - ../collections
   - /concepts/collections/

--- a/qdrant-landing/content/documentation/manage-data/collections.md
+++ b/qdrant-landing/content/documentation/manage-data/collections.md
@@ -3,6 +3,7 @@ title: Collections
 short_description: "Create and configure Qdrant collections — named sets of points sharing vector dimensions and a distance metric."
 description: "Configure Qdrant collections, define named vectors with configurable distance metrics, and manage the building blocks of vector search at the collection level."
 weight: 20
+cta: "Create your first collection in Qdrant Cloud. Free, no card needed."
 aliases:
   - ../collections
   - /concepts/collections/

--- a/qdrant-landing/content/documentation/manage-data/indexing.md
+++ b/qdrant-landing/content/documentation/manage-data/indexing.md
@@ -3,6 +3,7 @@ title: Indexing
 short_description: "Combine HNSW vector indexes with payload indexes in Qdrant for fast filtered search across structured fields."
 description: "Configure HNSW vector indexes and payload indexes in Qdrant to accelerate similarity search with filters on structured fields and high-cardinality metadata."
 weight: 30
+cta: "Run indexed search on your own vectors in the Cloud."
 aliases:
   - ../indexing
 ---

--- a/qdrant-landing/content/documentation/manage-data/multitenancy.md
+++ b/qdrant-landing/content/documentation/manage-data/multitenancy.md
@@ -3,6 +3,7 @@ title: Multitenancy
 short_description: "Partition tenants in a single Qdrant collection with payload-based filtering and per-tenant indexes for clean isolation."
 description: "Set up Qdrant multitenancy with payload-based partitioning and per-tenant indexes for tenant isolation, predictable performance, and lower cluster overhead."
 weight: 40
+cta: "Set up tenant isolation on a free Cloud cluster in minutes."
 aliases:
   - ../tutorials/multiple-partitions
   - /tutorials/multiple-partitions/

--- a/qdrant-landing/content/documentation/manage-data/payload.md
+++ b/qdrant-landing/content/documentation/manage-data/payload.md
@@ -3,6 +3,7 @@ title: Payload
 short_description: "Attach JSON payloads to Qdrant points to store metadata alongside vectors and filter or rank results on it."
 description: "Store JSON payloads alongside vectors in Qdrant, then use them for filtering, faceting, and result ranking to combine metadata with semantic similarity search."
 weight: 15
+cta: "See payload filtering in action on a live cluster."
 aliases:
   - ../payload
   - /documentation/concepts/payload/

--- a/qdrant-landing/content/documentation/manage-data/points.md
+++ b/qdrant-landing/content/documentation/manage-data/points.md
@@ -3,6 +3,7 @@ title: Points
 short_description: "Insert, update, and delete points in Qdrant — the core records that pair a vector with an optional payload."
 description: "Manage points in Qdrant collections by upserting, updating, deleting, and retrieving records that combine a vector with an optional JSON payload for search."
 weight: 5
+cta: "Try uploading your first points to a live collection."
 aliases:
   - ../points
   - /documentation/concepts/points/

--- a/qdrant-landing/content/documentation/manage-data/quantization.md
+++ b/qdrant-landing/content/documentation/manage-data/quantization.md
@@ -3,6 +3,7 @@ title: Quantization
 short_description: "Compress vectors with scalar, product, or binary quantization to shrink memory use and speed up Qdrant search."
 description: "Apply quantization in Qdrant to compress high-dimensional vectors, reduce memory footprint, and accelerate similarity search while preserving recall quality."
 weight: 35
+cta: "Benchmark quantization on your data without any setup."
 aliases:
   - ../quantization
   - /articles/dedicated-service/documentation/guides/quantization/

--- a/qdrant-landing/content/documentation/manage-data/storage.md
+++ b/qdrant-landing/content/documentation/manage-data/storage.md
@@ -3,6 +3,7 @@ title: Storage
 short_description: "Tune how Qdrant stores vectors and payloads across segments, with options for in-memory, mmap, and on-disk storage."
 description: "Configure Qdrant storage across segments, balancing in-memory, memory-mapped, and on-disk options for vectors and payloads to fit cost and latency goals."
 weight: 25
+cta: "Try on-disk storage options without managing infrastructure."
 aliases:
   - ../storage
 ---

--- a/qdrant-landing/content/documentation/manage-data/vectors.md
+++ b/qdrant-landing/content/documentation/manage-data/vectors.md
@@ -3,6 +3,7 @@ title: Vectors
 short_description: "Configure dense, sparse, and multivector representations in Qdrant to model text, images, and multimodal data."
 description: "Define dense, sparse, and multivector configurations in Qdrant collections to support text, image, multimodal, and late-interaction retrieval like ColBERT."
 weight: 10
+cta: "Try dense and sparse vectors with your own data in Cloud."
 aliases:
   - /vectors
 ---

--- a/qdrant-landing/content/documentation/search/explore.md
+++ b/qdrant-landing/content/documentation/search/explore.md
@@ -3,6 +3,7 @@ title: Explore
 short_description: "Explore Qdrant data beyond similarity search with recommendation, discovery, and dissimilar-vector search APIs."
 description: "Use Qdrant's exploration APIs for recommendation, discovery, and dissimilar-vector search to power data discovery, cleaning, and personalized retrieval."
 weight: 20
+cta: "Try recommendation queries on a live cluster."
 aliases:
   - ../explore
 ---

--- a/qdrant-landing/content/documentation/search/filtering.md
+++ b/qdrant-landing/content/documentation/search/filtering.md
@@ -3,6 +3,7 @@ title: Filtering
 short_description: "Combine vector similarity with payload filters in Qdrant to enforce business rules and refine search results."
 description: "Filter Qdrant search results with payload conditions on metadata and IDs, combining database-style clauses with vector similarity for precise retrieval."
 weight: 10
+cta: "Try filtered vector search on a free Cloud cluster."
 aliases:
   - ../filtering
 ---

--- a/qdrant-landing/content/documentation/search/hybrid-queries.md
+++ b/qdrant-landing/content/documentation/search/hybrid-queries.md
@@ -3,6 +3,7 @@ title: Hybrid Queries
 short_description: "Combine dense, sparse, and multivector queries in Qdrant with hybrid search, weighted RRF tuning, DBSF, and multi-stage rescoring with Formula Query."
 description: "Run hybrid queries in Qdrant: fuse dense, sparse, and multivector results with RRF or DBSF, layer custom scoring with Formula Query, and pick the right method for your data."
 weight: 15
+cta: "Run hybrid queries on a free Cloud cluster."
 aliases:
   - ../hybrid-queries
 hideInSidebar: false

--- a/qdrant-landing/content/documentation/search/low-latency-search.md
+++ b/qdrant-landing/content/documentation/search/low-latency-search.md
@@ -3,6 +3,7 @@ title: Low-Latency Search
 short_description: "Tune Qdrant for low-latency vector search with quantization, HNSW indexing, sharding, and replica routing strategies."
 description: "Reduce Qdrant search latency by tuning HNSW indexes, quantization, sharding, and replica routing for fast vector retrieval in distributed deployments."
 weight: 35
+cta: "Experience low-latency search. Spin up a free cluster in minutes."
 aliases:
   - /documentation/guides/low-latency-search/
 ---

--- a/qdrant-landing/content/documentation/search/search-relevance.md
+++ b/qdrant-landing/content/documentation/search/search-relevance.md
@@ -3,6 +3,7 @@ title: Search Relevance
 short_description: "Tune Qdrant search relevance with custom scoring, payload-based ranking, and business-aware result ordering."
 description: "Tune search relevance in Qdrant by adjusting scoring, applying payload-based ranking, and incorporating business signals to reorder vector search results."
 weight: 30
+cta: "Tune search relevance on a free Qdrant Cloud cluster."
 aliases:
   - /documentation/concepts/search-relevance/
 ---

--- a/qdrant-landing/content/documentation/search/search.md
+++ b/qdrant-landing/content/documentation/search/search.md
@@ -3,6 +3,7 @@ title: Search
 short_description: "Run similarity search in Qdrant to find points whose vectors are nearest to a query in the configured vector space."
 description: "Run similarity search in Qdrant to retrieve nearest-neighbor points for text, image, and multimodal queries using configurable distance metrics and HNSW."
 weight: 5
+cta: "Run your first similarity search. Free, no infrastructure needed."
 aliases:
   - ../search
   - /documentation/concepts/search/

--- a/qdrant-landing/content/documentation/search/text-search/_index.md
+++ b/qdrant-landing/content/documentation/search/text-search/_index.md
@@ -3,6 +3,7 @@ title: Text Search
 short_description: "Combine semantic vector search with lexical text features in Qdrant, including BM25 and full-text payload filters."
 description: "Run text search in Qdrant by mixing semantic vector retrieval with BM25 lexical search and full-text payload filters for robust hybrid search experiences."
 weight: 25
+cta: "Test full-text and vector search together in Qdrant Cloud."
 aliases:
   - ../text-search
   - /documentation/guides/text-search/

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/documentation/footer.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/documentation/footer.html
@@ -4,7 +4,7 @@
   <footer class="docs-footer w-100 py-0 pt-0 pb-4 pb-xl-0">
     {{ if not (eq $currentPage.Section "course") }}
       <div class="docs-footer__cta">
-        <h4>{{ .Params.question }}</h4>
+        <h4>{{ if $currentPage.Params.cta }}{{ $currentPage.Params.cta }}{{ else }}{{ .Params.question }}{{ end }}</h4>
         <a href="{{ .Params.questionButton.url }}" class="button button_outlined button_sm" target="_blank">
           {{ .Params.questionButton.text }}
         </a>


### PR DESCRIPTION
Makes the CTA at the bottom of every documentation page configurable, so we can have per-page contextual CTAs. 

Configure a `cta` parameter with a string value on a page's frontmatter, and that string will be used as the CTA. If no `cta` is configured, we'll fall back to the default CTA, _"Ready to get started with Qdrant?"_

This PR also configures a custom CTA for the "Manage Data" and "Search" pages.

Previews (scroll to the bottom):

- [Custom CTA on Multitenancy page](https://deploy-preview-2562--condescending-goldwasser-91acf0.netlify.app/documentation/manage-data/multitenancy/#limitations-1)
- [Fallback to default CTA on Inference page](https://deploy-preview-2562--condescending-goldwasser-91acf0.netlify.app/documentation/inference/#choose-your-approach)