### PR TITLE
Remove reference to local mode from quickstart

### DIFF
--- a/qdrant-landing/content/documentation/quickstart.md
+++ b/qdrant-landing/content/documentation/quickstart.md
@@ -609,3 +609,5 @@ Now you know how Qdrant works. Getting started with [Qdrant Cloud](/documentatio
 To move onto some more complex examples of vector search, read our [Tutorials](/documentation/tutorials-lp-overview/) and create your own app with the help of our [Examples](/documentation/examples/).
 
 When you're ready to deploy, run through the [Production Checklist](/documentation/production-checklist/) to make sure your instance is secure and optimized.
+
+**Note**: For embedded, on-device vector search, try [Qdrant Edge](/documentation/edge/edge-quickstart/), a lightweight library with support for Python and Rust that runs directly inside your application.

--- a/qdrant-landing/content/documentation/quickstart.md
+++ b/qdrant-landing/content/documentation/quickstart.md
@@ -610,4 +610,4 @@ To move onto some more complex examples of vector search, read our [Tutorials](/
 
 When you're ready to deploy, run through the [Production Checklist](/documentation/production-checklist/) to make sure your instance is secure and optimized.
 
-**Note**: For embedded, on-device vector search, try [Qdrant Edge](/documentation/edge/edge-quickstart/), a lightweight library with support for Python and Rust that runs directly inside your application.
+**Note**: Qdrant can also run embedded, right inside your application, with no separate server required. [Qdrant Edge](/documentation/edge/edge-quickstart/) is a lightweight vector search engine that supports Python and Rust and runs directly in-process.

--- a/qdrant-landing/content/documentation/quickstart.md
+++ b/qdrant-landing/content/documentation/quickstart.md
@@ -609,5 +609,3 @@ Now you know how Qdrant works. Getting started with [Qdrant Cloud](/documentatio
 To move onto some more complex examples of vector search, read our [Tutorials](/documentation/tutorials-lp-overview/) and create your own app with the help of our [Examples](/documentation/examples/).
 
 When you're ready to deploy, run through the [Production Checklist](/documentation/production-checklist/) to make sure your instance is secure and optimized.
-
-**Note:** There is another way of running Qdrant locally. If you are a Python developer, we recommend that you try Local Mode in [Qdrant Client](https://github.com/qdrant/qdrant-client), as it only takes a few moments to get setup.


### PR DESCRIPTION
## Overview

### [Preview](https://deploy-preview-2597--condescending-goldwasser-91acf0.netlify.app/documentation/quickstart/#next-steps)

This PR removes the note from the bottom of the Quickstart page that recommends using the Local mode in the Py client and adds a reference to Qdrant Edge.