### PR TITLE
fix: generated md syntax check to avoid broken code

### DIFF
--- a/.github/workflows/snippets.yml
+++ b/.github/workflows/snippets.yml
@@ -28,6 +28,7 @@ jobs:
     if: >
       !(contains(github.event.pull_request.labels.*.name, 'skip snippet check') && github.event.pull_request.base.ref != 'master')
     runs-on: ubuntu-latest
+    needs: [convert-snippets]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/automation/snippets/check.py
+++ b/automation/snippets/check.py
@@ -10,7 +10,7 @@ import types
 import typing
 from pathlib import Path
 
-from lib import SNIPPETS_DIR, CollectedSnippetsType, collect_snippets, log
+from lib import SNIPPETS_DIR, CollectedSnippetsType, collect_snippets, extract_code, log
 from lib.languages import ALL_LANGUAGES, CompileResult, Language, parse_languages
 
 
@@ -84,6 +84,29 @@ def build_and_run(
             assert spec.loader is not None
             spec.loader.exec_module(mod)
             test_modules[snippet_dir] = mod
+
+    log("Syntax check stage")
+    for lang in snippets_by_lang:
+        if not lang.SUPPORTS_SYNTAX_CHECK:
+            log(
+                f"· Cannot check syntax of generated {lang.NAME} markdown "
+                "(no syntax-only parser available) - please review it manually"
+            )
+            continue
+
+        log(f"· Checking syntax of generated {lang.NAME} markdown")
+        for snippet_dir in snippets:
+            generated_dir = snippet_dir / "generated"
+            if not generated_dir.is_dir():
+                continue
+            for md_fname in sorted(generated_dir.rglob(f"{lang.NAME}.md")):
+                try:
+                    lang.check_syntax(extract_code(lang, md_fname))
+                except Exception as e:
+                    log(f"· · Syntax check failed for {md_fname}")
+                    errors.append(f"Syntax check failed for {md_fname}")
+                    if not isinstance(e, subprocess.CalledProcessError):
+                        traceback.print_exc()
 
     log("Compile stage")
     for lang, fnames in snippets_by_lang.items():

--- a/automation/snippets/lib/__init__.py
+++ b/automation/snippets/lib/__init__.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import typing
 from pathlib import Path
@@ -39,6 +40,13 @@ Example:
 }
 """
 
+def extract_code(language: type[Language], file: Path) -> str:
+    content = file.read_text()
+    regex = re.compile(rf"```{language.NAME}\r?\n([\s\S]*?)\r?\n```")
+    matches = regex.findall(content)
+    if len(matches) == 0:
+        raise RuntimeError("No code find in markdown file")
+    return matches[0]
 
 def collect_snippets(
     bases: list[Path],

--- a/automation/snippets/lib/languages/base.py
+++ b/automation/snippets/lib/languages/base.py
@@ -17,11 +17,25 @@ class Language:
     SNIPPET_FILENAME: str
     """Filename of the snippet in this language, e.g., 'python.py'."""
 
+    SUPPORTS_SYNTAX_CHECK: bool = False
+    """Whether `check_syntax()` is implemented for this language."""
+
     @classmethod
     def compile(cls, tmpdir: Path, fnames: list[Path]) -> "CompileResult":
         """Compile, typecheck, and prepare all snippets listed in fnames.
 
         Might create scratch projects in tmpdir.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def check_syntax(cls, code: str) -> None:
+        """Parse (but do not compile/typecheck) code, raising an exception
+        if it is not syntactically valid.
+
+        Unlike `compile()`, this does not need to resolve imports/types or
+        build a scratch project, so it can run directly on the shortened
+        code extracted from generated markdown files.
         """
         raise NotImplementedError
 

--- a/automation/snippets/lib/languages/bash.py
+++ b/automation/snippets/lib/languages/bash.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 from .base import CompileResult, Language, copy_template
@@ -6,6 +7,11 @@ from .base import CompileResult, Language, copy_template
 class LanguageBash(Language):
     NAME = "bash"
     SNIPPET_FILENAME = "bash.sh"
+    SUPPORTS_SYNTAX_CHECK = True
+
+    @classmethod
+    def check_syntax(cls, code: str) -> None:
+        subprocess.run(["bash", "-n"], input=code, text=True, check=True)
 
     @classmethod
     def compile(cls, tmpdir: Path, fnames: list[Path]) -> CompileResult:

