### PR TITLE
Update admonition about snapshot restoring compatibility

### DIFF
--- a/qdrant-landing/content/documentation/snapshots.md
+++ b/qdrant-landing/content/documentation/snapshots.md
@@ -53,7 +53,7 @@ To download a specified snapshot from a collection as a file:
 
 ## Restore snapshot
 
-<aside role="status">Snapshots generated in one Qdrant cluster can only be restored to other Qdrant clusters that share the same minor version. For instance, a snapshot captured from a v1.4.1 cluster can only be restored to clusters running version v1.4.x, where x is equal to or greater than 1.</aside>
+<aside role="status">Snapshots generated in one Qdrant cluster can only be restored to other Qdrant clusters running the same minor version or the next minor version. For instance, a snapshot captured from a v1.18.1 cluster can only be restored to clusters running version v1.18.x, where x is equal to or greater than 1, or v1.19.x</aside>
 
 Snapshots can be restored in three possible ways:
 


### PR DESCRIPTION
## Overview

### [Preview](https://deploy-preview-2610--condescending-goldwasser-91acf0.netlify.app/documentation/snapshots/#restore-snapshot)

This PR updates an outdated admonition block on the Snapshot page. It stated that a snapshot generated from a Qdrant cluster can be restored only to clusters on the same minor version. This is no longer true: snapshots can be restored on the same minor version or the next minor version. The changes reflect this behavior.