### PR TITLE
Documentation for the io_uring setting

### DIFF
--- a/qdrant-landing/content/documentation/ops-configuration/configuration.md
+++ b/qdrant-landing/content/documentation/ops-configuration/configuration.md
@@ -232,6 +232,16 @@ storage:
     # See: <https://qdrant.tech/articles/io_uring/#and-what-about-qdrant>
     #async_scorer: false
 
+    # Whether components readable through either a memory mapping or io_uring should use
+    # io_uring. Only has an effect on Linux.
+    #
+    # - unset (default): the immutable vector storages follow `async_scorer`, nothing else
+    #   uses io_uring.
+    # - "disabled": no component uses io_uring.
+    # - "auto": use io_uring for components with a `cold` memory placement, where reads hit
+    #   the disk. Components meant to sit in RAM keep using mmap, which is faster there.
+    #io_uring: disabled
+
     # Maximum number of collections to load concurrently.
     #max_concurrent_collection_loads: 1
     # Maximum number of local shards to load concurrently when loading a collection.

--- a/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
+++ b/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
@@ -76,7 +76,31 @@ If the accuracy loss is acceptable, you can disable rescoring against the origin
 
 ### Async I/O
 
-Enable `async_scorer` in the [storage configuration](/documentation/ops-configuration/configuration/) to let Qdrant issue disk reads concurrently during rescoring, instead of one at a time:
+Async I/O lets Qdrant issue disk reads concurrently instead of one at a time, reducing how long a query waits on disk when structures are `cold`. This uses [io_uring](/articles/io_uring/), a Linux kernel interface for asynchronous I/O, and requires a kernel that supports it. Async I/O helps most for vector rescoring, where the original vectors are `cold` and quantization is enabled, since rescoring the top candidates against the on-disk originals is where sequential disk reads would otherwise add up. It also applies to payload storage, so it helps whenever a `cold` payload is read from disk.
+
+#### `io_uring` Setting
+
+*Available as of v1.19.0.* 
+
+Set `io_uring` to `auto` in the [storage configuration](/documentation/ops-configuration/configuration/) to apply async I/O to any structure that's `cold`. You can enable it in the configuration file:
+
+```yaml
+storage:
+  performance:
+    io_uring: auto
+```
+
+ or via an environment variable:
+
+```bash
+QDRANT__STORAGE__PERFORMANCE__IO_URING=auto
+```
+
+#### `async_scorer` Setting
+
+*Available as of v1.3.0.*
+
+An older setting that applies async I/O to vector rescoring only. Prefer `io_uring` unless you're on a version older than 1.19. You can enable it in the configuration file:
 
 ```yaml
 storage:
@@ -84,7 +108,11 @@ storage:
     async_scorer: true
 ```
 
-This uses [io_uring](/articles/io_uring/), a Linux kernel interface for asynchronous I/O, and requires a kernel that supports it. Async I/O helps most when the original vectors are `cold` and quantization is enabled, since rescoring the top candidates against the on-disk originals is where sequential disk reads would otherwise add up.
+or via an environment variable:
+
+```bash
+QDRANT__STORAGE__PERFORMANCE__ASYNC_SCORER=true
+```
 
 ### Local NVMe/SSD Storage
 

--- a/qdrant-landing/content/documentation/ops-optimization/read-write-contention.md
+++ b/qdrant-landing/content/documentation/ops-optimization/read-write-contention.md
@@ -116,11 +116,35 @@ To disable, set `read_fan_out_delay_ms` back to `0`.
 
 *Linux only. Requires kernel support.*
 
-If your vectors or HNSW index are on disk, enabling the [async scorer](/articles/io_uring/) can reduce the time Qdrant spends waiting on disk reads. By default, Qdrant reads vectors synchronously: it sends a request, waits for the response, then sends the next. With Async I/O enabled, it batches disk requests and waits for them in parallel, saturating disk bandwidth instead of leaving it idle between reads.
+If your vectors or payload are on disk, [async I/O](/articles/io_uring/) can reduce the time Qdrant spends waiting on disk reads. By default, Qdrant reads data synchronously: it sends a request, waits for the response, then sends the next. With async I/O enabled, it batches disk requests and waits for them in parallel, saturating disk bandwidth instead of leaving it idle between reads. This is most relevant during rescoring: when Qdrant retrieves candidate vectors from disk to rerank results, async I/O allows it to fetch all of them concurrently rather than one by one.
 
-This is most relevant during rescoring: when Qdrant retrieves candidate vectors from disk to rerank results, async I/O allows it to fetch all of them concurrently rather than one by one.
+Async I/O relies on `io_uring`, so verify kernel support before enabling in production.
 
-Enable it in the config file by setting `async_scorer` to `true`:
+### `io_uring` Setting
+
+*Available as of v1.19.0.* 
+
+Set `storage.performance.io_uring` to `auto` to apply async I/O to vector storage and payload storage when they're `cold`. You can enable it in the configuration file:
+
+```yaml
+storage:
+  performance:
+    io_uring: auto
+```
+
+or via an environment variable:
+
+```bash
+QDRANT__STORAGE__PERFORMANCE__IO_URING=auto
+```
+
+### `async_scorer` Setting
+
+*Available as of v1.3.0.* 
+
+An older setting that applies async I/O to vector rescoring only, not payload. Prefer `io_uring` unless you're on a version older than 1.19. Setting `io_uring` takes precedence over `async_scorer` for the structures it covers.
+
+You can enable `async_scorer` in the configuration file:
 
 ```yaml
 storage:
@@ -128,15 +152,13 @@ storage:
     async_scorer: true
 ```
 
-Or via an environment variable:
+or via an environment variable:
 
 ```bash
 QDRANT__STORAGE__PERFORMANCE__ASYNC_SCORER=true
 ```
 
-On Qdrant Cloud, it's available under **Advanced Optimizations** in the cluster **Configuration** tab.
-
-If your data is entirely in memory, this setting has no effect. And because it relies on `io_uring`, it only works on Linux with a kernel that supports it. Verify kernel support before enabling in production.
+On Qdrant Cloud, `async_scorer` is available under **Advanced Optimizations** in the cluster **Configuration** tab.
 
 ## Step 7: Lower the Maximum Segment Size
 

--- a/qdrant-landing/content/documentation/tutorials-operations/large-scale-search.md
+++ b/qdrant-landing/content/documentation/tutorials-operations/large-scale-search.md
@@ -320,6 +320,10 @@ In Qdrant Managed cloud Async IO can be enabled via `Advanced optimizations` sec
 
 {{< figure src="/documentation/tutorials/large-scale-search/async_io.png" caption="Async IO configuration in Cloud" width="80%" >}}
 
+<aside role="status">
+As of Qdrant v1.19, <code>storage.performance.io_uring</code> is a broader alternative: set it to <code>auto</code> to apply async I/O to vector storage and payload storage when they're on disk, not only vector rescoring. See <a href="/documentation/ops-configuration/memory-tiers/#async-io">Async I/O</a> for details.
+</aside>
+
 
 ## Running search requests
 


### PR DESCRIPTION
Adds documentation for the `io_uring` setting (https://github.com/qdrant/qdrant/pull/10008) to the memory tiers ([preview](https://deploy-preview-2603--condescending-goldwasser-91acf0.netlify.app/documentation/ops-configuration/memory-tiers/#async-io)) and read-wrire contention ([preview](https://deploy-preview-2603--condescending-goldwasser-91acf0.netlify.app/documentation/ops-optimization/read-write-contention/#step-6-try-async-io)) pages.