### PR TITLE
Link Cloud page customer cards to their case studies

### DIFF
--- a/qdrant-landing/content/qdrant-cloud/qdrant-cloud-customers.md
+++ b/qdrant-landing/content/qdrant-cloud/qdrant-cloud-customers.md
@@ -10,6 +10,9 @@ cards:
     description: Travelers using the generative AI experience show 2-3x more revenue than those using traditional search.
     category: CONSUMER-FACING AI APP
     label: 11M BUSINESSES · 21 COUNTRIES
+    link:
+      text: Read Case Study
+      url: /blog/case-study-tripadvisor/
   - id: 1
     icon:
       src: /img/customer-logo/telekom.svg
@@ -18,6 +21,9 @@ cards:
     description: After replacing their vector stack with Qdrant, Deutsche Telekom cut AI agent development from 15 days to 2 days.
     category: MULTI-AGENT PLATFORM
     label: 2M+ AI CONVERSATIONS SERVED
+    link:
+      text: Read Case Study
+      url: /blog/case-study-deutsche-telekom/
   - id: 2
     icon:
       src: /img/customer-logo/faz.svg
@@ -26,5 +32,8 @@ cards:
     description: Sub-second response times on complex, highly filtered semantic queries across an indexed archive of more than 14 million vectors.
     category: MEDIA
     label: 75 YEARS OF ARCHIVED JOURNALISM
+    link:
+      text: Read Case Study
+      url: /blog/case-study-faz/
 sitemapExclude: true
 ---

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/qdrant-cloud/_qdrant-cloud-customers.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/qdrant-cloud/_qdrant-cloud-customers.scss
@@ -28,7 +28,8 @@
     align-items: flex-start;
     gap: $spacer * 3.5;
     padding: $spacer * 2;
-    
+    text-decoration: none;
+
     &:hover {
       box-shadow:
               0 76px 21px 0 rgba(22, 30, 51, 0.00),
@@ -63,6 +64,10 @@
       color: $neutral-40;
     }
     
+    &-link {
+      margin-top: $spacer;
+    }
+
     &-footer {
       width: 100%;
       margin-top: auto;

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-customers.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-customers.html
@@ -6,17 +6,22 @@
       <div class="row g-4">
         {{ range .Params.cards }}
           <div class="col-12 col-lg-4">
-            <div class="card qdrant-cloud-customers__card">
+            <a
+              class="card qdrant-cloud-customers__card"
+              href="{{ .link.url }}"
+              {{ if strings.HasPrefix .link.url "http" }}target="_blank"{{ end }}
+            >
               <img class="qdrant-cloud-customers__card-icon" src="{{ .icon.src }}" alt="{{ .icon.alt }}" />
               <div>
                 <h5 class="qdrant-cloud-customers__card-title">{{ .title | safeHTML }}</h5>
                 <p class="qdrant-cloud-customers__card-description">{{ .description }}</p>
+                <span class="link link_dark link_md qdrant-cloud-customers__card-link">{{ .link.text }}</span>
               </div>
               <div class="qdrant-cloud-customers__card-footer">
                 <p class="qdrant-cloud-customers__card-category">{{ .category }}</p>
                 <p class="qdrant-cloud-customers__card-label">{{ .label }}</p>
               </div>
-            </div>
+            </a>
           </div>
         {{ end }}
       </div>


### PR DESCRIPTION
The three customer cards at the top of `/cloud` (Tripadvisor, Deutsche Telekom, FAZ) were static. Each now links to its case study post.

| Card | Links to |
|---|---|
| Tripadvisor | `/blog/case-study-tripadvisor/` |
| Deutsche Telekom | `/blog/case-study-deutsche-telekom/` |
| FAZ | `/blog/case-study-faz/` |

Reuses the existing `link link_dark link_md` style from the resources section further down the same page, the one on "Talk to Engineering". No new link styles.

### Implementation notes

- **The whole card is the anchor**, and the "Read Case Study" label is a `<span>`, not a nested `<a>`. An anchor inside an anchor is invalid HTML and browsers handle it inconsistently; this way the card is a single tab stop and a single link for SEO, while the clickable area covers the whole card.
- Needed `text-decoration: none` on the card now that it is an `<a>`, otherwise the anchor's underline is inherited by all the card text.
- Link text lives in the front matter, so it is editable without touching the template.
- The arrow animates on hover of the label rather than hover of the whole card. `.link`'s animation is keyed to `.link:hover`, and propagating it from the card would mean re-declaring the `::before`/`::after` gradient rules and outweighing the existing `.link:not(:hover)` rule. The card already has its own box-shadow hover. Happy to add it if you want the arrow moving on card hover.

### Verified

Local Hugo build: all three cards render as anchors with the correct hrefs, all three target pages exist in the output, and both new CSS rules compile.