### PR TITLE
Fix rescore placement in memory tiers quantization section

### DIFF
--- a/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
+++ b/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
@@ -72,7 +72,9 @@ When structures are in the `cold` tier, retrieval may involve reading from disk.
 
 Keep the quantized vectors in RAM by setting `memory: "pinned"` in the `quantization_config`. Without pinning, the quantized copy may be evicted under memory pressure, forcing Qdrant to read both the quantized and original vectors from disk.
 
-If the accuracy loss is acceptable, you can disable rescoring against the original vectors entirely by setting `rescore: false` in the `quantization_config`. This avoids any disk reads during search, and the memory tier of the original vectors no longer affects search latency.
+If the accuracy loss is acceptable, you can disable rescoring against the original vectors by setting `rescore: false` in a query's search parameters. This avoids any disk reads during search, and the memory tier of the original vectors no longer affects search latency. `rescore` is a per-query parameter, so you can keep it on for the queries that need the accuracy:
+
+{{< code-snippet path="/documentation/headless/snippets/query-points/disable-quantization-rescoring/" >}}
 
 ### Async I/O
 


### PR DESCRIPTION
The quantization section of the memory tiers page told readers to set `rescore: false` in the `quantization_config`. That field doesn't exist there. `rescore` (and `oversampling`) only live in a query's search params, on `QuantizationSearchParams`.

Checked against the qdrant repo at v1.19.0 (74f3e85b9):

- `lib/segment/src/types.rs:572` is `QuantizationSearchParams`, with `rescore` at :583 and `oversampling` at :595. Same in `points.proto:466`. That's the only struct with either field, and the generated OpenAPI has exactly one `rescore` property in the whole file.
- The collection-level configs (`ScalarQuantizationConfig` :937, `ProductQuantizationConfig` :987, `BinaryQuantizationConfig` :1045) only take `type`, `quantile`, `compression`, `encoding`, `query_encoding`, `always_ram`, and `memory`.
- `git log -S rescore` shows it was added to the search params in #1538 and never existed on a config struct, so this was never valid.

None of those config structs use `deny_unknown_fields`, so anyone who followed the old text got no error, just silently dropped the field and kept rescoring.

Fixed the sentence and pulled in the existing `query-points/disable-quantization-rescoring/` snippet so the placement is unambiguous. The neighboring `memory: "pinned"` line is correct and untouched.
