### PR TITLE
Update Edge Rust snippets to the new request interfaces

### DIFF
--- a/automation/snippets/templates/rust/Cargo.lock
+++ b/automation/snippets/templates/rust/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blink-alloc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4c15bad517bc0fb4a44523adf470e2c3eb3a365769327acdba849948ea3705"
+dependencies = [
+ "allocator-api2 0.4.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +753,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
 ]
 
 [[package]]
@@ -1519,7 +1545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
+ "allocator-api2 0.2.21",
 ]
 
 [[package]]
@@ -1528,7 +1554,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.1.5",
 ]
@@ -1539,10 +1565,16 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -1616,6 +1648,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
@@ -2001,6 +2039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2230,9 +2277,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2806,7 +2853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2845,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "qdrant-edge"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5e480105a06c8f1703082758d74a13c98fb7a94df06e12d914460786e55ea"
+checksum = "0b8072302c87506a34bffec9bc16dbdcd36df8ab1321406b6e141530348c7e54"
 dependencies = [
  "ahash",
  "aligned-vec",
@@ -2857,12 +2904,14 @@ dependencies = [
  "bincode 1.3.3",
  "bitpacking",
  "bitvec",
+ "blink-alloc",
  "bytemuck",
  "byteorder",
  "cc",
  "cgroups-rs",
  "charabia",
  "chrono",
+ "core_affinity",
  "crc32c",
  "data-encoding",
  "docopt",
@@ -2876,10 +2925,11 @@ dependencies = [
  "geo",
  "geohash",
  "half 2.7.1",
+ "humantime",
  "indexmap 2.13.0",
  "integer-encoding",
  "io-uring",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "lz4_flex",
  "macro_rules_attribute",
@@ -2891,6 +2941,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_cpus",
+ "once_cell",
  "ordered-float 5.3.0",
  "parking_lot",
  "permutation_iterator",
@@ -2905,7 +2956,6 @@ dependencies = [
  "roaring",
  "rustix 1.1.4",
  "schemars",
- "seahash",
  "self_cell",
  "semver",
  "serde",
@@ -2915,6 +2965,7 @@ dependencies = [
  "serde_json",
  "serde_variant",
  "sha2",
+ "siphasher",
  "slab",
  "smallvec",
  "strum",
@@ -2927,7 +2978,6 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tonic",
- "typed-arena",
  "uuid",
  "validator",
  "vaporetto",
@@ -2947,13 +2997,13 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.22"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
+checksum = "403c1a912fec895cafb223201e368234842acb9220aaf08ab042ae89ba5f135c"
 dependencies = [
- "ahash",
  "equivalent",
- "hashbrown 0.16.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
  "parking_lot",
 ]
 
@@ -3527,12 +3577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,9 +3795,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3892,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -4264,12 +4308,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typeid"
@@ -5211,18 +5249,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/automation/snippets/templates/rust/Cargo.toml
+++ b/automation/snippets/templates/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 anyhow = "1.0.100"
 chrono = "0.4"
 csv = "1.3"
-qdrant-edge = "0.7.2"
+qdrant-edge = "0.8.0"
 fs-err = "3"
 ordered-float = "5"
 qdrant-client = { git = "https://github.com/qdrant/rust-client", branch = "master" }

--- a/qdrant-landing/content/documentation/edge/edge-quickstart.md
+++ b/qdrant-landing/content/documentation/edge/edge-quickstart.md
@@ -112,6 +112,8 @@ For example, to set the WAL size to 4 MB:
 
 {{< code-snippet path="/documentation/headless/snippets/edge/quickstart/" block="wal-options" >}}
 
+When loading an existing Edge Shard, any parameter left unset on the supplied `EdgeConfig` keeps the value persisted with the shard. A config that only sets `wal_options` therefore leaves the rest of the shard's configuration untouched.
+
 ## More Examples
 
 The Qdrant GitHub repository contains examples of using the Qdrant Edge API in [Python](https://github.com/qdrant/qdrant/tree/dev/lib/edge/python/examples) and [Rust](https://github.com/qdrant/qdrant/tree/dev/lib/edge/publish/examples).

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/query-with-bm25/rust.md
@@ -3,18 +3,13 @@ use qdrant_edge::*;
 
 let query_vector = bm25.embed_query("clever fox");
 
-let results = shard.query(QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-        query: VectorInternal::from(query_vector),
-        using: Some("text".to_string()),
-    }))),
-    filter: None,
-    score_threshold: None,
-    limit: 3,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-})?;
+let results = shard.query(
+    QueryRequestBuilder::new(3)
+        .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+            query: VectorInternal::from(query_vector),
+            using: Some("text".to_string()),
+        })))
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build(),
+)?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/generated/rust.md
@@ -45,18 +45,13 @@ use qdrant_edge::*;
 
 let query_vector = bm25.embed_query("clever fox");
 
