### PR TITLE
Add Google Tag Manager with OneTrust-driven Consent Mode v2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,7 @@ HUGO_ENABLEGITINFO = "true"
 DEPLOY_PRIME_URL = "https://qdrant.tech"
 HUGO_PARAMS_segmentWriteKey = "eQYi1nZE2zQSmnHuxjMRlDd2uLl65oHe"
 HUGO_PARAMS_onetrustScriptId = "01960152-5e40-782d-af01-f7f5768a214e"
+HUGO_PARAMS_googleTagManager = "GTM-M35C8G6"
 
 [context.deploy-preview.environment]
 HUGO_ENV = "staging"

--- a/qdrant-landing/themes/qdrant-2024/assets/js/gtm-helpers.check.mjs
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/gtm-helpers.check.mjs
@@ -1,0 +1,60 @@
+/**
+ * Self-check for the OneTrust -> Consent Mode v2 mapping.
+ * Run: node qdrant-landing/themes/qdrant-2024/assets/js/gtm-helpers.check.mjs
+ *
+ * Loaded via a data: URL because the theme has no test runner and no
+ * "type": "module" — this keeps the check dependency-free.
+ */
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync(new URL('./gtm-helpers.js', import.meta.url), 'utf8');
+const { mapOneTrustConsent } = await import('data:text/javascript,' + encodeURIComponent(src));
+
+// No consent yet: everything denied.
+assert.deepEqual(mapOneTrustConsent(''), {
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+  analytics_storage: 'denied',
+  functionality_storage: 'denied',
+  personalization_storage: 'denied',
+});
+
+// Strictly necessary only: still nothing granted.
+assert.equal(mapOneTrustConsent(',C0001,').analytics_storage, 'denied');
+
+// Performance grants analytics but not ads.
+const performanceOnly = mapOneTrustConsent(',C0001,C0002,');
+assert.equal(performanceOnly.analytics_storage, 'granted');
+assert.equal(performanceOnly.ad_storage, 'denied');
+
+// Targeting grants all three ad signals.
+const targeting = mapOneTrustConsent(',C0001,C0004,');
+assert.equal(targeting.ad_storage, 'granted');
+assert.equal(targeting.ad_user_data, 'granted');
+assert.equal(targeting.ad_personalization, 'granted');
+assert.equal(targeting.analytics_storage, 'denied');
+
+// Functional maps to both functionality and personalization storage.
+const functional = mapOneTrustConsent(',C0003,');
+assert.equal(functional.functionality_storage, 'granted');
+assert.equal(functional.personalization_storage, 'granted');
+
+// Full consent.
+assert.deepEqual(mapOneTrustConsent(',C0001,C0002,C0003,C0004,'), {
+  ad_storage: 'granted',
+  ad_user_data: 'granted',
+  ad_personalization: 'granted',
+  analytics_storage: 'granted',
+  functionality_storage: 'granted',
+  personalization_storage: 'granted',
+});
+
+// Exact group matching: a longer ID must not satisfy a shorter one.
+assert.equal(mapOneTrustConsent(',C00020,').analytics_storage, 'denied');
+
+// Missing/undefined groups must not throw.
+assert.equal(mapOneTrustConsent(undefined).analytics_storage, 'denied');
+
+console.log('gtm-helpers: all consent mapping checks passed');

