### PR TITLE
Track clicks and scroll depth on the /cloud landing

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/qdrant-cloud.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/qdrant-cloud.js
@@ -1,8 +1,9 @@
-import { trackAllClicksIn } from './segment-helpers';
+import { trackAllClicksIn, trackScrollDepth } from './segment-helpers';
 
 // ponytail: /cloud only, so Segment volume elsewhere is untouched.
 // Move to index.js to take it sitewide.
 trackAllClicksIn(document);
+trackScrollDepth();
 
 // Capabilities
 (function initCapabilities() {

--- a/qdrant-landing/themes/qdrant-2024/assets/js/qdrant-cloud.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/qdrant-cloud.js
@@ -1,3 +1,9 @@
+import { trackAllClicksIn } from './segment-helpers';
+
+// ponytail: /cloud only, so Segment volume elsewhere is untouched.
+// Move to index.js to take it sitewide.
+trackAllClicksIn(document);
+
 // Capabilities
 (function initCapabilities() {
   const stickyWrap = document.querySelector('.qdrant-cloud-capabilities__tabs-sticky');

--- a/qdrant-landing/themes/qdrant-2024/assets/js/qdrant-cloud.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/qdrant-cloud.js
@@ -1,9 +1,10 @@
-import { trackAllClicksIn, trackScrollDepth } from './segment-helpers';
+import { trackAllClicksIn, trackScrollDepth, trackSectionViews } from './segment-helpers';
 
 // ponytail: /cloud only, so Segment volume elsewhere is untouched.
 // Move to index.js to take it sitewide.
 trackAllClicksIn(document);
 trackScrollDepth();
+trackSectionViews();
 
 // Capabilities
 (function initCapabilities() {

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -28,32 +28,81 @@ const nameMapper = (url) => { // Mapping names based on pathname for Segment
 /***************/
 /* DOM helpers */
 /***************/
-const handleClickInteraction = (event) => {
-  // currentTarget, not target: the tagged element is where the listener was attached,
-  // while target is the innermost node clicked (an <img>/<p> inside a card anchor).
-  const el = event.currentTarget;
-  const rawLabel = el.getAttribute('data-metric-label') ?? el.innerText;
-  const cleanedLabel = rawLabel ? rawLabel.replace(/\s+/g, ' ').trim() : '';
+const LABEL_MAX = 120;
 
-  const payload = {
-    ...PAYLOAD_BOILERPLATE,
-    location: el.getAttribute('data-metric-loc') ?? '',
-    label: cleanedLabel,
-    action: 'clicked'
-  };
+// Fall back to the nearest landmark when an element carries no data-metric-loc,
+// so untagged clicks still land in a readable bucket ('cloud_hero', 'footer', ...).
+const deriveLocation = (el) => {
+  // No 'nav' here on purpose: a <nav> nested in the footer would otherwise split
+  // footer clicks into its own bucket.
+  const region = el.closest('section, header, footer');
+  if (!region) return 'page';
 
+  const cls = [...region.classList].find((c) => c && !/^(col|row|g|container)([-_]|$)/.test(c));
+  return (cls || region.tagName.toLowerCase())
+    .replace(/^qdrant-cloud-/, 'cloud-')
+    .replace(/[^a-z0-9]+/gi, '_')
+    .toLowerCase();
+};
+
+// || not ??: an icon-only link has innerText '' and needs to fall through to the image alt.
+const deriveLabel = (el) =>
+  el.getAttribute('data-metric-label')
+  || el.getAttribute('aria-label')
+  || el.innerText
+  || el.querySelector('img[alt]')?.getAttribute('alt')
+  || el.getAttribute('title')
+  || el.getAttribute('href')
+  || '';
+
+const emitInteraction = (payload) => {
   // If consented to tracking the track
-  if(getCookie('cookie-consent')) {
+  if (getCookie('cookie-consent')) {
     trackInteractionEvent(payload);
-
-    // If element can be clicked more than once (ie user remains on same page)
-    if (!el.hasAttribute('data-metric-keep')) {
-      el.removeEventListener('click', handleClickInteraction);
-    }
   } else { // If no consent yet the store in sessionStorage in case of later consent
     createSegmentStoredInteraction(payload);
   }
 };
+
+const trackClickOn = (el) => {
+  const rawLabel = deriveLabel(el);
+  const cleanedLabel = rawLabel ? rawLabel.replace(/\s+/g, ' ').trim().slice(0, LABEL_MAX) : '';
+  const href = el.getAttribute('href') ?? '';
+
+  emitInteraction({
+    ...PAYLOAD_BOILERPLATE,
+    location: el.getAttribute('data-metric-loc') ?? deriveLocation(el),
+    label: cleanedLabel,
+    action: 'clicked',
+    href,
+    outbound: /^https?:\/\//.test(href) && !href.includes(window.location.host),
+  });
+};
+
+const handleClickInteraction = (event) => {
+  // currentTarget, not target: the tagged element is where the listener was attached,
+  // while target is the innermost node clicked (an <img>/<p> inside a card anchor).
+  const el = event.currentTarget;
+  trackClickOn(el);
+
+  // If element can be clicked more than once (ie user remains on same page)
+  if (getCookie('cookie-consent') && !el.hasAttribute('data-metric-keep')) {
+    el.removeEventListener('click', handleClickInteraction);
+  }
+};
+
+// Track every link/button under root, not just the data-metric-loc ones.
+// Delegated so elements added after load are covered too.
+export function trackAllClicksIn(root) {
+  root.addEventListener('click', (event) => {
+    const el = event.target.closest('a, button');
+
+    // Explicitly tagged elements have their own listener via tagAllAnchors()
+    if (!el || !root.contains(el) || el.hasAttribute('data-metric-loc')) return;
+
+    trackClickOn(el);
+  });
+}
 
 // Gather all <a> and <button> elements that have been tagged
 // for tracking via 'data-metric-loc' attribute

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -29,23 +29,26 @@ const nameMapper = (url) => { // Mapping names based on pathname for Segment
 /* DOM helpers */
 /***************/
 const handleClickInteraction = (event) => {
-  const rawLabel = event.target.getAttribute('data-metric-label') ?? event.target.innerText;
+  // currentTarget, not target: the tagged element is where the listener was attached,
+  // while target is the innermost node clicked (an <img>/<p> inside a card anchor).
+  const el = event.currentTarget;
+  const rawLabel = el.getAttribute('data-metric-label') ?? el.innerText;
   const cleanedLabel = rawLabel ? rawLabel.replace(/\s+/g, ' ').trim() : '';
 
   const payload = {
     ...PAYLOAD_BOILERPLATE,
-    location: event.target.getAttribute('data-metric-loc') ?? '',
+    location: el.getAttribute('data-metric-loc') ?? '',
     label: cleanedLabel,
     action: 'clicked'
   };
 
-  // If consented to tracking the track 
+  // If consented to tracking the track
   if(getCookie('cookie-consent')) {
     trackInteractionEvent(payload);
-    
+
     // If element can be clicked more than once (ie user remains on same page)
-    if (!event.target.hasAttribute('data-metric-keep')) {
-      event.target.removeEventListener('click', handleClickInteraction);
+    if (!el.hasAttribute('data-metric-keep')) {
+      el.removeEventListener('click', handleClickInteraction);
     }
   } else { // If no consent yet the store in sessionStorage in case of later consent
     createSegmentStoredInteraction(payload);

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -94,10 +94,14 @@ const handleClickInteraction = (event) => {
 // GA4 Enhanced Measurement only reports 90%, so fire the quarters ourselves.
 const SCROLL_MILESTONES = [25, 50, 75, 90];
 
-// Fires each milestone at most once per page load.
+// Fires each milestone at most once per page load, plus the deepest point on the way out.
 export function trackScrollDepth(milestones = SCROLL_MILESTONES) {
   const pending = new Set(milestones);
+  const startedAt = performance.now();
+  const sinceLoad = () => Math.round(performance.now() - startedAt);
   let queued = false;
+  let deepest = 0;
+  let reportedDeepest = false;
 
   const check = () => {
     queued = false;
@@ -107,6 +111,7 @@ export function trackScrollDepth(milestones = SCROLL_MILESTONES) {
     if (scrollable <= 0) return;
 
     const percent = (window.scrollY / scrollable) * 100;
+    deepest = Math.max(deepest, Math.min(100, Math.round(percent)));
 
     // Sorted so a single jump (anchor link, restored position) reports in order.
     [...pending].sort((a, b) => a - b).forEach((milestone) => {
@@ -119,10 +124,9 @@ export function trackScrollDepth(milestones = SCROLL_MILESTONES) {
         label: `${milestone}%`,
         action: 'scrolled',
         percent: milestone,
+        ms_to_reach: sinceLoad(),
       });
     });
-
-    if (!pending.size) window.removeEventListener('scroll', onScroll);
   };
 
   // Coalesce to one measurement per frame; scroll fires far more often than that.
@@ -132,8 +136,68 @@ export function trackScrollDepth(milestones = SCROLL_MILESTONES) {
     requestAnimationFrame(check);
   };
 
+  // Deepest point reached, which is the only depth we get from visitors who
+  // leave without crossing a milestone.
+  const reportDeepest = () => {
+    if (reportedDeepest || !deepest) return;
+    reportedDeepest = true;
+
+    emitInteraction({
+      ...PAYLOAD_BOILERPLATE,
+      location: 'page',
+      label: `${deepest}%`,
+      action: 'scroll_max',
+      percent: deepest,
+      ms_to_reach: sinceLoad(),
+    });
+  };
+
+  // The listener stays attached after the last milestone: deepest still needs updating.
   window.addEventListener('scroll', onScroll, { passive: true });
+
+  // ponytail: best-effort on the way out, a request started here can still be dropped.
+  // visibilitychange covers mobile, where pagehide does not reliably fire.
+  window.addEventListener('pagehide', reportDeepest);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') reportDeepest();
+  });
+
   check(); // page may already be loaded part-way down
+}
+
+// Which sections a visitor actually reached, which a page-level percentage only implies.
+export function trackSectionViews(selector = 'section') {
+  const sections = [...document.querySelectorAll(selector)];
+  if (!sections.length || !('IntersectionObserver' in window)) return;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+
+        observer.unobserve(entry.target); // once per section per page load
+
+        const location = deriveLocation(entry.target);
+
+        // Skip OneTrust consent markup, and unclassed wrappers that would otherwise
+        // land in a meaningless bucket named after the tag.
+        if (location.startsWith('ot_') || location === entry.target.tagName.toLowerCase()) return;
+
+        const heading = entry.target.querySelector('h1, h2, h3, h4');
+        emitInteraction({
+          ...PAYLOAD_BOILERPLATE,
+          location,
+          label: heading ? heading.innerText.replace(/\s+/g, ' ').trim().slice(0, LABEL_MAX) : '',
+          action: 'viewed',
+        });
+      });
+    },
+    // ponytail: a quarter of the section counts as seen. A higher threshold would
+    // never trigger for tall sections on small screens.
+    { threshold: 0.25 },
+  );
+
+  sections.forEach((section) => observer.observe(section));
 }
 
 // Track every link/button under root, not just the data-metric-loc ones.

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -91,6 +91,51 @@ const handleClickInteraction = (event) => {
   }
 };
 
+// GA4 Enhanced Measurement only reports 90%, so fire the quarters ourselves.
+const SCROLL_MILESTONES = [25, 50, 75, 90];
+
+// Fires each milestone at most once per page load.
+export function trackScrollDepth(milestones = SCROLL_MILESTONES) {
+  const pending = new Set(milestones);
+  let queued = false;
+
+  const check = () => {
+    queued = false;
+
+    const scrollable = document.documentElement.scrollHeight - window.innerHeight;
+    // Page fits the viewport, so there is no scrolling to measure.
+    if (scrollable <= 0) return;
+
+    const percent = (window.scrollY / scrollable) * 100;
+
+    // Sorted so a single jump (anchor link, restored position) reports in order.
+    [...pending].sort((a, b) => a - b).forEach((milestone) => {
+      if (percent < milestone) return;
+
+      pending.delete(milestone);
+      emitInteraction({
+        ...PAYLOAD_BOILERPLATE,
+        location: 'page',
+        label: `${milestone}%`,
+        action: 'scrolled',
+        percent: milestone,
+      });
+    });
+
+    if (!pending.size) window.removeEventListener('scroll', onScroll);
+  };
+
+  // Coalesce to one measurement per frame; scroll fires far more often than that.
+  const onScroll = () => {
+    if (queued) return;
+    queued = true;
+    requestAnimationFrame(check);
+  };
+
+  window.addEventListener('scroll', onScroll, { passive: true });
+  check(); // page may already be loaded part-way down
+}
+
 // Track every link/button under root, not just the data-metric-loc ones.
 // Delegated so elements added after load are covered too.
 export function trackAllClicksIn(root) {

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-capabilities.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-capabilities.html
@@ -43,6 +43,7 @@
                 <a
                   class="qdrant-cloud-capabilities__tab-feature"
                   href="{{ .link }}"
+                  data-metric-label="{{ .title | plainify }}"
                   {{ if strings.HasPrefix .link "http" }}target="_blank" rel="noopener"{{ end }}
                 >
                 {{ else }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-customers.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-customers.html
@@ -9,6 +9,7 @@
             <a
               class="card qdrant-cloud-customers__card"
               href="{{ .link.url }}"
+              data-metric-label="{{ .title | plainify }}"
               {{ if strings.HasPrefix .link.url "http" }}target="_blank"{{ end }}
             >
               <img class="qdrant-cloud-customers__card-icon" src="{{ .icon.src }}" alt="{{ .icon.alt }}" />

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-dev-experience.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-cloud/qdrant-cloud-dev-experience.html
@@ -10,6 +10,7 @@
             <a
               class="card qdrant-cloud-dev-experience__card"
               href="{{ .link.url }}"
+              data-metric-label="{{ .link.text | plainify }}"
               {{ if strings.HasPrefix .link.url "http" }}target="_blank"{{ end }}
             >
               <img class="qdrant-cloud-dev-experience__card-image" src="{{ .img.src }}" alt="{{ .img.alt }}">


### PR DESCRIPTION
## Why

`/cloud` had 5 tracked elements, all inherited from the shared header, against ~68 links and buttons of its own. Nothing in the page body reported to Segment/GA4 — no CTA clicks, no card clicks, no tab interactions, no scroll depth.

While tagging it I found a bug in the shared click handler that affected every page using `data-metric-loc`.

## Commits

1. **`fix(analytics)`: read click metrics from `currentTarget`, not `target`** — `handleClickInteraction` read `data-metric-loc`/`data-metric-label` off `event.target`, which is the innermost node clicked rather than the tagged element. Any anchor wrapping child elements reported `location: ''` and a label scraped from whichever `<img>`/`<p>` the user hit, and the dedupe `removeEventListener` ran against the wrong node so it never deduped. 37 of 46 anchors on `/cloud` are that shape. Existing text-only nav links are unaffected (`currentTarget === target`).

2. **`feat(analytics)`: track every link and button on `/cloud`** — hand-tagging ~68 elements would have meant ~70 attributes across 13 files and would still miss anything added later, so this tracks by delegation. `trackAllClicksIn(root)` resolves the element with `closest()`, derives `location` from the nearest `section`/`header`/`footer` class (`qdrant-cloud-hero` → `cloud_hero`), and skips anything carrying `data-metric-loc` so existing listeners stay authoritative and nothing double-counts. Adds `href` + `outbound` to the payload and widens the label fallback to `aria-label`/`img[alt]`/`title`/`href` so icon-only links stop reporting empty labels.

3. **`feat(analytics)`: scroll depth at 25/50/75/90** — GA4 Enhanced Measurement only reports a single 90% milestone. Each milestone fires once per page load, applied in ascending order so one large jump still reports every threshold it crossed. Coalesced to one measurement per animation frame.

4. **`feat(analytics)`: section views, max scroll depth and time-to-milestone** — three additions that all reuse the existing `interaction` schema, so they need no Segment mapping beyond what the milestones already require:
   - **`trackSectionViews()`** reports which sections a visitor actually reached, which a page-level percentage only implies — on a 9-section landing page "50% scrolled" is a proxy for "saw the capabilities section", and an `IntersectionObserver` measures that directly. Fires `action: 'viewed'` once per section at a 25% threshold, reusing the `location` vocabulary already derived for clicks, with the section heading as label. 10 sections report on `/cloud`; OneTrust consent markup and unclassed wrappers are skipped so they don't create buckets named after their tag.
   - **`action: 'scroll_max'`** on `pagehide`/`visibilitychange` reports the deepest point reached, which is the only depth we get from visitors who leave without crossing a milestone. The scroll listener therefore stays attached after the last milestone, since deepest still needs updating.
   - **`ms_to_reach`** on each milestone, via `performance.now()`, separating fast skimming from actual reading.

## Event vocabulary

One event name, `interaction`, with `action` distinguishing the kind:

| `action` | fires when | carries |
|---|---|---|
| `clicked` | any link or button | `location`, `label`, `href`, `outbound` |
| `scrolled` | 25/50/75/90% crossed | `location: page`, `percent`, `ms_to_reach` |
| `scroll_max` | page hidden or unloaded | `location: page`, `percent` (deepest), `ms_to_reach` |
| `viewed` | a section becomes 25% visible | `location` (section), `label` (heading) |

## Scope

Bound from `qdrant-cloud.js`, which Hugo only loads for section `qdrant-cloud`. **Segment event volume on the rest of the site is unchanged.** Promoting this sitewide is moving three lines into `index.js` — worth doing deliberately, since ~2/3 of the clickables on any page are header/footer chrome.

## Verification

Tested in the browser against the built bundle, and end-to-end on the deploy preview: **`POST https://events.eu1.segmentapis.com/v1/t` → HTTP 200**, payloads carrying correct `location`, `label`, `href`, `outbound`.

| case | result |
|---|---|
| click the `<p>` inside a customer card (previously broken) | `cloud_customers` / "2-3x Revenue Lift" |
| click the `<h3>` inside a capability feature | `cloud_capabilities` / "Hybrid Search" |
| click the `<img>` inside a dev-experience card | `cloud_dev_experience` / "Language SDKs" |
| header + footer `contact-us` links | both fire, `site_header` / `footer` |
| repeat clicks on tabs | fires every time |
| the 5 explicitly tagged elements | no double-counting |
| gradual scroll 10→95% | `25,50,75,90` once each, in order |
| scroll to top then bottom again | 0 duplicates |
| single jump to bottom | all four, ascending |
| page shorter than viewport | silent |
| every milestone carries `ms_to_reach` | ✅ |
| `scroll_max` once-guard | two `visibilitychange` events → exactly one event |
| section `location` + `label` derivation | all 10 clean and readable |
| `IntersectionObserver` fires and reports | verified live in a focused tab, 0 duplicates |
| OneTrust / unclassed sections | 4 skipped, no junk buckets |

**`IntersectionObserver` firing is verified** on the deploy preview in a focused tab: six sections reported live with correct locations and readable headings, no duplicates — `cloud_customers`, `cloud_dev_experience`, `pricing_banner`, `cloud_resources`, `cloud_faq`, `cta_banner` — alongside all four scroll milestones with plausible `ms_to_reach` values from real scrolling. A direct probe confirmed delivery for `cloud_hero` at `intersectionRatio` 0.797. The remaining sections fire at page load, before instrumentation can wrap `analytics.track`, and are then `unobserve`d — correct behaviour, simply not observable from a console attached after load.

Each commit builds standalone (`hugo` exit 0). Rebased on latest `master`.

## Config status for GA4 visibility

The website property is **"Qdrant landing"** (`p271085741`, stream `qdrant.tech`, `G-NZYW2651NE` — matching `config.toml:136`).

**Done — custom dimensions registered** (4 Aug 2026), all Event-scoped:

| Dimension name | Parameter |
|---|---|
| Interaction location | `location` |
| Interaction label | `label` |
| Interaction action | `action` |
| Scroll depth percent | `percent` |
| Interaction outbound | `outbound` |

**Done — custom metric registered**, Event-scoped, unit Milliseconds:

| Metric name | Parameter |
|---|---|
| Scroll time to milestone | `ms_to_reach` |

Registered ahead of the mapping on purpose: custom definitions do not backfill, so they must exist before events start arriving. `href` is deliberately not registered — URLs are high-cardinality and would collapse into an `(other)` bucket.

**Blocked — Segment mapping.** On the production source (write key `eQYi1nZE…`), the GA4 destination needs a mapping triggered on `event = "interaction"`, branching on `action` for nicer GA4 event names:

| `action` | GA4 event name |
|---|---|
| `clicked` | `cta_click` |
| `scrolled` | `scroll_depth` |
| `scroll_max` | `scroll_max` |
| `viewed` | `section_view` |

Segment Actions destinations forward nothing without an explicit trigger, which is why GA4 currently reports exactly 0 `interaction` events over 28 days rather than a partial count. This needs someone with access to the production Segment workspace.

Splitting event names in the mapping rather than in code is deliberate: renaming in code would not remove the mapping requirement, and would drop `/cloud` out of Segment-side `interaction` analysis, which is currently the only surface receiving this data.

**The parameter names above must pass through the mapping unrenamed.** If the mapping renames `location`, the registered dimension stays permanently empty and the mismatch is invisible until someone builds a report.

**Deferred to merge day — Enhanced Measurement "Scrolls".** It is currently **on** for this property (152k `scroll` events in 28 days). Leave it on until the mapping is live and this PR is merged, then switch it off. Flipping it early would leave no scroll data at all in the gap; flipping it late means GA4's `scroll` (90% only) double-counts against this PR's `scrolled` (25/50/75/90).

Also worth knowing: Enhanced Measurement **Outbound clicks** is already on, so GA4 already captures outbound navigation via its own `click` event. The `outbound` flag here is not net-new at the GA4 layer — it adds outbound *within the Segment `interaction` schema, carrying section context* (`location: cloud_hero`), which GA4's `click` does not have.

Form-submit tracking is out of scope: `/cloud` has no form, "Talk to Engineering" hands off to `/contact-us/`.

## Note on CI

`linkChecker` was failing for a pre-existing reason unrelated to this PR (a link to a drafted article, see the comment below). That was fixed on `master` in #2590 and this branch has been rebased on top of it.

