### PR TITLE
Clarify shard_number semantics in multitenancy article

### DIFF
--- a/qdrant-landing/content/articles/multitenancy.md
+++ b/qdrant-landing/content/articles/multitenancy.md
@@ -70,7 +70,8 @@ When creating a collection, you will need to configure user-defined sharding. Th
 ```python
 client.create_collection(
     collection_name="{tenant_data}",
-    shard_number=2,
+    # number of physical shards per shard key, not the number of shard keys
+    shard_number=1,
     sharding_method=models.ShardingMethod.CUSTOM,
     # ... other collection parameters
 )


### PR DESCRIPTION
## Problem

In the [multitenancy article](https://qdrant.tech/articles/multitenancy/#create-custom-shards-for-a-single-collection), the custom sharding example paired `shard_number=2` with exactly two `create_shard_key` calls:

```python
client.create_collection(
    collection_name="{tenant_data}",
    shard_number=2,
    sharding_method=models.ShardingMethod.CUSTOM,
)
client.create_shard_key("{tenant_data}", "canada")
client.create_shard_key("{tenant_data}", "germany")
```

That reads as though `shard_number` declares how many shard keys you intend to create. It doesn't — per [`distributed_deployment.md`](qdrant-landing/content/documentation/scaling/distributed_deployment.md), under custom sharding `shard_number` is the number of physical shards **per shard key**. The snippet as written actually creates 2 × 2 = 4 physical shards per replica.

## Change

- `shard_number=2` → `shard_number=1`, matching the canonical `create-collection/with-custom-sharding` snippet.
- Added an inline comment stating what the parameter controls.

Prose and shard-key lines are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)