### PR TITLE
replace elastic reference with qdrant bm25

### DIFF
--- a/qdrant-landing/content/articles/sparse-vectors.md
+++ b/qdrant-landing/content/articles/sparse-vectors.md
@@ -37,7 +37,7 @@ The numbers 331 and 14136 map to specific tokens in the vocabulary e.g. `['choco
 
 The tokens aren't always words though, sometimes they can be sub-words: `['ch', 'ocolate']` too.
 
-They're pivotal in information retrieval, especially in ranking and search systems. BM25, a standard ranking function now natively available in Qdrant, exemplifies this. BM25 calculates the relevance of documents to a given search query. 
+They're pivotal in information retrieval, especially in ranking and search systems. [BM25](/documentation/search/text-search/full-text-search/#bm25), a standard ranking function natively available in Qdrant, exemplifies this. BM25 calculates the relevance of documents to a given search query. 
 
 BM25's capabilities are well-established, yet it has its limitations. 
 

--- a/qdrant-landing/content/articles/sparse-vectors.md
+++ b/qdrant-landing/content/articles/sparse-vectors.md
@@ -37,7 +37,7 @@ The numbers 331 and 14136 map to specific tokens in the vocabulary e.g. `['choco
 
 The tokens aren't always words though, sometimes they can be sub-words: `['ch', 'ocolate']` too.
 
-They're pivotal in information retrieval, especially in ranking and search systems. BM25, a standard ranking function used by search engines like [Elasticsearch](https://www.elastic.co/blog/practical-bm25-part-2-the-bm25-algorithm-and-its-variables?utm_source=qdrant&utm_medium=website&utm_campaign=sparse-vectors&utm_content=article&utm_term=sparse-vectors), exemplifies this. BM25 calculates the relevance of documents to a given search query. 
+They're pivotal in information retrieval, especially in ranking and search systems. BM25, a standard ranking function now natively available in Qdrant, exemplifies this. BM25 calculates the relevance of documents to a given search query. 
 
 BM25's capabilities are well-established, yet it has its limitations. 
 


### PR DESCRIPTION
old article referenced Elasticsearch's BM25 but not ours. Replaced