-let results = shard.query(QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-        query: VectorInternal::from(query_vector),
-        using: Some("text".to_string()),
-    }))),
-    filter: None,
-    score_threshold: None,
-    limit: 3,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-})?;
+let results = shard.query(
+    QueryRequestBuilder::new(3)
+        .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+            query: VectorInternal::from(query_vector),
+            using: Some("text".to_string()),
+        })))
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build(),
+)?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/bm25/rust.rs
@@ -53,20 +53,15 @@ pub async fn main() -> anyhow::Result<()> {
 
     let query_vector = bm25.embed_query("clever fox");
 
-    let results = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: VectorInternal::from(query_vector),
-            using: Some("text".to_string()),
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 3,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = shard.query(
+        QueryRequestBuilder::new(3)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: VectorInternal::from(query_vector),
+                using: Some("text".to_string()),
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     // @block-end query-with-bm25
 
     Ok(())

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/facet/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/facet/rust.md
@@ -1,10 +1,9 @@
 ```rust
 use qdrant_edge::*;
 
-let facet_response = edge_shard.facet(FacetRequest {
-    key: "color".try_into().unwrap(),
-    limit: 10,
-    filter: None,
-    exact: false,
-})?;
+let facet_response = edge_shard.facet(
+    FacetRequestBuilder::new("color".try_into().unwrap())
+        .limit(10)
+        .build(),
+)?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/filter/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/filter/rust.md
@@ -13,18 +13,14 @@ let filter = Filter {
     must_not: None,
 };
 
-let results = edge_shard.query(QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-        query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
-        using: Some(VECTOR_NAME.to_string()),
-    }))),
-    filter: Some(filter),
-    score_threshold: None,
-    limit: 10,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-})?;
+let results = edge_shard.query(
+    QueryRequestBuilder::new(10)
+        .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+            query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
+            using: Some(VECTOR_NAME.to_string()),
+        })))
+        .filter(filter)
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build(),
+)?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/query-points/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/query-points/rust.md
@@ -1,18 +1,13 @@
 ```rust
 use qdrant_edge::*;
 
-let results = edge_shard.query(QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-        query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
-        using: Some(VECTOR_NAME.to_string()),
-    }))),
-    filter: None,
-    score_threshold: None,
-    limit: 10,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-})?;
+let results = edge_shard.query(
+    QueryRequestBuilder::new(10)
+        .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+            query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
+            using: Some(VECTOR_NAME.to_string()),
+        })))
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build(),
+)?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/retrieve-point/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/retrieve-point/rust.md
@@ -2,8 +2,9 @@
 use qdrant_edge::*;
 
 let retrieved = edge_shard.retrieve(
-    &[PointId::NumId(1)],
-    Some(WithPayloadInterface::Bool(true)),
-    Some(WithVector::Bool(false)),
+    RetrieveRequestBuilder::new(vec![PointId::NumId(1)])
+        .with_payload(WithPayloadInterface::Bool(true))
+        .with_vector(WithVector::Bool(false))
+        .build(),
 )?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/generated/rust.md
