### PR TITLE
[1.19] Documentation for resource quotas

### DIFF
--- a/qdrant-landing/content/documentation/common-errors.md
+++ b/qdrant-landing/content/documentation/common-errors.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
-short_description: "Diagnose and resolve common Qdrant errors, from open-file limits to incompatible file systems and corrupted collection metadata."
-description: "Troubleshoot common Qdrant runtime errors — open-file limits, POSIX file system requirements, and recovery from corrupted collection metadata."
+short_description: "Diagnose and resolve common Qdrant errors, from open-file limits and quota rejections to incompatible file systems and corrupted collection metadata."
+description: "Troubleshoot common Qdrant runtime errors: open-file limits, HTTP 507 quota rejections, POSIX file system requirements, and recovery from corrupted collection metadata."
 partition: deploy
 weight: 150
 aliases:
@@ -37,6 +37,28 @@ ulimit -n 10000
 ```
 
 Please note, the command should be executed before you run Qdrant server.
+
+## Insufficient storage (HTTP 507)
+
+*Available as of v1.19.0*
+
+When nodes have been configured with a [resource quotas](/documentation/ops-configuration/quotas/) no nodes may be availabe with replicas that accept writes. In that case, clients see an HTTP 507 Insufficient Storage, or gRPC `ResourceExhausted` error:
+
+```text
+Disk usage is at 95% of total capacity, exceeding the configured limit of 90%.
+Help: Reduce disk usage (e.g. delete points or drop collections), or raise
+`max_disk_usage_percent` in the global quota config.
+```
+
+See also: [When a Quota Is Exceeded](/documentation/ops-configuration/quotas/#when-a-quota-is-exceeded)
+
+To resolve it, either free the resource or raise the limit:
+
+- Delete points, or drop collections you no longer need. Point deletes stay allowed under a quota for exactly this reason. Deleting individual vectors or payload keys is rejected.
+- Add capacity. See [Capacity Planning](/documentation/capacity-planning/).
+- Raise the limit with `PUT /quotas`, if the quota is set lower than the node can actually handle.
+
+Writes don't resume the instant usage drops. A tripped limit clears only once usage has fallen under the [release margin](/documentation/ops-configuration/quotas/#release-margin), which defaults to 5 percentage points under the limit.
 
 ## Incompatible file system
 

--- a/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
+++ b/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
@@ -257,6 +257,12 @@ Common recovery steps:
 
 See also: [Grey collection status](/documentation/manage-data/collections/#grey-collection-status)
 
+### Why are my writes rejected with HTTP 507?
+
+An write succeeds once at least [`write_consistency_factor`](/documentation/scaling/consistency-guarantees/) replicas have accepted it. When nodes have been configured with [resource quotas](/documentation/ops-configuration/quotas/), no nodes may be availabe with replicas that accept writes. A 507 means too few replicas were left to reach the `write_consistency_factor`. With the default factor of 1, that means no replica of the shard had room.
+
+[Use `GET /quotas` to see which peer is full](/documentation/ops-configuration/quotas/#finding-the-node-that-is-full). Note that a node doesn't resume writes the moment usage drops: a tripped limit clears only once usage has fallen under the [release margin](/documentation/ops-configuration/quotas/#release-margin), five percentage points by default.
+
 ### How do I upload a large number of vectors into a Qdrant collection?
 
 Read about our recommendations in the [Bulk Upload](/documentation/manage-data/bulk-upload/) guide.

--- a/qdrant-landing/content/documentation/ops-configuration/_index.md
+++ b/qdrant-landing/content/documentation/ops-configuration/_index.md
@@ -14,9 +14,13 @@ These pages cover the settings and runtime options available for customizing and
 
 [Configuration](/documentation/ops-configuration/configuration/) describes how to customize Qdrant's behavior using config files and environment variables, covering storage paths, network interfaces, performance parameters, and feature flags.
 
+## Resource Quotas
+
+[Resource Quotas](/documentation/ops-configuration/quotas/) explains how to cap node memory and disk usage across a cluster, what happens when a node reaches a limit, and how to find the node that is full.
+
 ## Administration
 
-[Administration](/documentation/ops-configuration/administration/) covers runtime administration tools that let you modify instance behavior without restarting — including recovery mode for resolving out-of-memory situations.
+[Administration](/documentation/ops-configuration/administration/) covers runtime administration tools that let you modify instance behavior without restarting, including recovery mode for resolving out-of-memory situations, low memory mode, and strict mode.
 
 ## Usage Statistics
 

--- a/qdrant-landing/content/documentation/ops-configuration/administration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/administration.md
@@ -189,6 +189,8 @@ Setting `max_collection_vector_size_bytes` and/or `max_collection_payload_size_b
 
 ### Maximum Resident Memory Usage
 