--- a/automation/snippets/lib/languages/go.py
+++ b/automation/snippets/lib/languages/go.py
@@ -17,6 +17,17 @@ from .base import (
 class LanguageGo(Language):
     NAME = "go"
     SNIPPET_FILENAME = "go.go"
+    SUPPORTS_SYNTAX_CHECK = True
+
+    @classmethod
+    def check_syntax(cls, code: str) -> None:
+        subprocess.run(
+            ["gofmt", "-e"],
+            input=cls.unshorten(code),
+            text=True,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
 
     @classmethod
     def compile(cls, tmpdir: Path, fnames: list[Path]) -> CompileResult:

--- a/automation/snippets/lib/languages/go.py
+++ b/automation/snippets/lib/languages/go.py
@@ -13,6 +13,35 @@ from .base import (
     trim_commonpath,
 )
 
+_RE_HEADER_LINE = re.compile(r"^(import|type|func)\b")
+
+
+def _split_header_body(contents: str) -> tuple[str, str]:
+    """Split shortened Go code into leading package-level declarations
+    (imports, types, helper funcs) and the remaining statements that belong
+    inside `func Main()`.
+
+    `shorten()`/`generic_shorten()` flatten these together and dedent
+    everything to column 0, so indentation alone can no longer tell them
+    apart. Helper declarations always come first (`shorten()`'s `RE_CODE`
+    requires `func Main()` to be the last top-level declaration), so this
+    scans for the first line, outside of any brackets, that isn't the start
+    of an `import`/`type`/`func` declaration and treats everything from
+    there onward as the body.
+    """
+    lines = contents.splitlines(keepends=True)
+    depth = 0
+    header_end = 0
+    for i, line in enumerate(lines):
+        if depth == 0:
+            stripped = line.strip()
+            if stripped and _RE_HEADER_LINE.match(stripped) is None:
+                break
+        depth += line.count("{") + line.count("(")
+        depth -= line.count("}") + line.count(")")
+        header_end = i + 1
+    return "".join(lines[:header_end]), "".join(lines[header_end:])
+
 
 class LanguageGo(Language):
     NAME = "go"
@@ -105,35 +134,20 @@ class LanguageGo(Language):
     def format(cls, fnames: list[str]) -> None:
         subprocess.run(["gofmt", "-w", *fnames], check=True)
 
-    RE_RENDERED = re.compile(
-        r"""
-        (?P<imports>
-            (?: import\s*\([^)]+\)\n
-              | import\s+"[^"]+"\n
-              | \n
-            )*
-        )
-        (?P<body> .* )
-        $
-        """,
-        re.DOTALL | re.VERBOSE,
-    )
-
     @classmethod
     def unshorten(cls, contents: str) -> str:
-        if m := LanguageGo.RE_RENDERED.match(contents):
-            return textwrap.dedent(
-                """\
-                package snippet
+        header, body = _split_header_body(contents)
+        return textwrap.dedent(
+            """\
+            package snippet
 
-                {imports}
+            {header}
 
-                func Main() {{
-                {body}
-                }}
-                """
-            ).format(
-                imports=m["imports"].strip(),
-                body=textwrap.indent(m["body"].strip(), "\t"),
-            )
-        return contents
+            func Main() {{
+            {body}
+            }}
+            """
+        ).format(
+            header=header.strip(),
+            body=textwrap.indent(body.strip(), "\t"),
+        )

--- a/automation/snippets/lib/languages/python.py
+++ b/automation/snippets/lib/languages/python.py
@@ -1,3 +1,4 @@
+import ast
 import re
 import subprocess
 from pathlib import Path
@@ -19,6 +20,11 @@ RE_IMPORTS = re.compile(
 class LanguagePython(Language):
     NAME = "python"
     SNIPPET_FILENAME = "python.py"
+    SUPPORTS_SYNTAX_CHECK = True
+
+    @classmethod
+    def check_syntax(cls, code: str) -> None:
+        ast.parse(code)
 
     @classmethod
     def compile(cls, tmpdir: Path, fnames: list[Path]) -> CompileResult:

--- a/automation/snippets/lib/languages/rust.py
+++ b/automation/snippets/lib/languages/rust.py
@@ -18,6 +18,17 @@ from .base import (
 class LanguageRust(Language):
     NAME = "rust"
     SNIPPET_FILENAME = "rust.rs"
+    SUPPORTS_SYNTAX_CHECK = True
+
+    @classmethod
+    def check_syntax(cls, code: str) -> None:
+        subprocess.run(
+            ["rustfmt", "--edition=2024"],
+            input=cls.unshorten(code),
+            text=True,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
 
     @classmethod
     def compile(cls, tmpdir: Path, fnames: list[Path]) -> CompileResult:


### PR DESCRIPTION
This is an attempt to enhance snippets CI by adding a syntax checking step for those language that allow checking without compiling (go, python, bash, rust).

All existing code snippets pass syntax checking and still compile/build.