@@ -47,9 +47,10 @@ edge_shard.update(UpdateOperation::PointOperation(
 use qdrant_edge::*;
 
 let retrieved = edge_shard.retrieve(
-    &[PointId::NumId(1)],
-    Some(WithPayloadInterface::Bool(true)),
-    Some(WithVector::Bool(false)),
+    RetrieveRequestBuilder::new(vec![PointId::NumId(1)])
+        .with_payload(WithPayloadInterface::Bool(true))
+        .with_vector(WithVector::Bool(false))
+        .build(),
 )?;
 
 use qdrant_edge::*;
@@ -66,20 +67,15 @@ edge_shard.update(UpdateOperation::VectorNameOperation(
 
 use qdrant_edge::*;
 
-let results = edge_shard.query(QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-        query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
-        using: Some(VECTOR_NAME.to_string()),
-    }))),
-    filter: None,
-    score_threshold: None,
-    limit: 10,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-})?;
+let results = edge_shard.query(
+    QueryRequestBuilder::new(10)
+        .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+            query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
+            using: Some(VECTOR_NAME.to_string()),
+        })))
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build(),
+)?;
 
 use qdrant_edge::*;
 
@@ -95,29 +91,24 @@ let filter = Filter {
     must_not: None,
 };
 
-let results = edge_shard.query(QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-        query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
-        using: Some(VECTOR_NAME.to_string()),
-    }))),
-    filter: Some(filter),
-    score_threshold: None,
-    limit: 10,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-})?;
+let results = edge_shard.query(
+    QueryRequestBuilder::new(10)
+        .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+            query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
+            using: Some(VECTOR_NAME.to_string()),
+        })))
+        .filter(filter)
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build(),
+)?;
 
 use qdrant_edge::*;
 
-let facet_response = edge_shard.facet(FacetRequest {
-    key: "color".try_into().unwrap(),
-    limit: 10,
-    filter: None,
-    exact: false,
-})?;
+let facet_response = edge_shard.facet(
+    FacetRequestBuilder::new("color".try_into().unwrap())
+        .limit(10)
+        .build(),
+)?;
 
 edge_shard.optimize()?;
 

--- a/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/quickstart/rust.rs
@@ -57,9 +57,10 @@ pub async fn main() -> anyhow::Result<()> {
     use qdrant_edge::*;
 
     let retrieved = edge_shard.retrieve(
-        &[PointId::NumId(1)],
-        Some(WithPayloadInterface::Bool(true)),
-        Some(WithVector::Bool(false)),
+        RetrieveRequestBuilder::new(vec![PointId::NumId(1)])
+            .with_payload(WithPayloadInterface::Bool(true))
+            .with_vector(WithVector::Bool(false))
+            .build(),
     )?;
     // @block-end retrieve-point
 
@@ -80,20 +81,15 @@ pub async fn main() -> anyhow::Result<()> {
     // @block-start query-points
     use qdrant_edge::*;
 
-    let results = edge_shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
-            using: Some(VECTOR_NAME.to_string()),
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 10,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = edge_shard.query(
+        QueryRequestBuilder::new(10)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
+                using: Some(VECTOR_NAME.to_string()),
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     // @block-end query-points
 
     // @block-start filter
@@ -111,31 +107,26 @@ pub async fn main() -> anyhow::Result<()> {
         must_not: None,
     };
 
-    let results = edge_shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
-            using: Some(VECTOR_NAME.to_string()),
-        }))),
-        filter: Some(filter),
-        score_threshold: None,
-        limit: 10,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = edge_shard.query(
+        QueryRequestBuilder::new(10)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
+                using: Some(VECTOR_NAME.to_string()),
+            })))
+            .filter(filter)
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     // @block-end filter
 
     // @block-start facet
     use qdrant_edge::*;
 
-    let facet_response = edge_shard.facet(FacetRequest {
-        key: "color".try_into().unwrap(),
-        limit: 10,
-        filter: None,
-        exact: false,
-    })?;
+    let facet_response = edge_shard.facet(
+        FacetRequestBuilder::new("color".try_into().unwrap())
+            .limit(10)
+            .build(),
+    )?;
     // @block-end facet
 
     // @block-start optimize

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/query-both-shards/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/query-both-shards/rust.md
@@ -3,20 +3,13 @@ use std::cmp::*;
 use std::collections::*;
 use qdrant_edge::*;
 
