### PR TITLE
Agent-readable Markdown for the marketing pages

### DIFF
--- a/.github/workflows/internal-dead-links.yml
+++ b/.github/workflows/internal-dead-links.yml
@@ -32,6 +32,8 @@ jobs:
             curl -sf http://localhost:1314/ >/dev/null && break
             sleep 1
           done
+      - name: Marketing Markdown Output Check
+        run: automation/check-markdown-output.sh
       - name: Internal Links Check
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/automation/check-markdown-output.sh
+++ b/automation/check-markdown-output.sh
@@ -9,18 +9,65 @@ set -uo pipefail
 PUBLIC=${1:-qdrant-landing/public}
 fail=0
 
-# Still title-only, deliberately: /contact-us and /subscribe are forms with
-# nothing to render. /learn has its own agent page (PR #2462).
-PAGES=(
-  cloud qdrant-vector-database pricing hybrid-cloud private-cloud edge
-  cloud-inference ai-agents advanced-search recommendations
-  data-analysis-anomaly-detection rag use-cases healthcare
-  enterprise-solutions qdrant-for-startups customers partners benchmarks
-  about-us lp/lucene e-commerce hr-tech legal-tech hospitality-and-travel
-  rag/rag-evaluation-guide
-  community stars events vector-space-day-sf-26 vector-space-day-sf-26-recap
-  brand-resources demo
+# The pages to check are whichever ones have a Markdown template, so adding or
+# removing a page needs no edit here. A list.markdown.md means the section
+# landing page; a single.markdown.md means the pages in that section that build
+# themselves (build.render: always), which is how the industry pages and the RAG
+# evaluation guide work. The URL comes from the page's own url: override, or the
+# section name when there isn't one.
+#
+# Still title-only, deliberately, and so absent from this list: /contact-us and
+# /subscribe are forms with nothing to render. /learn has its own agent page
+# (PR #2462).
+PAGES=()
+while IFS= read -r page; do PAGES+=("$page"); done < <(python3 - <<'PY'
+import glob, os, re
+LAYOUTS = "qdrant-landing/themes/qdrant-2024/layouts"
+CONTENT = "qdrant-landing/content"
+
+def front_matter(path):
+    try:
+        text = open(path).read()
+    except OSError:
+        return ""
+    m = re.match(r"^---\n(.*?)\n---", text, re.S)
+    return m.group(1) if m else ""
+
+def own_render(fm):
+    """render: from the page's own build block, ignoring any cascade block."""
+    m = re.search(r"^build:\n((?:[ \t]+.*\n)+)", fm + "\n", re.M)
+    if not m:
+        return ""
+    r = re.search(r"render:\s*(\w+)", m.group(1))
+    return r.group(1) if r else ""
+
+def url(fm, fallback):
+    m = re.search(r'^url:\s*"?([^"\n]+)"?', fm, re.M)
+    return (m.group(1) if m else fallback).strip().strip("/")
+
+pages = []
+for template in sorted(glob.glob(f"{LAYOUTS}/*/list.markdown.md")):
+    section = os.path.basename(os.path.dirname(template))
+    fm = front_matter(f"{CONTENT}/{section}/_index.md")
+    if own_render(fm) == "never":
+        continue  # a container for other pages, not a page itself
+    pages.append(url(fm, section))
+for template in sorted(glob.glob(f"{LAYOUTS}/*/single.markdown.md")):
+    section = os.path.basename(os.path.dirname(template))
+    for page in sorted(glob.glob(f"{CONTENT}/{section}/*.md")):
+        if page.endswith("_index.md"):
+            continue
+        fm = front_matter(page)
+        if own_render(fm) == "always":
+            pages.append(url(fm, os.path.basename(page)[:-3]))
+print("\n".join(p for p in dict.fromkeys(pages) if p))
+PY
 )
+
+if [ "${#PAGES[@]}" -lt 20 ]; then
+  echo "derived only ${#PAGES[@]} pages to check; the layout or content layout changed"
+  exit 1
+fi
 
 for p in "${PAGES[@]}"; do
   f="$PUBLIC/$p/index.md"

--- a/automation/check-markdown-output.sh
+++ b/automation/check-markdown-output.sh
@@ -9,12 +9,17 @@ set -uo pipefail
 PUBLIC=${1:-qdrant-landing/public}
 fail=0
 
+# Still title-only, deliberately: /contact-us and /subscribe are forms with
+# nothing to render. /learn has its own agent page (PR #2462).
 PAGES=(
   cloud qdrant-vector-database pricing hybrid-cloud private-cloud edge
   cloud-inference ai-agents advanced-search recommendations
   data-analysis-anomaly-detection rag use-cases healthcare
   enterprise-solutions qdrant-for-startups customers partners benchmarks
   about-us lp/lucene e-commerce hr-tech legal-tech hospitality-and-travel
+  rag/rag-evaluation-guide
+  community stars events vector-space-day-sf-26 vector-space-day-sf-26-recap
+  brand-resources demo
 )
 
 for p in "${PAGES[@]}"; do
@@ -69,6 +74,17 @@ $(grep -hE '^[[:space:]]*(title|pricing|price):[[:space:]]*\S' "$src" \
   | normalize)
 EOF
   done
+fi
+
+# Customers is a table of every client, also hand-written, so a truncated or
+# dropped table has to fail rather than quietly shrink the page.
+clients_src=qdrant-landing/content/customers/clients/_index.md
+if [ -f "$clients_src" ] && [ -f "$PUBLIC/customers/index.md" ]; then
+  want=$(grep -cE '^  - id: ' "$clients_src")
+  got=$(( $(grep -cE '^\| ' "$PUBLIC/customers/index.md") - 2 ))  # minus header and divider
+  if [ "$want" -ne "$got" ]; then
+    echo "customers/index.md lists $got clients, content has $want"; fail=1
+  fi
 fi
 
 # llms.txt is how an agent finds these pages at all.

--- a/automation/check-markdown-output.sh
+++ b/automation/check-markdown-output.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Checks the Markdown output of the marketing landing pages, which is assembled
+# from front-matter params by themes/qdrant-2024/layouts/partials/md-params.txt
+# rather than from page bodies. Run it after a Hugo build.
+#
+# Usage: automation/check-markdown-output.sh [path/to/public]
+set -uo pipefail
+
+PUBLIC=${1:-qdrant-landing/public}
+fail=0
+
+PAGES=(
+  cloud qdrant-vector-database pricing hybrid-cloud private-cloud edge
+  cloud-inference ai-agents advanced-search recommendations
+  data-analysis-anomaly-detection rag use-cases healthcare
+  enterprise-solutions qdrant-for-startups customers partners benchmarks
+  about-us lp/lucene e-commerce hr-tech legal-tech hospitality-and-travel
+)
+
+for p in "${PAGES[@]}"; do
+  f="$PUBLIC/$p/index.md"
+  if [ ! -f "$f" ]; then
+    echo "missing: $f"; fail=1; continue
+  fi
+  words=$(wc -w < "$f" | tr -d ' ')
+  # A page that lost its rollup falls back to the title alone, around 30 words.
+  if [ "$words" -lt 80 ]; then
+    echo "too thin ($words words): $f"; fail=1
+  fi
+  if grep -q '&#43;\|&lt;\|&gt;\|&amp;' "$f"; then
+    echo "HTML-escaped output (needs safeHTML): $f"; fail=1
+  fi
+  # span and br are the tags marketing copy carries inside params for styling.
+  # Page bodies legitimately contain other HTML, same as the docs Markdown output.
+  if grep -qE '</?(span|br)[ />]' "$f"; then
+    echo "raw inline markup left in copy: $f"; fail=1
+  fi
+  if grep -qE '\]\(/|\]\(\.\.?/' "$f"; then
+    echo "site-relative link not rewritten to https://qdrant.tech/...index.md: $f"; fail=1
+  fi
+done
+
+# Pricing carries the tier tables; without them the page is worthless to agents.
+if ! grep -q '^| Feature |' "$PUBLIC/pricing/index.md" 2>/dev/null; then
+  echo "pricing/index.md has no tier comparison table"; fail=1
+fi
+
+# llms.txt is how an agent finds these pages at all.
+listed=$(awk '/^## Pages$/{f=1;next} /^## /{f=0} f && /^- \[/{n++} END{print n+0}' "$PUBLIC/llms.txt")
+if [ "$listed" -lt 30 ]; then
+  echo "llms.txt lists only $listed landing pages under '## Pages' (expected 30+)"; fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "Markdown output OK: ${#PAGES[@]} marketing pages, $listed pages listed in llms.txt"
+fi
+exit "$fail"

--- a/automation/check-markdown-output.sh
+++ b/automation/check-markdown-output.sh
@@ -45,6 +45,32 @@ if ! grep -q '^| Feature |' "$PUBLIC/pricing/index.md" 2>/dev/null; then
   echo "pricing/index.md has no tier comparison table"; fail=1
 fi
 
+# Pricing is rendered by a hand-written template (themes/.../pricing/list.markdown.md),
+# so a bundle or a tier the template does not know about disappears silently -
+# which is how doors-a stayed in the Markdown after the site moved to doors-b.
+# Every headline value in the bundles list.html actually renders must reach the
+# output. Sources are read relative to the repo root.
+PRICING_LAYOUT=qdrant-landing/themes/qdrant-2024/layouts/pricing/list.html
+if [ -f "$PRICING_LAYOUT" ] && [ -f "$PUBLIC/pricing/index.md" ]; then
+  normalize() { sed -E 's/<[^>]*>/ /g; s/[[:space:]]+/ /g; s/^ //; s/ $//'; }
+  out=$(normalize < "$PUBLIC/pricing/index.md")
+  for bundle in $(grep -oE '/pricing/[a-z0-9-]+' "$PRICING_LAYOUT" | sort -u); do
+    src="qdrant-landing/content${bundle}.md"
+    [ -f "$src" ] || continue
+    while IFS= read -r value; do
+      [ "${#value}" -ge 6 ] || continue
+      case "$value" in ''|\'\'|\"\") continue ;; esac
+      if ! printf '%s' "$out" | grep -qF "$value"; then
+        echo "pricing/index.md is missing copy from ${bundle}: \"$value\""; fail=1
+      fi
+    done <<EOF
+$(grep -hE '^[[:space:]]*(title|pricing|price):[[:space:]]*\S' "$src" \
+  | sed -E 's/^[[:space:]]*[a-z]+:[[:space:]]*//; s/^"(.*)"$/\1/; s/^'"'"'(.*)'"'"'$/\1/' \
+  | normalize)
+EOF
+  done
+fi
+
 # llms.txt is how an agent finds these pages at all.
 listed=$(awk '/^## Pages$/{f=1;next} /^## /{f=0} f && /^- \[/{n++} END{print n+0}' "$PUBLIC/llms.txt")
 if [ "$listed" -lt 30 ]; then

--- a/qdrant-landing/content/customers/clients/_index.md
+++ b/qdrant-landing/content/customers/clients/_index.md
@@ -78,7 +78,7 @@ clients:
     industry: E-commerce
     product: Qdrant Cloud
     company_size: 1-50 by
-    locationse: Asia Pacific
+    location: Asia Pacific
     use_cases: ["Recommendations", "E-commerce discovery", "Real-time analytics"]
     title: "How ConvoSearch Boosted Revenue for D2C Brands with Qdrant"
     blog_path: /blog/case-study-convosearch

--- a/qdrant-landing/content/get_anonymous_id/_index.md
+++ b/qdrant-landing/content/get_anonymous_id/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Anonymous ID
+sitemapExclude: true
 ---
-

--- a/qdrant-landing/content/pricing/_index.md
+++ b/qdrant-landing/content/pricing/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pricing for Cloud and Vector Database Solutions  Qdrant"
+title: "Pricing for Cloud and Vector Database Solutions | Qdrant"
 description: "Explore Qdrant Cloud and Enterprise solutions for your vector search applications. Choose the right deployment option and explore transparent pricing plans."
 url: pricing
 build:

--- a/qdrant-landing/themes/qdrant-2024/layouts/about-us/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/about-us/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/advanced-search/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/advanced-search/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/ai-agents/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/ai-agents/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/benchmarks/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/benchmarks/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/brand-resources/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/brand-resources/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/cloud-inference/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/cloud-inference/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/community/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/community/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/customers/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/customers/list.markdown.md
@@ -1,1 +1,43 @@
-{{ partial "md-marketing-page.txt" . }}
+{{- /*
+  Customers renders one bundle on the live page: content/customers/clients,
+  a directory of clients the page presents as a facet filter (industry,
+  product, size, location, use case). A table keeps those facets queryable.
+
+  The generic rollup is wrong here because it walks .Pages, which still holds
+  18 retired bundles - the case-study-*, logo-cards-* and testimonial-* files
+  the page stopped rendering - and republished them as duplicates.
+*/ -}}
+> Explore Qdrant's agent skills catalog at https://skills.qdrant.tech/
+> Search the documentation at https://skills.qdrant.tech/search?query=your+query+here
+> Use this file to discover all available pages: https://qdrant.tech/llms.txt
+
+{{ $content := printf "# %s\n\n" .Title -}}
+{{- with .Description }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+{{- with .Site.GetPage "/customers/customers-hero" -}}
+  {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+    {{- $content = printf "%s%s\n\n" $content . -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with .Site.GetPage "/customers/clients" -}}
+  {{- $content = printf "%s## Case Studies\n\n" $content -}}
+  {{- $content = printf "%s| Company | Industry | Product | Company size | Location | Use cases | Case study |\n| --- | --- | --- | --- | --- | --- | --- |\n" $content -}}
+  {{- range .Params.clients -}}
+    {{- $study := .title | default "" -}}
+    {{- with .blog_path -}}
+      {{- /* Trailing slash so md-finish rewrites it to an index.md link. */ -}}
+      {{- $study = printf "[%s](%s/)" $study (strings.TrimSuffix "/" .) -}}
+    {{- end -}}
+    {{- $row := slice
+        (.name | default "")
+        (.industry | default "")
+        (.product | default "")
+        (.company_size | default "")
+        (.location | default "")
+        (delimit (.use_cases | default slice) ", ")
+        $study -}}
+    {{- $content = printf "%s| %s |\n" $content (delimit $row " | ") -}}
+  {{- end -}}
+  {{- $content = printf "%s\n" $content -}}
+{{- end -}}
+{{ partial "md-finish.txt" $content | safeHTML }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/customers/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/customers/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/data-analysis/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/data-analysis/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/demo/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/demo/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/edge/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/edge/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/elastic-lucene/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/elastic-lucene/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/enterprise-solutions/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/enterprise-solutions/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/events/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/events/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/healthcare/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/healthcare/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/hybrid-cloud/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/hybrid-cloud/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/index.llms.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/index.llms.txt
@@ -1,6 +1,24 @@
 # {{ .Site.BaseURL }}
 ## Overall Summary
 > {{ .Site.Params.description }}
+{{- /* Landing pages. The loop below only reaches RegularPages, so the pages a
+   section is actually built around — /cloud, /pricing, /edge — were missing.
+   The industry pages come from GetPage because their parent section sets
+   build.list: never, which keeps it out of .Site.Sections entirely. */ -}}
+{{- $landing := .Site.Sections.ByWeight -}}
+{{- with .Site.GetPage "/industries" -}}{{- $landing = $landing | append .Pages -}}{{- end -}}
+{{- $header := "\n## Pages\n" -}}
+{{- range $landing -}}
+{{- $include := ne .Params.sitemapExclude true -}}
+{{- if .Sitemap.Disable -}}{{- $include = false -}}{{- end -}}
+{{- with .Params.build -}}
+  {{- if in (slice "never" "link") (.render | default "always") -}}{{- $include = false -}}{{- end -}}
+{{- end -}}
+{{- if and $include (ne .Title "") (ne .Permalink "") -}}
+{{ $header }}{{- $header = "" -}}
+- [{{ .Title }}]({{ .Permalink }}index.md): {{ with .Description }}{{ . | plainify | replaceRE "\\s+" " " | strings.TrimSpace }}{{ else }}{{ .Summary | plainify | replaceRE "\\s+" " " | strings.TrimSpace | truncate 200 "" }}{{ end }}
+{{ end -}}
+{{- end -}}
 {{ range .Site.Sections.ByWeight -}}
 {{- $header := printf "\n## %s\n" .Title -}}
 {{- range .RegularPagesRecursive.ByWeight -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/industries/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/industries/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/industries/single.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/industries/single.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-finish.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-finish.txt
@@ -1,0 +1,10 @@
+{{- /*
+  Shared tail for Markdown output built from marketing params: tightens bullet
+  lists and rewrites internal links the way the docs Markdown output does.
+  Takes the assembled Markdown, returns it. Callers still need | safeHTML.
+*/ -}}
+{{- $content := . -}}
+{{- $content = replaceRE `\n\n(- )` "\n$1" $content -}}
+{{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](https://qdrant.tech${1}index.md${2}` $content -}}
+{{- $content = replaceRE `<(/[^>]*/)>` `<https://qdrant.tech${1}index.md>` $content -}}
+{{- return $content -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-marketing-page.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-marketing-page.txt
@@ -1,38 +1,49 @@
 {{- /*
-  Markdown output for a marketing landing page: rolls the page's headless
-  section bundles up into one document, hero first, then by file path.
+  Markdown output for a marketing landing page: rolls the page's section
+  bundles up into one document, hero first, then by file path. Each bundle
+  contributes its front-matter copy and, where it has one, its page body.
 */ -}}
 > Explore Qdrant's agent skills catalog at https://skills.qdrant.tech/
 > Search the documentation at https://skills.qdrant.tech/search?query=your+query+here
 > Use this file to discover all available pages: https://qdrant.tech/llms.txt
 
 {{ $pages := sort .Pages "File.Path" -}}
+{{- $ordered := slice -}}
+{{- range $pages -}}
+  {{- if in (lower .File.BaseFileName) "hero" -}}{{- $ordered = $ordered | append . -}}{{- end -}}
+{{- end -}}
+{{- range $pages -}}
+  {{- if not (in (lower .File.BaseFileName) "hero") -}}{{- $ordered = $ordered | append . -}}{{- end -}}
+{{- end -}}
+
 {{- $blocks := slice -}}
-{{- range $pages -}}
-  {{- if in (lower .File.BaseFileName) "hero" -}}
-    {{- $blocks = $blocks | append (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+{{- /* A single page (industries/*) carries its sections in its own params. */ -}}
+{{- if not $ordered -}}
+  {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 1 "skipTitle" true)) -}}
+    {{- $blocks = $blocks | append . -}}
   {{- end -}}
 {{- end -}}
-{{- range $pages -}}
-  {{- if not (in (lower .File.BaseFileName) "hero") -}}
-    {{- $blocks = $blocks | append (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+{{- range $ordered -}}
+  {{- $parts := slice -}}
+  {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+    {{- $parts = $parts | append . -}}
   {{- end -}}
+  {{- with strings.TrimSpace .RenderShortcodes -}}
+    {{- $parts = $parts | append . -}}
+  {{- end -}}
+  {{- with $parts -}}{{- $blocks = $blocks | append (delimit . "\n\n") -}}{{- end -}}
 {{- end -}}
+
 {{- $content := printf "# %s\n\n" .Title -}}
 {{- with .Description }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+{{- with strings.TrimSpace .RenderShortcodes }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
 {{- range $blocks -}}
-  {{- $b := strings.TrimSpace . -}}
   {{- /* Skip blocks that reduce to a bare heading: video and image-only
          sections keep nothing an agent can read. */ -}}
-  {{- if and $b (not (findRE `^#+ [^\n]*$` $b)) -}}
-    {{- $content = printf "%s%s\n\n" $content $b -}}
+  {{- if not (findRE `^#+ [^\n]*$` .) -}}
+    {{- $content = printf "%s%s\n\n" $content . -}}
   {{- end -}}
 {{- end -}}
-{{- /* Tighten bullet lists that the recursive join spaced out. */ -}}
-{{- $content = replaceRE `\n\n(- )` "\n$1" $content -}}
-{{- /* Same internal-link rewriting as the docs Markdown output. */ -}}
-{{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](https://qdrant.tech${1}index.md${2}` $content -}}
-{{- $content = replaceRE `<(/[^>]*/)>` `<https://qdrant.tech${1}index.md>` $content -}}
 {{- /* safeHTML: the params are plain strings, so without it Go's HTML escaping
        turns "+" into "&#43;" and "<" into "&lt;". */ -}}
-{{ $content | safeHTML }}
+{{ partial "md-finish.txt" $content | safeHTML }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-marketing-page.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-marketing-page.txt
@@ -7,7 +7,27 @@
 > Search the documentation at https://skills.qdrant.tech/search?query=your+query+here
 > Use this file to discover all available pages: https://qdrant.tech/llms.txt
 
-{{ $pages := sort .Pages "File.Path" -}}
+{{ $all := sort .Pages "File.Path" -}}
+{{- /* Some bundles build a page of their own rather than a block of this one:
+   /rag holds rag-evaluation-guide plus its rag-evaluation-guide-* blocks, which
+   build /rag/rag-evaluation-guide/ and get their own Markdown there. A bundle
+   that overrides the section cascade with render: always is one of those, and
+   the blocks named after it belong to it. */ -}}
+{{- $siblings := slice -}}
+{{- range $all -}}
+  {{- if eq (index (.Params.build | default dict) "render") "always" -}}
+    {{- $siblings = $siblings | append .File.BaseFileName -}}
+  {{- end -}}
+{{- end -}}
+{{- $pages := slice -}}
+{{- range $all -}}
+  {{- $base := .File.BaseFileName -}}
+  {{- $elsewhere := false -}}
+  {{- range $siblings -}}
+    {{- if or (eq $base .) (hasPrefix $base (printf "%s-" .)) -}}{{- $elsewhere = true -}}{{- end -}}
+  {{- end -}}
+  {{- if not $elsewhere -}}{{- $pages = $pages | append . -}}{{- end -}}
+{{- end -}}
 {{- $ordered := slice -}}
 {{- range $pages -}}
   {{- if in (lower .File.BaseFileName) "hero" -}}{{- $ordered = $ordered | append . -}}{{- end -}}
@@ -19,8 +39,16 @@
 {{- $blocks := slice -}}
 {{- /* A single page (industries/*) carries its sections in its own params. */ -}}
 {{- if not $ordered -}}
-  {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 1 "skipTitle" true)) -}}
+  {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 1 "skipTitle" true "omit" (slice .Title .Description))) -}}
     {{- $blocks = $blocks | append . -}}
+  {{- end -}}
+  {{- /* rag-evaluation-guide keeps its blocks as siblings in the parent section
+         rather than in its own params, so collect the ones named after it. */ -}}
+  {{- $prefix := printf "%s-" .File.BaseFileName -}}
+  {{- with .Parent -}}
+    {{- range (sort .Pages "File.Path") -}}
+      {{- if hasPrefix .File.BaseFileName $prefix -}}{{- $ordered = $ordered | append . -}}{{- end -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- range $ordered -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-marketing-page.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-marketing-page.txt
@@ -1,0 +1,38 @@
+{{- /*
+  Markdown output for a marketing landing page: rolls the page's headless
+  section bundles up into one document, hero first, then by file path.
+*/ -}}
+> Explore Qdrant's agent skills catalog at https://skills.qdrant.tech/
+> Search the documentation at https://skills.qdrant.tech/search?query=your+query+here
+> Use this file to discover all available pages: https://qdrant.tech/llms.txt
+
+{{ $pages := sort .Pages "File.Path" -}}
+{{- $blocks := slice -}}
+{{- range $pages -}}
+  {{- if in (lower .File.BaseFileName) "hero" -}}
+    {{- $blocks = $blocks | append (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+  {{- end -}}
+{{- end -}}
+{{- range $pages -}}
+  {{- if not (in (lower .File.BaseFileName) "hero") -}}
+    {{- $blocks = $blocks | append (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+  {{- end -}}
+{{- end -}}
+{{- $content := printf "# %s\n\n" .Title -}}
+{{- with .Description }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+{{- range $blocks -}}
+  {{- $b := strings.TrimSpace . -}}
+  {{- /* Skip blocks that reduce to a bare heading: video and image-only
+         sections keep nothing an agent can read. */ -}}
+  {{- if and $b (not (findRE `^#+ [^\n]*$` $b)) -}}
+    {{- $content = printf "%s%s\n\n" $content $b -}}
+  {{- end -}}
+{{- end -}}
+{{- /* Tighten bullet lists that the recursive join spaced out. */ -}}
+{{- $content = replaceRE `\n\n(- )` "\n$1" $content -}}
+{{- /* Same internal-link rewriting as the docs Markdown output. */ -}}
+{{- $content = replaceRE `\]\((/[^):]*/)([\)#?])` `](https://qdrant.tech${1}index.md${2}` $content -}}
+{{- $content = replaceRE `<(/[^>]*/)>` `<https://qdrant.tech${1}index.md>` $content -}}
+{{- /* safeHTML: the params are plain strings, so without it Go's HTML escaping
+       turns "+" into "&#43;" and "<" into "&lt;". */ -}}
+{{ $content | safeHTML }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-params.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-params.txt
@@ -13,13 +13,18 @@
   ponytail: substring key matching, not a per-page field mapping. Hand-write a
   section's own list.markdown.md if its generated output reads badly.
 
-  Params: v (any), level (int, heading depth), item (bool, rendering a list entry)
+  Params: v (any), level (int, heading depth), item (bool, rendering a list entry),
+          omit (slice of strings already printed by the caller)
 */ -}}
 {{- $v := .v -}}
 {{- $level := .level | default 2 -}}
 {{- $item := .item | default false -}}
 {{- $drop := slice "src" "alt" "icon" "image" "img" "logo" "avatar" "photo" "path" "color" "class" "id" "form" "schema" "video" "youtube" "background" "illustration" "visual" "badge" -}}
 {{- $keep := slice "title" "heading" "question" "name" "tab" "text" "subtitle" "description" "content" "answer" "quote" "review" "testimonial" "position" "role" "summary" "part" "benefit" "value" "lesson" "problem" "solution" "step" "stat" -}}
+{{- /* Exact matches, not substrings: "start" must not catch startFree, and
+       "place" must not catch marketplace. Events and Vector Space Day carry
+       their when and where in these. */ -}}
+{{- $keepExact := slice "start" "end" "date" "time" "place" "location" "venue" -}}
 {{- $titleKeys := slice "title" "heading" "question" "name" "tab" "text" -}}
 {{- $bodyOrder := slice "subtitle" "description" "content" "answer" "quote" "review" -}}
 {{- $out := slice -}}
@@ -49,10 +54,22 @@
     {{- else -}}
       {{- $kept := false -}}
       {{- range $keep -}}{{- if in $kl . -}}{{- $kept = true -}}{{- end -}}{{- end -}}
+      {{- $labelled := in $keepExact $kl -}}
+      {{- if $labelled -}}{{- $kept = true -}}{{- end -}}
       {{- /* Copy carries inline markup for styling; agents want the words. */ -}}
       {{- $s := replaceRE `</?(span|br|b|i|em|strong|p|div|small|sup|sub)[^>]*>` " " (printf "%v" $val) -}}
       {{- $s = strings.TrimSpace (replaceRE `\s+` " " $s) -}}
-      {{- if and $kept $s -}}{{- $scalars = merge $scalars (dict $kl $s) -}}{{- end -}}
+      {{- /* omit: copy the caller already printed, e.g. the page title and
+             description above a single page's own params. */ -}}
+      {{- /* Hugo types bare YAML dates as timestamps, which stringify as
+             "2023-02-13 00:00:00 +0000 UTC". */ -}}
+      {{- $s = replaceRE ` [+-]\d{4} \w+$` "" $s -}}
+      {{- $s = replaceRE ` 00:00:00$` "" $s -}}
+      {{- /* When and where mean nothing unlabelled: "Online", "2026-04-21T17:00". */ -}}
+      {{- if and $labelled $s -}}{{- $s = printf "%s: %s" (title $kl) $s -}}{{- end -}}
+      {{- if and $kept $s (not (in ($.omit | default slice) $s)) -}}
+        {{- $scalars = merge $scalars (dict $kl $s) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 
@@ -91,6 +108,9 @@
   {{- else if and (ne $url "") (not $body) (not $children) -}}
     {{- /* Bare call to action: just the link. */ -}}
     {{- with $label -}}{{- $out = $out | append . -}}{{- end -}}
+  {{- else if not (or $body $children (ne $url "")) -}}
+    {{- /* Title and nothing else: a badge or kicker, not a section. Emitting it
+           leaves an orphan heading with no content under it. */ -}}
   {{- else -}}
     {{- with $title -}}
       {{- $out = $out | append (printf "%s %s" (strings.Repeat $level "#") .) -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-params.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-params.txt
@@ -1,0 +1,106 @@
+{{- /*
+  Renders arbitrary marketing front-matter params as Markdown, recursively.
+  Marketing pages keep their copy in params instead of page bodies, so the
+  generic .RenderShortcodes Markdown output comes out empty for them.
+
+  Keys that read like copy are kept; image, icon and bookkeeping keys are
+  dropped. A map without nested children renders as a bullet inside a list and
+  as a heading otherwise.
+
+  .txt, not .html, so Hugo treats it as a text template and stops escaping
+  "+" and "<" into HTML entities.
+
+  ponytail: substring key matching, not a per-page field mapping. Hand-write a
+  section's own list.markdown.md if its generated output reads badly.
+
+  Params: v (any), level (int, heading depth), item (bool, rendering a list entry)
+*/ -}}
+{{- $v := .v -}}
+{{- $level := .level | default 2 -}}
+{{- $item := .item | default false -}}
+{{- $drop := slice "src" "alt" "icon" "image" "img" "logo" "avatar" "photo" "path" "color" "class" "id" "form" "schema" "video" "youtube" "background" "illustration" "visual" "badge" -}}
+{{- $keep := slice "title" "heading" "question" "name" "tab" "text" "subtitle" "description" "content" "answer" "quote" "review" "position" "summary" "part" "benefit" "value" "lesson" "problem" "solution" "step" "stat" -}}
+{{- $titleKeys := slice "title" "heading" "question" "name" "tab" "text" -}}
+{{- $bodyOrder := slice "subtitle" "description" "content" "answer" "quote" "review" -}}
+{{- $out := slice -}}
+
+{{- if reflect.IsSlice $v -}}
+  {{- range $v -}}
+    {{- with partial "md-params.txt" (dict "v" . "level" $level "item" true) -}}
+      {{- $out = $out | append . -}}
+    {{- end -}}
+  {{- end -}}
+
+{{- else if reflect.IsMap $v -}}
+  {{- $url := "" -}}
+  {{- $scalars := dict -}}
+  {{- $children := slice -}}
+  {{- range $k, $val := $v -}}
+    {{- $kl := lower $k -}}
+    {{- $dropped := false -}}
+    {{- range $drop -}}{{- if in $kl . -}}{{- $dropped = true -}}{{- end -}}{{- end -}}
+    {{- if $dropped -}}
+    {{- else if or (reflect.IsMap $val) (reflect.IsSlice $val) -}}
+      {{- with partial "md-params.txt" (dict "v" $val "level" (add $level 1)) -}}
+        {{- $children = $children | append . -}}
+      {{- end -}}
+    {{- else if in (slice "url" "link") $kl -}}
+      {{- $url = printf "%v" $val -}}
+    {{- else -}}
+      {{- $kept := false -}}
+      {{- range $keep -}}{{- if in $kl . -}}{{- $kept = true -}}{{- end -}}{{- end -}}
+      {{- /* Copy carries inline markup for styling; agents want the words. */ -}}
+      {{- $s := replaceRE `</?(span|br|b|i|em|strong|p|div|small|sup|sub)[^>]*>` " " (printf "%v" $val) -}}
+      {{- $s = strings.TrimSpace (replaceRE `\s+` " " $s) -}}
+      {{- if and $kept $s -}}{{- $scalars = merge $scalars (dict $kl $s) -}}{{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- /* Heading: the first title-ish key present. The others are alternate
+         labels for the same block (tab captions, link text), so drop them. */ -}}
+  {{- $title := "" -}}
+  {{- range $titleKeys -}}
+    {{- if not $title -}}{{- with index $scalars . -}}{{- $title = . -}}{{- end -}}{{- end -}}
+  {{- end -}}
+
+  {{- /* Body: known copy keys in reading order, then anything else kept. */ -}}
+  {{- $body := slice -}}
+  {{- range $bodyOrder -}}
+    {{- with index $scalars . -}}{{- $body = $body | append . -}}{{- end -}}
+  {{- end -}}
+  {{- range $k, $s := $scalars -}}
+    {{- if not (or (in $titleKeys $k) (in $bodyOrder $k)) -}}
+      {{- $body = $body | append $s -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $label := cond (and (ne $url "") (ne $title "")) (printf "[%s](%s)" $title $url) $title -}}
+  {{- if and (eq $title "") (ne $url "") -}}{{- $label = printf "<%s>" $url -}}{{- end -}}
+
+  {{- if and $item (not $children) -}}
+    {{- /* Leaf list entry: one bullet. Entries with children stay headings so
+           the nesting (tabs holding features, sections holding cards) survives. */ -}}
+    {{- $line := $label -}}
+    {{- with delimit $body " " -}}
+      {{- $line = cond (ne $line "") (printf "**%s** — %s" $line .) . -}}
+    {{- end -}}
+    {{- with $line -}}{{- $out = $out | append (printf "- %s" .) -}}{{- end -}}
+  {{- else if and (ne $url "") (not $body) (not $children) -}}
+    {{- /* Bare call to action: just the link. */ -}}
+    {{- with $label -}}{{- $out = $out | append . -}}{{- end -}}
+  {{- else -}}
+    {{- with $title -}}
+      {{- $out = $out | append (printf "%s %s" (strings.Repeat $level "#") .) -}}
+    {{- end -}}
+    {{- range $body -}}{{- $out = $out | append . -}}{{- end -}}
+    {{- if ne $url "" -}}{{- $out = $out | append $label -}}{{- end -}}
+    {{- range $children -}}{{- $out = $out | append . -}}{{- end -}}
+  {{- end -}}
+
+{{- else -}}
+  {{- with strings.TrimSpace (printf "%v" $v) -}}{{- $out = $out | append . -}}{{- end -}}
+{{- end -}}
+
+{{- /* uniq: logo and partner strips repeat their entries to animate as a
+       marquee, which is noise once it is a list. */ -}}
+{{- return (delimit (uniq $out) "\n\n") -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-params.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-params.txt
@@ -19,7 +19,7 @@
 {{- $level := .level | default 2 -}}
 {{- $item := .item | default false -}}
 {{- $drop := slice "src" "alt" "icon" "image" "img" "logo" "avatar" "photo" "path" "color" "class" "id" "form" "schema" "video" "youtube" "background" "illustration" "visual" "badge" -}}
-{{- $keep := slice "title" "heading" "question" "name" "tab" "text" "subtitle" "description" "content" "answer" "quote" "review" "position" "summary" "part" "benefit" "value" "lesson" "problem" "solution" "step" "stat" -}}
+{{- $keep := slice "title" "heading" "question" "name" "tab" "text" "subtitle" "description" "content" "answer" "quote" "review" "testimonial" "position" "role" "summary" "part" "benefit" "value" "lesson" "problem" "solution" "step" "stat" -}}
 {{- $titleKeys := slice "title" "heading" "question" "name" "tab" "text" -}}
 {{- $bodyOrder := slice "subtitle" "description" "content" "answer" "quote" "review" -}}
 {{- $out := slice -}}
@@ -44,7 +44,7 @@
       {{- with partial "md-params.txt" (dict "v" $val "level" (add $level 1)) -}}
         {{- $children = $children | append . -}}
       {{- end -}}
-    {{- else if in (slice "url" "link") $kl -}}
+    {{- else if in (slice "url" "link" "href") $kl -}}
       {{- $url = printf "%v" $val -}}
     {{- else -}}
       {{- $kept := false -}}
@@ -62,6 +62,9 @@
   {{- range $titleKeys -}}
     {{- if not $title -}}{{- with index $scalars . -}}{{- $title = . -}}{{- end -}}{{- end -}}
   {{- end -}}
+  {{- /* Top-level call on a page's own params: the H1 already says this, and
+         the url is the page's own permalink. */ -}}
+  {{- if .skipTitle -}}{{- $title = "" -}}{{- $url = "" -}}{{- end -}}
 
   {{- /* Body: known copy keys in reading order, then anything else kept. */ -}}
   {{- $body := slice -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/md-tier-table.txt
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/md-tier-table.txt
@@ -1,0 +1,29 @@
+{{- /*
+  Renders a tier comparison as a Markdown table. Pricing carries its value in
+  per-tier cells (tier × feature), which collapse to nothing useful if flattened
+  into prose.
+
+  Params: tiers (slice of {id, name}), sections (slice of {name, features}),
+          first (header for the first column, default "Feature")
+*/ -}}
+{{- $tiers := .tiers -}}
+{{- $head := slice (.first | default "Feature") -}}
+{{- range $tiers -}}{{- $head = $head | append (.name | default .id) -}}{{- end -}}
+{{- $out := printf "| %s |\n|%s\n" (delimit $head " | ") (strings.Repeat (len $head) " --- |") -}}
+{{- range .sections -}}
+  {{- with .name -}}
+    {{- $out = printf "%s| **%s** |%s\n" $out . (strings.Repeat (len $tiers) " |") -}}
+  {{- end -}}
+  {{- range .features -}}
+    {{- $row := slice (.name | default .title) -}}
+    {{- $f := . -}}
+    {{- range $tiers -}}
+      {{- $cell := index $f .id -}}
+      {{- if eq $cell true -}}{{- $row = $row | append "Yes" -}}
+      {{- else if or (eq $cell false) (eq $cell nil) -}}{{- $row = $row | append "—" -}}
+      {{- else -}}{{- $row = $row | append (printf "%v" $cell) -}}{{- end -}}
+    {{- end -}}
+    {{- $out = printf "%s| %s |\n" $out (delimit $row " | ") -}}
+  {{- end -}}
+{{- end -}}
+{{- return $out -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partners/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partners/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/pricing/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/pricing/list.markdown.md
@@ -1,7 +1,11 @@
 {{- /*
   Pricing is the one page the generic params renderer cannot carry: its value
-  lives in per-tier cells (tier × feature), which only survive as tables.
-  Everything else on the page still goes through the generic renderer.
+  lives in per-tier cells (tier × feature) and in tier cards, which collapse to
+  bare feature names if flattened into prose.
+
+  Which bundles are live is decided in pricing/list.html, not by what exists in
+  content/pricing: doors-a is a retired A/B variant and must stay out, or this
+  page reports prices the site no longer shows.
 */ -}}
 > Explore Qdrant's agent skills catalog at https://skills.qdrant.tech/
 > Search the documentation at https://skills.qdrant.tech/search?query=your+query+here
@@ -9,58 +13,53 @@
 
 {{ $content := printf "# %s\n\n" .Title -}}
 {{- with .Description }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+{{- with .Site.GetPage "/pricing/qdrant-pricing-hero" -}}
+  {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+    {{- $content = printf "%s%s\n\n" $content . -}}
+  {{- end -}}
+{{- end -}}
 
-{{- /* Tier cards: price and per-tier feature lists. */ -}}
-{{- range (sort .Pages "File.Path") -}}
-  {{- if in .File.BaseFileName "doors" -}}
-    {{- $note := .Params.pricingNote -}}
-    {{- range .Params.cards -}}
-      {{- $content = printf "%s## %s\n\n" $content .title -}}
-      {{- with .price -}}
+{{- /* Tier cards, grouped by deployment tab. */ -}}
+{{- with .Site.GetPage "/pricing/qdrant-pricing-doors-b" -}}
+  {{- range .Params.tabs -}}
+    {{- $content = printf "%s## %s\n\n" $content (.label | default .id) -}}
+    {{- range .tiers -}}
+      {{- $tier := . -}}
+      {{- $content = printf "%s### %s\n\n" $content .title -}}
+      {{- with .pricing -}}
         {{- $content = printf "%s**%s**" $content . -}}
-        {{- with $note }}{{ $content = printf "%s %s" $content . }}{{ end -}}
+        {{- with $tier.pricingNote }}{{ $content = printf "%s %s" $content . }}{{ end -}}
         {{- $content = printf "%s\n\n" $content -}}
       {{- end -}}
-      {{- with .description }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
-      {{- with .featureDescription }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
-      {{- range .features -}}
-        {{- with .content }}{{ $content = printf "%s- %s\n" $content . }}{{ end -}}
+      {{- with .target }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+      {{- range .features }}{{ $content = printf "%s- %s\n" $content . }}{{ end -}}
+      {{- with .marketplace -}}
+        {{- $names := slice -}}
+        {{- range .logos -}}{{- $names = $names | append .name -}}{{- end -}}
+        {{- $content = printf "%s\n%s %s\n" $content (.label | default "Available on:") (delimit $names ", ") -}}
       {{- end -}}
-      {{- with .button }}{{ $content = printf "%s\n[%s](%s)\n\n" $content .text .url }}{{ end -}}
+      {{- with .cta }}{{ $content = printf "%s\n[%s](%s)\n\n" $content .text .url }}{{ end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
 
-{{- /* Feature comparison: one Markdown table per tier group. */ -}}
+{{- /* Tier comparison tables: feature matrix and support matrix. */ -}}
 {{- with .Site.GetPage "/pricing/qdrant-pricing-features" -}}
   {{- $content = printf "%s## %s\n\n" $content .Title -}}
   {{- range .Params.tables -}}
-    {{- $tiers := .tiers -}}
     {{- with .label }}{{ $content = printf "%s### %s\n\n" $content . }}{{ end -}}
-    {{- $head := slice "Feature" -}}
-    {{- range $tiers -}}{{- $head = $head | append .name -}}{{- end -}}
-    {{- $content = printf "%s| %s |\n|%s\n" $content (delimit $head " | ") (strings.Repeat (len $head) " --- |") -}}
-    {{- range .sections -}}
-      {{- with .name }}{{ $content = printf "%s| **%s** |%s\n" $content . (strings.Repeat (len $tiers) " |") }}{{ end -}}
-      {{- range .features -}}
-        {{- $row := slice .name -}}
-        {{- $f := . -}}
-        {{- range $tiers -}}
-          {{- $cell := index $f .id -}}
-          {{- if eq $cell true -}}{{- $row = $row | append "Yes" -}}
-          {{- else if or (eq $cell false) (eq $cell nil) -}}{{- $row = $row | append "—" -}}
-          {{- else -}}{{- $row = $row | append (printf "%v" $cell) -}}{{- end -}}
-        {{- end -}}
-        {{- $content = printf "%s| %s |\n" $content (delimit $row " | ") -}}
-      {{- end -}}
-    {{- end -}}
-    {{- $content = printf "%s\n" $content -}}
+    {{- $content = printf "%s%s\n" $content (partial "md-tier-table.txt" (dict "tiers" .tiers "sections" .sections)) -}}
   {{- end -}}
 {{- end -}}
+{{- with .Site.GetPage "/pricing/qdrant-pricing-support-reliability" -}}
+  {{- $content = printf "%s## %s\n\n" $content .Title -}}
+  {{- $content = printf "%s%s\n" $content (partial "md-tier-table.txt" (dict "tiers" .Params.tiers "sections" .Params.sections "first" "Support")) -}}
+  {{- with .Params.button }}{{ $content = printf "%s[%s](%s)\n\n" $content .text .url }}{{ end -}}
+{{- end -}}
 
-{{- /* Everything else on the page, generically. */ -}}
-{{- range (sort .Pages "File.Path") -}}
-  {{- if not (or (in .File.BaseFileName "doors") (in .File.BaseFileName "features")) -}}
+{{- /* Calculator, FAQ and closing CTA, generically. */ -}}
+{{- range (slice "qdrant-pricing-calculator" "qdrant-pricing-faq" "qdrant-pricing-cta") -}}
+  {{- with $.Site.GetPage (printf "/pricing/%s" .) -}}
     {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
       {{- if not (findRE `^#+ [^\n]*$` .) -}}{{- $content = printf "%s%s\n\n" $content . -}}{{- end -}}
     {{- end -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/pricing/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/pricing/list.markdown.md
@@ -1,0 +1,69 @@
+{{- /*
+  Pricing is the one page the generic params renderer cannot carry: its value
+  lives in per-tier cells (tier × feature), which only survive as tables.
+  Everything else on the page still goes through the generic renderer.
+*/ -}}
+> Explore Qdrant's agent skills catalog at https://skills.qdrant.tech/
+> Search the documentation at https://skills.qdrant.tech/search?query=your+query+here
+> Use this file to discover all available pages: https://qdrant.tech/llms.txt
+
+{{ $content := printf "# %s\n\n" .Title -}}
+{{- with .Description }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+
+{{- /* Tier cards: price and per-tier feature lists. */ -}}
+{{- range (sort .Pages "File.Path") -}}
+  {{- if in .File.BaseFileName "doors" -}}
+    {{- $note := .Params.pricingNote -}}
+    {{- range .Params.cards -}}
+      {{- $content = printf "%s## %s\n\n" $content .title -}}
+      {{- with .price -}}
+        {{- $content = printf "%s**%s**" $content . -}}
+        {{- with $note }}{{ $content = printf "%s %s" $content . }}{{ end -}}
+        {{- $content = printf "%s\n\n" $content -}}
+      {{- end -}}
+      {{- with .description }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+      {{- with .featureDescription }}{{ $content = printf "%s%s\n\n" $content . }}{{ end -}}
+      {{- range .features -}}
+        {{- with .content }}{{ $content = printf "%s- %s\n" $content . }}{{ end -}}
+      {{- end -}}
+      {{- with .button }}{{ $content = printf "%s\n[%s](%s)\n\n" $content .text .url }}{{ end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Feature comparison: one Markdown table per tier group. */ -}}
+{{- with .Site.GetPage "/pricing/qdrant-pricing-features" -}}
+  {{- $content = printf "%s## %s\n\n" $content .Title -}}
+  {{- range .Params.tables -}}
+    {{- $tiers := .tiers -}}
+    {{- with .label }}{{ $content = printf "%s### %s\n\n" $content . }}{{ end -}}
+    {{- $head := slice "Feature" -}}
+    {{- range $tiers -}}{{- $head = $head | append .name -}}{{- end -}}
+    {{- $content = printf "%s| %s |\n|%s\n" $content (delimit $head " | ") (strings.Repeat (len $head) " --- |") -}}
+    {{- range .sections -}}
+      {{- with .name }}{{ $content = printf "%s| **%s** |%s\n" $content . (strings.Repeat (len $tiers) " |") }}{{ end -}}
+      {{- range .features -}}
+        {{- $row := slice .name -}}
+        {{- $f := . -}}
+        {{- range $tiers -}}
+          {{- $cell := index $f .id -}}
+          {{- if eq $cell true -}}{{- $row = $row | append "Yes" -}}
+          {{- else if or (eq $cell false) (eq $cell nil) -}}{{- $row = $row | append "—" -}}
+          {{- else -}}{{- $row = $row | append (printf "%v" $cell) -}}{{- end -}}
+        {{- end -}}
+        {{- $content = printf "%s| %s |\n" $content (delimit $row " | ") -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $content = printf "%s\n" $content -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Everything else on the page, generically. */ -}}
+{{- range (sort .Pages "File.Path") -}}
+  {{- if not (or (in .File.BaseFileName "doors") (in .File.BaseFileName "features")) -}}
+    {{- with strings.TrimSpace (partial "md-params.txt" (dict "v" .Params "level" 2)) -}}
+      {{- if not (findRE `^#+ [^\n]*$` .) -}}{{- $content = printf "%s%s\n\n" $content . -}}{{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{ partial "md-finish.txt" $content | safeHTML }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/private-cloud/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/private-cloud/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/qdrant-cloud/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/qdrant-cloud/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/qdrant-for-startups/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/qdrant-for-startups/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/qdrant-vector-database/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/qdrant-vector-database/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/recommendations/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/recommendations/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/retrieval-augmented-generation/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/retrieval-augmented-generation/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/retrieval-augmented-generation/single.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/retrieval-augmented-generation/single.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/stars/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/stars/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/use-cases/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/use-cases/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/vsd-recap/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/vsd-recap/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}

--- a/qdrant-landing/themes/qdrant-2024/layouts/vsd/list.markdown.md
+++ b/qdrant-landing/themes/qdrant-2024/layouts/vsd/list.markdown.md
@@ -1,0 +1,1 @@
+{{ partial "md-marketing-page.txt" . }}


### PR DESCRIPTION
Marketing pages already have `.md` URLs. `curl https://qdrant.tech/cloud/index.md` returns 200 `text/markdown` today, but the body is only the page title. The docs Markdown output renders `.RenderShortcodes`, and marketing pages keep their copy in the front-matter params of headless section bundles, so there is nothing for it to render. Every marketing landing page comes out at 250 to 330 bytes.

Two gaps, both fixed here:

**Empty bodies.** `partials/md-params.txt` walks a bundle's params recursively and renders the copy: keys that read like copy are kept, image/icon/bookkeeping keys are dropped, nested lists become headings and bullets. `partials/md-marketing-page.txt` concatenates a section's bundles, hero first, plus any page bodies. Each page gets a one-line `list.markdown.md` that calls it. `/cloud` goes from 282 bytes to 18.8KB. 33 pages are covered.

**Discovery.** `llms.txt` only walked `RegularPages`, so no section landing page was listed. `/cloud`, `/pricing`, `/edge` and `/customers` were absent entirely. A `## Pages` group now lists all 40, including the four industry pages, which needed `GetPage` because their parent section sets `build.list: never`.

Two pages are hand-written, because the generic renderer flattens what they are actually for:

- **Pricing.** Its value lives in per-tier cells (tier by feature), which only survive as tables. Writing that template surfaced a bug in it, caught before merge: `pricing/list.html` renders `qdrant-pricing-doors-b`, and the Markdown template was reading `doors-a`, a retired A/B variant. The HTML page was always correct; the Markdown published tier cards the site no longer shows, dropped the live ones, and flattened the Support and Reliability matrix to bare row names. Tables now come from a shared `md-tier-table.txt` partial driven by tiers by sections, so both matrices render.
- **Customers.** `customers/list.html` renders two bundles, `customers-hero` and `clients`. The generic rollup walked `.Pages`, which still holds 18 bundles the page stopped rendering (`case-study-*`, `case-studies-1/2`, `logo-cards-*`, `testimonial-*`, `vector-space-wall`), and republished them, duplicating nine case studies. The client directory now renders as a table so the facets the page filters on stay queryable.

`/rag` had the same shape of problem across pages rather than within one: it rolled up the `rag-evaluation-guide-*` bundles, which build `/rag/rag-evaluation-guide/`. A bundle that overrides the section cascade with `render: always` is a page in its own right, so it and the blocks named after it are excluded. That page rendered from `_default` at 27 words and now rolls up its own sibling blocks.

`automation/check-markdown-output.sh` runs in the Links workflow, which already builds the site. It fails if a page stops rolling up (a broken template falls back to the title, which the word count catches), if HTML escaping or `<span>`/`<br>` leak into the copy, if internal links are not rewritten, if pricing loses its tier tables, if a bundle `pricing/list.html` renders does not reach the Markdown, if the client table stops matching the source, or if `llms.txt` stops listing the pages.

### Relation to #2428

Same goal, different approach. #2428 hand-maps each page's params, about 57 lines per page. That PR also shows the maintenance cost: it reads `qdrant-cloud-bento-cards` and `qdrant-cloud-features-link`, both deleted in #2542 when the Cloud page was restructured, so two of its six blocks render nothing and nothing fails. `/cloud` builds to 182 words through that template today, against 2465 through this one, with a `[<no value>](<no value>)` where `contactUs` used to be.

The generic renderer follows content restructuring on its own, at the cost of output that reads less deliberately than hand-written mapping. #2428's `qdrant-vector-database` template is better than the generated version of that page: it stitches `content` + `contentLink` + `contentSecondPart` into one sentence where this leaves a stray `available.`, and it orders blocks the way the page does. Happy to go the other way on any page where that trade looks wrong. A section can override with its own `list.markdown.md`, which is what pricing and customers do, so both approaches coexist.

### Notes for review

- Generated Markdown is only as good as the params. `/private-cloud` renders `# private-cloud` with the body `private-cloud`, because `content/private-cloud/_index.md` has that as its literal title and description. `/customers`, `/partners` and `/events` use their title as their description. These are the H1 and the `llms.txt` summary now, so they are the first thing an agent reads. Left for whoever owns that copy.
- Three content fixes are included. `content/pricing/_index.md` read `Solutions  Qdrant`, a double space where the site's `|` separator belongs, which was wrong in the HTML `<title>` too. One client in `content/customers/clients/_index.md` had `locationse` instead of `location`, which also left it out of the location filter on the live page. `content/get_anonymous_id/_index.md` gets `sitemapExclude`, since it is the iframe endpoint for the Cloud console rather than a page, and it was appearing in both the page list and the sitemap. Its HTML still builds unchanged.
- `/contact-us` and `/subscribe` stay title-only, being forms with nothing to render. `/learn` has its own agent page from #2462.
- Known rough edges, documented in the templates: block order follows filename rather than the order the page renders in; the one stray `available.` on `/qdrant-vector-database`; four duplicate lines across all 33 pages, all of them content that genuinely repeats, such as the same testimonial author twice on `/e-commerce`.
- Built and verified locally on Hugo 0.164. CI builds the pinned 0.160.1.
