### PR TITLE
docs: refine RocketRide platform positioning

### DIFF
--- a/qdrant-landing/content/documentation/frameworks/_index.md
+++ b/qdrant-landing/content/documentation/frameworks/_index.md
@@ -39,7 +39,7 @@ aliases: ["/documentation/frameworks/memgpt/"]
 | [Neo4j GraphRAG](/documentation/frameworks/neo4j-graphrag/)   | Package to build graph retrieval augmented generation (GraphRAG) applications using Neo4j and Python.                |
 | [NLWeb](/documentation/frameworks/nlweb/)                     | A framework to turn websites into chat-ready data using schema.org and associated data formats.                      |
 | [Rig-rs](/documentation/frameworks/rig-rs/)                   | Rust library for building scalable, modular, and ergonomic LLM-powered applications.                                 |
-| [RocketRide](/documentation/frameworks/rocketride/)           | Open-source AI development environment and C++ runtime for building RAG pipelines and agents with Qdrant.             |
+| [RocketRide](/documentation/frameworks/rocketride/)           | Developer platform for building, deploying, and operating production AI systems.                                     |
 | [Semantic Router](/documentation/frameworks/semantic-router/) | Python library to build a decision-making layer for AI applications using vector search.                             |
 | [SmolAgents](/documentation/frameworks/smolagents/)           | Barebones library for agents. Agents write python code to call tools and orchestrate other agent.                    |
 | [Spring AI](/documentation/frameworks/spring-ai/)             | Java AI framework for building with Spring design principles such as portability and modular design.                 |

--- a/qdrant-landing/content/documentation/frameworks/rocketride.md
+++ b/qdrant-landing/content/documentation/frameworks/rocketride.md
@@ -1,14 +1,14 @@
 ---
 title: RocketRide
-short_description: "Build RAG pipelines and AI agents with RocketRide's multithreaded C++ runtime and Qdrant for vector search, retrieval, and memory."
-description: "Use Qdrant in RocketRide to ingest embedded documents, retrieve context for RAG, and expose vector search, upsert, and delete operations to AI agents."
+short_description: "Developer platform for building, deploying, and operating production AI systems with Qdrant."
+description: "Use Qdrant in RocketRide for vector search, retrieval, memory, and agent tools in production AI systems."
 ---
 
 # RocketRide
 
-[RocketRide](https://github.com/rocketride-org/rocketride-server) is an open-source AI development environment and runtime for building, running, and integrating AI systems. Pipelines are portable JSON and execute on a multithreaded C++ engine. You can compose them in the visual IDE, run them from the CLI, integrate them through Python or TypeScript SDKs, or expose them as tools over MCP.
+[RocketRide](https://cloud.rocketride.ai/) is a developer platform for building, deploying, and operating production AI systems. It gives developers one place to compose AI workloads, run them on managed infrastructure, and observe every step in production.
 
-RocketRide's native Qdrant node stores embedded documents, retrieves context for retrieval-augmented generation (RAG), and gives agents tools for searching and updating a Qdrant collection. It supports both Qdrant Cloud and self-hosted deployments.
+Qdrant is available as a native integration for vector search, retrieval, memory, and agent tools.
 
 ## Run the RAG example
 


### PR DESCRIPTION
## Summary

- describe RocketRide as a developer platform for building and operating production AI systems
- update the framework listing, page metadata, and introduction to match that positioning
- point the primary RocketRide link to the managed product while retaining the Qdrant-focused guide and technical resources

## Why

The existing copy emphasized the C++ runtime and RAG use case, which made the integration guide read as though those defined the whole RocketRide platform. This keeps the directory description concise while leaving the rest of the page focused on how RocketRide works with Qdrant.

## Validation

- `git diff --check`
- verified `https://cloud.rocketride.ai/` returns HTTP 200
- content-only change; Hugo is not installed in the local checkout