-let query = QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+let query = QueryRequestBuilder::new(10)
+    .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
         query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
         using: Some(VECTOR_NAME.to_string()),
-    }))),
-    filter: None,
-    score_threshold: None,
-    limit: 10,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-};
+    })))
+    .with_payload(WithPayloadInterface::Bool(true))
+    .build();
 
 let mut all_results = mutable_shard.query(query.clone())?;
 all_results.extend(immutable_shard.query(query)?);

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/generated/rust.md
@@ -158,20 +158,13 @@ use std::cmp::*;
 use std::collections::*;
 use qdrant_edge::*;
 
-let query = QueryRequest {
-    prefetches: vec![],
-    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+let query = QueryRequestBuilder::new(10)
+    .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
         query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
         using: Some(VECTOR_NAME.to_string()),
-    }))),
-    filter: None,
-    score_threshold: None,
-    limit: 10,
-    offset: 0,
-    params: None,
-    with_vector: WithVector::Bool(false),
-    with_payload: WithPayloadInterface::Bool(true),
-};
+    })))
+    .with_payload(WithPayloadInterface::Bool(true))
+    .build();
 
 let mut all_results = mutable_shard.query(query.clone())?;
 all_results.extend(immutable_shard.query(query)?);

--- a/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/edge/synchronization-guide/rust.rs
@@ -176,20 +176,13 @@ pub async fn main() -> anyhow::Result<()> {
     use std::collections::*;
     use qdrant_edge::*;
 
-    let query = QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+    let query = QueryRequestBuilder::new(10)
+        .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
             query: vec![0.2f32, 0.1, 0.9, 0.7].into(),
             using: Some(VECTOR_NAME.to_string()),
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 10,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    };
+        })))
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build();
 
     let mut all_results = mutable_shard.query(query.clone())?;
     all_results.extend(immutable_shard.query(query)?);


### PR DESCRIPTION
Updates the Rust snippets under `/documentation/edge` to the request interfaces introduced in qdrant/qdrant#9901 (*Edge: request-specific structures for `EdgeShardRead`*), and bumps the snippet template to the `qdrant-edge` release that carries them.

## What changed

| Snippet | Block | Change |
|---|---|---|
| `edge/quickstart` | `retrieve-point` | `retrieve()` now takes a `RetrieveRequest` (`RetrieveRequestBuilder`) instead of a `(&[ids], with_payload, with_vector)` triple |
| `edge/quickstart` | `query-points`, `filter` | `QueryRequestBuilder` instead of a `QueryRequest` struct literal |
| `edge/quickstart` | `facet` | `FacetRequestBuilder` instead of a `FacetRequest` struct literal |
| `edge/bm25` | `query-with-bm25` | `QueryRequestBuilder` |
| `edge/synchronization-guide` | `query-both-shards` | `QueryRequestBuilder` |

The `retrieve()` change is the only hard break — the old struct literals still compile, since the edge-owned request structs kept the same field names. The rest is aligned with the builder style now used in the [published Rust examples](https://github.com/qdrant/qdrant/tree/dev/lib/edge/publish/examples).

Also adds one sentence to the quickstart's *Custom WAL Size* section: `EdgeConfig` fields are now `Option`, and `EdgeShard::load` fills unspecified parameters from the persisted config, so a config that only sets `wal_options` no longer resets the rest of the shard configuration.

The second commit bumps `qdrant-edge` `0.7.2` → `0.8.0` in `automation/snippets/templates/rust/Cargo.toml`; 0.8.0 is the first release containing these interfaces. Lockfile refreshed with `cargo update -p qdrant-edge --precise 0.8.0`.

Generated markdown regenerated with `automation/snippets/generate-md.py`.

## Verification

`automation/snippets/check.py build -l rust` passes against the published `qdrant-edge` 0.8.0 — the full Rust snippet set compiles, not just the edge ones.

Python snippets are unaffected — the Python bindings kept their existing signatures (`retrieve()` still takes the id/payload/vector triple). The `Bm25Config` parameter table in `edge-bm25.md` was checked against `EdgeBm25Config` in 0.8.0 and is still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