--- a/qdrant-landing/themes/qdrant-2024/assets/js/gtm-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/gtm-helpers.js
@@ -1,0 +1,43 @@
+/**
+ * Bridges OneTrust consent choices onto Google Consent Mode v2 signals for GTM.
+ *
+ * The GTM container is loaded in partials/js.html with every consent signal
+ * defaulted to 'denied'. Nothing in the container fires until updateGtmConsent()
+ * pushes an update, which happens once OneTrust reports its stored choice and
+ * again on every preference change (see index.js).
+ *
+ * Group IDs below are the OneTrust defaults. If the OneTrust console for
+ * qdrant.tech uses custom group IDs, these constants are the only thing to change.
+ */
+const OT_GROUP = {
+  PERFORMANCE: 'C0002',
+  FUNCTIONAL: 'C0003',
+  TARGETING: 'C0004',
+};
+
+/**
+ * OneTrust exposes consent as a delimited string, e.g. ',C0001,C0002,'.
+ * Split rather than substring-match so 'C0002' never matches 'C00020'.
+ */
+export function mapOneTrustConsent(activeGroups) {
+  const groups = (activeGroups ?? '').split(',');
+  const performance = groups.includes(OT_GROUP.PERFORMANCE);
+  const functional = groups.includes(OT_GROUP.FUNCTIONAL);
+  const targeting = groups.includes(OT_GROUP.TARGETING);
+
+  return {
+    ad_storage: targeting ? 'granted' : 'denied',
+    ad_user_data: targeting ? 'granted' : 'denied',
+    ad_personalization: targeting ? 'granted' : 'denied',
+    analytics_storage: performance ? 'granted' : 'denied',
+    functionality_storage: functional ? 'granted' : 'denied',
+    personalization_storage: functional ? 'granted' : 'denied',
+  };
+}
+
+export function updateGtmConsent() {
+  // gtag is only defined when the container is configured (production w/ a container ID)
+  if (typeof window.gtag !== 'function') return;
+
+  window.gtag('consent', 'update', mapOneTrustConsent(window.OnetrustActiveGroups));
+}

--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -4,6 +4,7 @@ import { XXL_BREAKPOINT } from './constants';
 import { addUTMToLinks, initGoToTopButton, persistUTMParams } from './helpers';
 import { handleSegmentReady } from './segment-helpers';
 import { addOneTrustPreferencesToLinks, registerAndCall } from './onetrust-helpers';
+import { updateGtmConsent } from './gtm-helpers';
 import TableOfContents from './table-of-content';
 import { DOCS_HEADER_OFFSET } from './constants';
 import { scrollIntoViewWithOffset } from './helpers';
