### PR TITLE
Deprecate rag optimization with quotient

### DIFF
--- a/qdrant-landing/content/articles/rapid-rag-optimization-with-qdrant-and-quotient.md
+++ b/qdrant-landing/content/articles/rapid-rag-optimization-with-qdrant-and-quotient.md
@@ -9,7 +9,7 @@ weight: 30
 author: Atita Arora
 author_link: https://github.com/atarora
 date: 2024-06-12T00:00:00.000Z
-draft: false
+draft: true
 keywords:
 - vector database
 - vector search

--- a/qdrant-landing/content/blog/qdrant-relari.md
+++ b/qdrant-landing/content/blog/qdrant-relari.md
@@ -21,7 +21,7 @@ tags:
 
 Evaluating the performance of a [Retrieval-Augmented Generation (RAG)](/rag/) application can be a complex task for developers. 
 
-To help simplify this, Qdrant has partnered with [Relari](https://www.relari.ai) to provide an in-depth [RAG evaluation](/articles/rapid-rag-optimization-with-qdrant-and-quotient/) process.
+To help simplify this, Qdrant has partnered with [Relari](https://www.relari.ai) to provide an in-depth RAG evaluation process.
 
 As a [vector database](https://qdrant.tech), Qdrant handles the data storage and retrieval, while Relari enables you to run experiments to assess how well your RAG app performs in real-world scenarios. Together, they allow for fast, iterative testing and evaluation, making it easier to keep up with your app's development pace.
 


### PR DESCRIPTION
Unpublishes the article "Optimizing RAG Through an Evaluation-Based Methodology" (`/articles/rapid-rag-optimization-with-qdrant-and-quotient/`) by setting `draft: true`.
And removes references to the article 

## Why
Quotient has been acquired by Databricks, so the product and the integration the article walks through are no longer available. The tutorial can't be followed as written.

## Notes
- `content/course/essentials/day-7/quotient.md:121` still links to the now 404 URLs (this article, another one and quotient website) 