+<aside role="alert">Deprecated as of v1.19.0. Use <a href="/documentation/ops-configuration/quotas/">resource quotas</a> to cap memory instead.</aside>
+
 When a node is under memory pressure, new write operations can destabilize the cluster.
 
 Setting `max_resident_memory_percent` rejects memory-consuming write operations (such as upsert and set payload) when process resident memory exceeds the given percentage of total system memory. Delete operations are not affected. Accepts values in the range 1–100.

--- a/qdrant-landing/content/documentation/ops-configuration/configuration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/configuration.md
@@ -367,6 +367,39 @@ storage:
   # If null - no limit.
   max_collections: null
 
+  # Cluster-wide resource quotas.
+  #
+  # Memory and disk are node-wide resources, so their limits are configured once for the whole
+  # cluster instead of per collection. Quotas reject updates that would consume more of a resource,
+  # regardless of whether strict mode is enabled for the collection being written to. The deprecated
+  # `max_resident_memory_percent` in a collection's strict mode config can tighten the memory limit
+  # for that collection, but never lift it.
+  #
+  # A limit that is reached has to be cleared by `release_margin_percent` before the node accepts
+  # writes again. Without that margin a resource resting on its limit would put the node in and out
+  # of service on the noise between two readings, restarting a shard recovery every time.
+  #
+  # If this section is absent - no quota is enforced.
+  #quotas:
+    # Whether the limits below are enforced.
+    #enabled: false
+
+    # Reject memory-consuming updates once process resident memory reaches this percentage of total
+    # system memory (or of the cgroup limit, if one applies).
+    # If null - resident memory is not capped.
+    #max_resident_memory_percent: null
+
+    # Reject disk-consuming updates once the filesystem hosting the storage directory is filled to
+    # this percentage of its capacity.
+    # If null - disk usage is not capped.
+    #max_disk_usage_percent: null
+
+    # How many percentage points below its limit a resource has to fall before this node starts
+    # accepting work again. Raise it where usage is volatile; 0 releases as soon as usage is back
+    # under the limit.
+    # If null - the built-in default of 5 applies.
+    #release_margin_percent: null
+
 service:
   # Maximum size of POST data in a single request in megabytes
   max_request_size_mb: 32

