### PR TITLE
Align Go, C#, and Java snippet booleans with their descriptions

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/csharp.cs
@@ -16,7 +16,7 @@ public class Snippet
 		        TextIndexParams = new TextIndexParams
 		        {
 		            Tokenizer = TokenizerType.Word,
-		            Lowercase = true,
+		            Lowercase = false,
 		        }
 		    }
 		);

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/generated/csharp.md
@@ -13,7 +13,7 @@ await client.CreatePayloadIndexAsync(
         TextIndexParams = new TextIndexParams
         {
             Tokenizer = TokenizerType.Word,
-            Lowercase = true,
+            Lowercase = false,
         }
     }
 );

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/generated/go.md
@@ -17,7 +17,7 @@ client.CreateFieldIndex(context.Background(), &qdrant.CreateFieldIndexCollection
     FieldIndexParams: qdrant.NewPayloadIndexParamsText(
         &qdrant.TextIndexParams{
             Tokenizer:   qdrant.TokenizerType_Word,
-            Lowercase:   qdrant.PtrOf(true),
+            Lowercase:   qdrant.PtrOf(false),
         }),
 })
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/generated/java.md
@@ -18,7 +18,7 @@ client
             .setTextIndexParams(
                 TextIndexParams.newBuilder()
                     .setTokenizer(TokenizerType.Word)
-                    .setLowercase(true)
+                    .setLowercase(false)
                     .build())
             .build(),
         null,

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/go.go
@@ -21,7 +21,7 @@ func Main() {
 	    FieldIndexParams: qdrant.NewPayloadIndexParamsText(
 	        &qdrant.TextIndexParams{
 	            Tokenizer:   qdrant.TokenizerType_Word,
-	            Lowercase:   qdrant.PtrOf(true),
+	            Lowercase:   qdrant.PtrOf(false),
 	        }),
 	})
 }

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/lowercase-full-text/java.java
@@ -21,7 +21,7 @@ public class Snippet {
                             .setTextIndexParams(
                                 TextIndexParams.newBuilder()
                                     .setTokenizer(TokenizerType.Word)
-                                    .setLowercase(true)
+                                    .setLowercase(false)
                                     .build())
                             .build(),
                         null,

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-ignored-quantization/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-ignored-quantization/generated/go.md
@@ -15,7 +15,7 @@ client.Query(context.Background(), &qdrant.QueryPoints{
 	Query:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),
 	Params: &qdrant.SearchParams{
 		Quantization: &qdrant.QuantizationSearchParams{
-			Ignore: qdrant.PtrOf(false),
+			Ignore: qdrant.PtrOf(true),
 		},
 	},
 })

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-ignored-quantization/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-ignored-quantization/go.go
@@ -19,7 +19,7 @@ func Main() {
 		Query:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),
 		Params: &qdrant.SearchParams{
 			Quantization: &qdrant.QuantizationSearchParams{
-				Ignore: qdrant.PtrOf(false),
+				Ignore: qdrant.PtrOf(true),
 			},
 		},
 	})


### PR DESCRIPTION
Two snippets set a boolean that contradicts their own `_description.md`, so the language tabs on the same page disagree with each other.

**`query-points/with-ignored-quantization`** — the description says "By setting the `ignore` parameter to true", and python, typescript, rust, java, csharp, and http all pass true. Go passed `Ignore: qdrant.PtrOf(false)`, which does the opposite of what the snippet is demonstrating. Renders on `manage-data/quantization.md:341`.

**`create-payload-index/lowercase-full-text`** — the description says the index is for case-sensitive matching and that lowercasing is disabled here. Python, typescript, rust, and http pass false. Go, C#, and Java passed true. The sibling dirs `simple-full-text` and `phrase-full-text` set true in all seven languages, so this one looks copied from a sibling with only four of the seven files flipped. Renders on `manage-data/indexing.md:222`.

Checked the field types against `go-client` v1.19.0, which `automation/snippets/templates/go/go.mod` pins: `QuantizationSearchParams.Ignore` and the text-index `Lowercase` are both `*bool`, so `qdrant.PtrOf(false)` is the right shape and only the literal changes.

Regenerated the `generated/*.md` files with `automation/snippets/generate-md.py` per the README, rather than hand-editing them. The generator touched only the four corresponding files.

Not included: `query-points-explore/relevance-feedback-naive` sets `c = 0.16` in Go, Rust, Java, and C# but `c = 0.03` in Python, TypeScript, and HTTP. There is no description to arbitrate which is intended, so someone who knows the intent should pick.