@@ -15,11 +16,14 @@ document.addEventListener('DOMContentLoaded', function () {
   addUTMToLinks();
 
   const handleOneTrustLoaded = () => {
-    // One Trust Loaded
+    // One Trust Loaded — grant GTM from the stored choice (returning visitors)
+    updateGtmConsent();
+
     window.OneTrust.OnConsentChanged(async () => {
       // One Trust Preference Updated
       addOneTrustPreferencesToLinks();
       registerAndCall();
+      updateGtmConsent();
 
       await window.analytics.track('onetrust_consent_preference_updated', {
         onetrust_active_groups: window.OnetrustActiveGroups ?? '',

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/js.html
@@ -22,6 +22,42 @@
 {{ end }}
 <!-- OneTrust Cookies Consent Notice end for local.qdrant.tech -->
 
+<!-- Google Tag Manager -->
+{{ if and (not hugo.IsServer) .Site.Params.googleTagManager }}
+  <script>
+    // Consent Mode v2: deny everything before the container loads, so no tag can
+    // fire ahead of a choice. updateGtmConsent() in gtm-helpers.js grants from
+    // OneTrust once the CMP reports in. Must stay above the gtm.js loader below.
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied',
+      functionality_storage: 'denied',
+      personalization_storage: 'denied',
+      security_storage: 'granted',
+      wait_for_update: 500,
+    });
+  </script>
+  <script>
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+      j.async = true;
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', '{{ .Site.Params.googleTagManager }}');
+  </script>
+{{ end }}
+<!-- End Google Tag Manager -->
+
 <!-- Segment -->
 <script>
   const isFirstPageView = !localStorage.getItem('ajs_anonymous_id') && localStorage.getItem('isFirstPageView') === null;


### PR DESCRIPTION
## TL;DR (human-generated)
Google Tag Manager appears to not have been configured correctly when the qdrant website 2024 theme was launched. There was no GTM container ID present. This means web tracking for Google Analytics is off (though we do track through Segment as well, starting a few months ago).

This PR addresses the GTM issue, and also includes in OneTrust Consent.

We do not have anyone fully owning this at Qdrant so I've tagged a few suggested reviewers. If unsure, let me know.

Note: OneTrust Consent should be validated separately by whoever owns that.

Thanks

# Claude Code Details:

## Why

GTM has never been live on qdrant.tech. Verified against production HTML (`/`, `/documentation/`, `/blog/`, `/articles/`): zero hits for `gtm.js`, `ns.html`, or any `GTM-` string.

The repo *looks* like it has GTM already — `themes/qdrant/layouts/partials/head.html` carries a full snippet gated on `.Site.Params.googleTagManager`. That file is dead code: both `config.toml:4` and `config-theme.toml:1` set `theme = "qdrant-2024"`, so the snippet never renders no matter what params are set. This PR adds GTM to the **active** theme instead.

## What

Container `GTM-M35C8G6`, wired into `themes/qdrant-2024/layouts/partials/js.html` immediately after the OneTrust stub so the CMP always loads first.

**Consent Mode v2, denied by default.** Every signal (`ad_storage`, `ad_user_data`, `ad_personalization`, `analytics_storage`, `functionality_storage`, `personalization_storage`) is set to `denied` in a synchronous script *above* the `gtm.js` loader, with `wait_for_update: 500`. No tag in the container can fire before a consent choice exists. The site runs a OneTrust CMP and serves EU traffic (EU HubSpot, EU Segment), so a bare GTM snippet would have been a compliance regression.

**Consent is granted from OneTrust, reusing the existing plumbing.** `gtm-helpers.js` maps `window.OnetrustActiveGroups` onto Consent Mode signals. It is called from the `onetrust_loaded` and `OnConsentChanged` handlers already present in `index.js` — no second listener, no duplicate CMP wiring.

| OneTrust group | Consent Mode signal |
|---|---|
| `C0002` performance | `analytics_storage` |
| `C0003` functional | `functionality_storage`, `personalization_storage` |
| `C0004` targeting | `ad_storage`, `ad_user_data`, `ad_personalization` |

**Production only.** The ID is set in `[context.production.environment]` alongside the existing `segmentWriteKey` / `onetrustScriptId`, so deploy previews and local `hugo serve` render no GTM at all and won't pollute the container.

## ⚠️ One assumption to confirm before merge

The group IDs above are **OneTrust defaults**. Nothing in this repo names a specific group — `onetrust-helpers.js` only passes `OnetrustActiveGroups` through as an opaque string — so I could not verify them from code.

**If the OneTrust console for domain `01960152-5e40-782d-af01-f7f5768a214e` uses custom group IDs, this mapping will look correct in review and silently never grant consent in production.** The `OT_GROUP` constants at the top of `gtm-helpers.js` are the only thing to change. Could whoever owns the OneTrust console confirm?

## Verification

Built locally with the param set — correct render and ordering (HubSpot → OneTrust → consent defaults → `gtm.js` → Segment):

```
onetrust otSDKStub       778192
consent default          778xxx   (all denied)
gtm.js loader            778985   (GTM-M35C8G6)
segment analytics.load   779xxx
```

Built again *without* the param: `0` occurrences of `gtm.js`, the container ID, and the consent block — confirming previews stay clean.

Consent mapping has a dependency-free self-check (no test runner in this theme):

```bash
node qdrant-landing/themes/qdrant-2024/assets/js/gtm-helpers.check.mjs
# gtm-helpers: all consent mapping checks passed
```

It covers no-consent, strictly-necessary-only, each group in isolation, full consent, `undefined`, and that `C00020` does not satisfy `C0002`.

**Manual check on the preview deploy is not possible** (GTM is production-gated by design). After merge, confirm in GTM Preview mode that consent transitions from all-denied to granted when accepting cookies.

## Deliberately skipped

- **`<noscript>` iframe fallback** — needs a `baseof.html` edit, only serves JS-disabled users, and cannot respect consent. Add if someone wants it.
- **Migrating any Segment tracking into GTM** — this PR is purely additive. Segment, HubSpot, and the `ga_measurement_id` cookie are untouched.
- **Deleting the dead `themes/qdrant/` theme** — out of scope, but it's ~a whole theme of unused code and worth its own PR.

## Unrelated bugs found while tracing this (not fixed here)

1. `segment-helpers.js:32,37` — `handleClickInteraction` reads `event.target` instead of `event.currentTarget`. Any `data-metric-loc` element containing child markup will report the child and send `location: ''`. Today's 19 tagged elements are all plain-text anchors so it works, but it breaks silently the moment someone wraps an icon or `<span>` in one.
2. `partials/home/hero.html:11-14` — duplicate `data-metric-loc="hero"` on both anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)