--- a/qdrant-landing/content/documentation/ops-configuration/quotas.md
+++ b/qdrant-landing/content/documentation/ops-configuration/quotas.md
@@ -1,0 +1,143 @@
+---
+title: Resource Quotas
+short_description: "Cap node memory and disk usage cluster-wide so a full node stops taking writes before it destabilizes the cluster."
+description: "Configure cluster-wide memory and disk quotas in Qdrant, understand HTTP 507 rejections and replica deactivation, and find which node in a cluster is full."
+weight: 7
+---
+
+# Resource Quotas
+
+*Available as of v1.19.0*
+
+Resource quotas stop a node from taking on more data once it's low on memory or disk space. When usage reaches a configured limit, the node rejects updates that would consume more of that resource until usage drops back down.
+
+## Configuring Quotas
+
+Quotas are disabled by default. You can configure quotas per node, or apply them to every node in a cluster via the API.
+
+To apply quotas to a node, configure `storage.quotas` in the node's configuration file:
+
+```yaml
+storage:
+  quotas:
+    enabled: true
+    max_disk_usage_percent: 90
+```
+
+Or use the environment variables:
+
+```bash
+QDRANT__STORAGE__QUOTAS__ENABLED=true
+QDRANT__STORAGE__QUOTAS__MAX_DISK_USAGE_PERCENT=90
+```
+
+To change quotas cluster-wide, use the `PUT /quotas` API:
+
+```http
+PUT /quotas?wait=true
+{
+    "enabled": true,
+    "max_disk_usage_percent": 90
+}
+```
+
+Qdrant propagates the new configuration to every peer and persists it, so it survives restarts.
+
+<aside role="status">Once the quota has been set through <code>PUT /quotas</code>, Qdrant stops reading <code>storage.quotas</code>. See <a href="#configuration-precedence">Configuration Precedence</a>.</aside>
+
+The following parameters are available:
+
+| Parameter | Description |
+| --- | --- |
+| `enabled` | Whether the limits are enforced. Defaults to `false`. |
+| `max_resident_memory_percent` | Rejects memory-consuming updates once process resident memory reaches this percentage of the memory available to the node. Accepts values in the range 1–100. If unset, no memory quota is applied. |
+| `max_disk_usage_percent` | Rejects disk-consuming updates once the file system holding the storage directory is filled to this percentage of its capacity. Accepts values in the range 1–100. If unset, no disk quota is applied. |
+| `release_margin_percent` | How far a resource has to fall under its limit before the node accepts updates again. Accepts values in the range 0–100. Defaults to 5. |
+
+Qdrant measures resident memory against the cgroup limit where one applies, and against total system memory otherwise.
+
+### Configuration Precedence
+
+Quotas set through the API take precedence over the configuration file or environment variables.
+
+Until the quota is set through the API anywhere in the cluster, Qdrant reads the configuration file on every start, so stopping a node, changing the setting, and starting it again applies the new quota. A node joining a cluster whose quota was already set through the API receives that configuration through consensus instead, and its own configuration file stops being read.
+
+### When Nodes Have Different Quotas
+
+Each node resolves its own quota, and Qdrant neither compares them across peers nor warns you when they differ. Enforcement is per node: a node that reached the limit rejects updates to the replicas it holds. When a shard is replicated elsewhere, Qdrant deactivates the local replica and the update is applied on the other node.
+
+To ensure a uniform quota across all nodes, use the `PUT /quotas` API.
+
+## When a Quota Is Exceeded
+
+A quota stops a node from storing data, not from serving requests. Read operations are never affected. For writes, a node over its limit still accepts and coordinates updates, so sending a write to a full node is not a problem in itself. If the node you send a request to doesn't hold a replica of the shard being written to, its own quota doesn't apply at all.
+
+When an update reaches a shard on a full node, Qdrant excludes that replica, and records that exclusion as a failure of that node. The update as a whole still succeeds if at least [`write_consistency_factor`](/documentation/scaling/consistency-guarantees/#write-consistency-factor) replicas accept it. By default, `write_consistency_factor` equals `1`, so a single healthy replica is enough and the client gets a normal success response.
+
+Qdrant then marks the excluded replica dead. It stays inactive and doesn't request shard recovery until the node has room again. Raising `write_consistency_factor` above the number of replicas that still have room turns the same write into an error instead.
+
+Clients see HTTP 507 Insufficient Storage, or gRPC `ResourceExhausted` errors, when no replica is available to accept a write. That happens when the shard has a single replica and it's on the full node, or when every replica of the shard is on a node over its limit. The error names the resource, its current utilization, and the configured limit:
+
+```text
+Disk usage is at 95% of total capacity, exceeding the configured limit of 90%.
+Help: Reduce disk usage (e.g. delete points or drop collections), or raise
+`max_disk_usage_percent` in the global quota config.
+```
+
+While a node hasn't recovered from exceeding its quotas:
+
+- **Deleting points is always allowed.** On a full node it's the way back under the limit.
+- **Deleting a vector or a payload key isn't allowed.** Internally, Qdrant rewrites the point to drop the field, so storage grows before anything is reclaimed.
+- **Shard transfers are always allowed.** Qdrant checks free space once before a transfer starts, so rejecting its batches partway would abandon work that is nearly done.
+
+### Finding the Node That Is Full
+
+Use the `GET /quotas` API to check quotas on the whole cluster:
+
+```json
+{
+  "config": {"enabled": true, "max_disk_usage_percent": 90},
+  "usage":  {"resident_memory_percent": 12, "disk_usage_percent": 46},
+  "peers": {
+    "3421...": {"resident_memory_percent": 12, "disk_usage_percent": 46, "exceeded": false},
+    "7719...": {"resident_memory_percent": 9,  "disk_usage_percent": 91, "exceeded": true}
+  }
+}
+```
+
+In the response:
+- `config` is the quota configuration of the node that served the request.
+- `usage` reports the current memory and disk usage for that same node.
+- `peers` is what each peer reports about itself, keyed by peer ID. A peer that doesn't answer is left out rather than failing the call, so treat a missing peer as a signal: the nodes that are out of room are the ones most likely to time out. If not running in distributed mode, `peers` is absent.
+
+<aside role="status">A peer can report <code>exceeded</code> as <code>true</code> while the utilization it reports is already back under the configured limit. That's the <a href="#release-margin">release margin</a> holding the limit until usage has fallen far enough, not an inconsistency.</aside>
+
+To find out which collections account for the usage, see [Monitor Collection Memory Usage](/documentation/ops-monitoring/memory-usage/).
+
+## Release Margin
+
+A limit trips as soon as usage reaches it, but only clears once usage has fallen `release_margin_percent` percentage points below it. With the default margin of 5, a node with `max_disk_usage_percent` set to 90 stops taking writes at 90% and starts again below 85%.
+
+Changing the quota configuration clears any tripped limit, so new limits take effect right away instead of waiting out the margin of a limit that no longer exists.
+
+While usage sits inside the margin, the rejection says so rather than claiming a limit that is no longer exceeded:
+
+```text
+Disk usage is at 87% of total capacity. It reached the configured limit of 90%
+and has to fall below 85% before this node takes writes again.
+```
+
+## Monitoring Quotas
+
+Each node reports whether it's currently at or over a limit through the `quota_exceeded` metric on [`/metrics`](/documentation/ops-monitoring/monitoring/#node-metrics-metrics). Memory and disk get their own series, because you free them with different actions:
+
+```text
+quota_exceeded{resource="memory"} 0
+quota_exceeded{resource="disk"} 1
+```
+
+A node reports `1` from the moment usage reaches the limit until it has fallen back under the [release margin](#release-margin). Expect the series to stay at `1` for a while after usage has dropped under the configured limit.
+
+Qdrant emits no series at all for a resource that has no limit or while quotas are disabled.
+
+The `/telemetry` endpoint reports the same verdict alongside the quota configuration the peer is enforcing, in a top-level `quota` field. It reflects what that peer is applying rather than what the cluster agreed on, so a peer that missed a consensus update shows up here.

--- a/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/monitoring.md
@@ -45,6 +45,9 @@ Counters - such as the number of created snapshots - are reset when the node is 
 | ----------------------------------- | ------- | ------------------------------ |
 | app_info                            | gauge   | Qdrant server name and version |
 | app_status_recovery_mode            | gauge   | If started in recovery mode    |
+| quota_exceeded                      | gauge   | If a configured resource quota is exceeded, per resource <sup>(v1.19+)</sup> [^metrics-quota] |
+
+[^metrics-quota]: Only reported for resources that have a quota configured. See [Monitoring Quotas](/documentation/ops-configuration/quotas/#monitoring-quotas).
 
 **Collection Metrics**
 
@@ -171,6 +174,8 @@ The `endpoint` label uses the route template, not the resolved path. The actual 
 ## Telemetry Endpoint
 
 Qdrant also provides a `/telemetry` endpoint, which provides information about the current state of the database, including the number of vectors, shards, and other useful information. You can find the full documentation for this endpoint in the [API reference](https://api.qdrant.tech/api-reference/service/telemetry).
+
+As of v1.19.0, telemetry includes a top-level `quota` field. See [Monitoring Quotas](/documentation/ops-configuration/quotas/#monitoring-quotas).
 
 ## Cluster-Wide Telemetry
 

--- a/qdrant-landing/content/documentation/security.md
+++ b/qdrant-landing/content/documentation/security.md
@@ -313,6 +313,8 @@ This is also applicable to using api keys instead of tokens. In that case, `api_
 | get cluster info | ✅ | ✅ | ❌ | ❌ |
 | recover raft state | ✅ | ❌ | ❌ | ❌ |
 | delete peer | ✅ | ❌ | ❌ | ❌ |
+| get quotas | ✅ | ✅ | ❌ | ❌ |
+| set quotas | ✅ | ❌ | ❌ | ❌ |
 | get point | ✅ | ✅ | ✅ | ✅ |
 | get points | ✅ | ✅ | ✅ | ✅ |
 | upsert points | ✅ | ❌ | ✅ | ❌ |


### PR DESCRIPTION
[Preview](https://deploy-preview-2586--condescending-goldwasser-91acf0.netlify.app/documentation/ops-configuration/quotas/)

Document the global quota API from qdrant/qdrant#10035, which replaces the per-collection strict mode knobs for memory and disk with a single cluster-wide quota.

New page, `ops-configuration/quotas.md` (weight 7, between Configuration and Administration):

- Configuring quotas via storage.quotas, `QDRANT__STORAGE__QUOTAS__*` env vars, and `PUT /quotas`, with the parameter reference
- Configuration precedence: the API wins once used anywhere in the cluster, and a joining peer receives the config through consensus instead of reading its own file
- What happens when a limit is reached: the full node's replica is excluded and marked dead, the write still succeeds at `write_consistency_factor` acknowledgements, and clients see HTTP 507 only when no replica can accept it
- Which operations stay allowed, the release margin, `GET /quotas` for finding the full node, and the `quota_exceeded` metric plus the `/telemetry` `quota` field

Supporting changes:

- `configuration.md`: add the storage.quotas block
- `monitoring.md`: add quota_exceeded to Application Metrics, and note the /telemetry quota field
- `security.md`: add get quotas and set quotas to the JWT access table
- `common-errors.md`: new Insufficient storage (HTTP 507) entry ([Preview](https://deploy-preview-2586--condescending-goldwasser-91acf0.netlify.app/documentation/common-errors/#insufficient-storage-http-507))
- `faq/qdrant-fundamentals.md`: entry on writes rejected with HTTP 507 ([Preview](https://deploy-preview-2586--condescending-goldwasser-91acf0.netlify.app/documentation/faq/qdrant-fundamentals/#why-are-my-writes-rejected-with-http-507))
- `administration.md`: mark `max_resident_memory_percent` strict mode deprecated as of 1.19.0
- `ops-configuration/_index.md`: add the new page