### PR TITLE
Repair broken Go snippet and dangling snippet path from TurboQuant docs update

### DIFF
--- a/qdrant-landing/assets/jsconfig.json
+++ b/qdrant-landing/assets/jsconfig.json
@@ -1,6 +1,5 @@
 {
  "compilerOptions": {
-  "baseUrl": ".",
   "paths": {
    "*": [
     "../themes/qdrant-2024/assets/*"

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/disable-quantization-rescoring/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/disable-quantization-rescoring/generated/go.md
@@ -10,9 +10,6 @@ client, err := qdrant.NewClient(&qdrant.Config{
 	Port: 6334,
 })
 
-if err != nil {
-	panic(err)
-
 client.Query(context.Background(), &qdrant.QueryPoints{
 	CollectionName: "{collection_name}",
 	Query:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/disable-quantization-rescoring/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/disable-quantization-rescoring/go.go
@@ -12,9 +12,11 @@ func Main() {
 		Port: 6334,
 	})
 
+	// @hide-start
 	if err != nil {
 		panic(err)
-	} // @hide
+	}
+	// @hide-end
 
 	client.Query(context.Background(), &qdrant.QueryPoints{
 		CollectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/manage-data/quantization.md
+++ b/qdrant-landing/content/documentation/manage-data/quantization.md
@@ -360,7 +360,9 @@ The memory usage and speed of the search process can be tuned by choosing a [mem
 - **Original cold, quantized pinned** - a hybrid mode that provides a good balance between speed and memory usage. It is recommended if you are aiming to shrink the memory footprint while keeping the search speed.
 
   This mode is enabled by setting the original vectors' `memory` to `cold` and the quantized vectors' `memory` to `pinned`:\
-{{< code-snippet path="/documentation/headless/snippets/create-collection/scalar-quantization-in-ram/" >}}
+{{< code-snippet path="/documentation/headless/snippets/create-collection/turbo-quantization-in-ram/" >}}
+
+  **Note**: These examples also set the [`turbo4`](/documentation/manage-data/vectors/#turbo4) datatype on the original vectors, which stores each dimension as a 4-bit value instead of a full 32-bit float. This shrinks the on-disk footprint further, but it can reduce recall and search quality. Weigh these trade-offs before you use `turbo4` in your setup. The memory tier itself is set by the `memory` parameters alone, so you can use this mode without `turbo4`.
 
   In this scenario, the number of disk reads may play a significant role in the search speed.
   In a system with high disk latency, the re-scoring step may become a bottleneck.


### PR DESCRIPTION
## Overview

### Previews

* [Optimize performance](https://deploy-preview-2619--condescending-goldwasser-91acf0.netlify.app/documentation/ops-optimization/optimize/#disable-rescoring-for-faster-search-optional)
* [Quantization](https://deploy-preview-2619--condescending-goldwasser-91acf0.netlify.app/documentation/manage-data/quantization/#memory-and-speed-tuning)

Related to https://github.com/qdrant/landing_page/pull/2614

Referenced PR left two broken references behind:
1. the reformatted // @hide marker in the `disable-quantization-rescoring` Go snippet leaked an unclosed block into the published docs
2. `quantization.md` still pointed at the deleted `scalar-quantization-in-ram/` directory. 

This PR fixes the Go snippet and repoints `quantization.md` to `turbo-quantization-in-ram/`, and also adds the turbo4 trade-off note that `optimize.md` already has.