### PR TITLE
Add a customer quote component with customer avatar and logo

### DIFF
--- a/qdrant-landing/content/blog/case-study-bayer.md
+++ b/qdrant-landing/content/blog/case-study-bayer.md
@@ -27,7 +27,14 @@ Bayer is a global life sciences company operating at the intersection of two of 
 
 Turning that ambition into production systems for 116,000 employees is a hard infrastructure problem. It requires retrieval that stays fast under sustained load, grounds large language models (LLMs) in real data to suppress hallucinations, satisfies strict life sciences compliance requirements, and adapts as the underlying AI workloads shift from simple chatbots to autonomous agents. This is the story of how Bayer built that foundation, and why Qdrant has sat at the center of it for nearly three years.
 
-> "If you don't have a Qdrant vector store behind the scenes, it's very difficult to ground LLMs into reality. If you remove the search from the agent, the results go back to two years ago." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
+{{< quote
+  text="If you don't have a Qdrant vector store behind the scenes, it's very difficult to ground LLMs into reality. If you remove the search from the agent, the results go back to two years ago."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg"
+  featured="true" >}}
 
 ## A Platform Born Weeks After ChatGPT
 
@@ -37,7 +44,13 @@ Bayer moved quickly. Within three months, Sedghamiz's team stood up myGenAssist,
 
 From there, it scaled into a full platform layer. Today, myGenAssist serves the entire company, processes over 1.5 million messages a month, and has ingested more than 450,000 uploaded documents, all while keeping the complexity of RAG hidden from the end user.
 
-> "The whole stack of RAG is hidden from users. For them it's just a file upload, but it ends up going through several layers of retrieval-augmented generation, Qdrant being part of it. That has proven to be quite successful to bring grounding and reduce hallucinations for LLM applications." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
+{{< quote
+  text="The whole stack of RAG is hidden from users. For them it's just a file upload, but it ends up going through several layers of retrieval-augmented generation, Qdrant being part of it. That has proven to be quite successful to bring grounding and reduce hallucinations for LLM applications."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 
 ## Choosing a Vector Search Engine, Three Years Ago
 
@@ -45,7 +58,13 @@ Three years ago, Bayer evaluated vector search. The company's first prototype, M
 
 The team evaluated across several dimensions: price-performance ratio, latency, and openness. Qdrant was open source, which meant the team could test it fast without procurement friction. Latency was strong. And it was written in Rust, a signal of the memory efficiency and predictable performance that life sciences workloads would later demand.
 
-> "There weren't many options back then. We did benchmarking across price-performance, latency, and other aspects. The first points we really liked: it was open source, we could test it very fast, latency was good, and it was written in Rust. We ended up going with Qdrant." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
+{{< quote
+  text="There weren't many options back then. We did benchmarking across price-performance, latency, and other aspects. The first points we really liked: it was open source, we could test it very fast, latency was good, and it was written in Rust. We ended up going with Qdrant."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 
 ## From Self-Hosted to Hybrid Cloud: Meeting Compliance Without Drowning in Ops
 

--- a/qdrant-landing/content/blog/case-study-bayer.md
+++ b/qdrant-landing/content/blog/case-study-bayer.md
@@ -116,7 +116,9 @@ The most significant shift in Bayer's architecture is the move from chatbot-styl
   text="If you don't have a Qdrant vector store behind the scenes, it's very difficult to ground LLMs into reality. If you remove the search from the agent, the results go back to two years ago."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
-  company="Bayer" >}}
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 
 Crucially, Bayer exposes the Qdrant API directly to the model. Whether the requester is a human or an agent, the same interface is available, and the agent can choose how to retrieve based on the task. This is exactly the composable model Qdrant is designed for: retrieval primitives the caller combines at query time, rather than a fixed pipeline hidden behind an opaque API. Under the hood, the hybrid path runs dense and sparse queries in parallel and fuses them with Reciprocal Rank Fusion before a BGE reranker sharpens the final ordering. The agent sees a clean set of tools, not that machinery.
 
@@ -194,9 +196,7 @@ The team is careful not to over-attribute. It does not isolate which component d
   text="We've seen 20% efficiency when it comes to using AI platforms. A big part of that gain is that you have to get results from AI that are grounded. If you get hallucinations, people are not satisfied. It wouldn't be possible without the components."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 
 With the recent shift to more autonomous agents, the measurement problem itself is evolving. Earlier chatbot-style systems delivered incremental time savings: a faster email summary, a quicker draft. The new agents can run for 10 to 15 minutes unattended and return a completed task: research done, document written, a notification sent to the user's phone. That changes the question from "how much time did we save" to "how well was the whole task done," a harder thing to quantify but a larger prize.
 

--- a/qdrant-landing/content/blog/case-study-bayer.md
+++ b/qdrant-landing/content/blog/case-study-bayer.md
@@ -74,7 +74,13 @@ Pure self-hosting satisfied the compliance side but became demanding for a team 
 
 ![Timeline of Bayer's path from a Redis prototype through benchmarking and self-hosted Qdrant to the current Qdrant Hybrid Cloud deployment, with the scale, infrastructure, and compliance pressures that drove each step](/blog/case-study-bayer/bayer-qdrant-timeline.png)
 
-> "Life science companies want data to stay inside and use the platform self-hosted if possible. But self-hosting was already quite demanding for us. Our team is not that big, so we decided to use hybrid management." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
+{{< quote
+  text="Life science companies want data to stay inside and use the platform self-hosted if possible. But self-hosting was already quite demanding for us. Our team is not that big, so we decided to use hybrid management."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 
 ## Scaling to Millions of Messages and an Evolving Data Model
 
@@ -84,8 +90,13 @@ Much of the operational strain has come not from Qdrant itself but from the surr
 
 The data model itself is also expanding. Bayer is migrating toward an omnimodal approach, driven by the reality of life sciences data: medical images, X-rays, CT scans, and molecular databases sit alongside text. With embedding models that handle multiple modalities, the team can now treat search as a problem across all enterprise assets, not just documents.
 
-> "For every enterprise, it's very important to be able to find assets no matter what format they're in: images, text, a molecular image, anything. We've started looking at these not just for simple RAG applications, but to let people search across all the assets they're dealing with." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
-
+{{< quote
+  text="For every enterprise, it's very important to be able to find assets no matter what format they're in: images, text, a molecular image, anything. We've started looking at these not just for simple RAG applications, but to let people search across all the assets they're dealing with."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 The omnimodal pipeline is concrete, not aspirational. When a scientific PDF enters the system, a vision model generates search-optimized descriptions of every figure (content summary, OCR'd labels, key concepts) and injects them into the text stream before chunking.
 
 So searching "receptor binding affinity curve" returns the figure itself, not just paragraphs that mention it. Audio and video recordings are chunked, transcribed via Whisper, and vector-indexed alongside text documents. A lab meeting from three months ago becomes searchable in Qdrant within minutes of upload.
@@ -96,8 +107,13 @@ For the people querying the platform, two things matter most. The first is laten
 
 The second is retrieval quality. Grounded, high-quality answers are what keep users satisfied and drive measurable productivity gains. Hallucinations do the opposite. This is where [hybrid search](https://qdrant.tech/documentation/concepts/hybrid-queries/) became decisive. Two years ago, semantic search alone was not enough. The combination of keyword and semantic retrieval in a single query proved far more capable, and it is now central to how Bayer's agents find relevant context.
 
-> "You want your retrieval to be very fast. A low-latency platform helps the user experience a lot. And the second point is the quality of retrieval inside that latency. It's important that your vector search supports hybrid search, for example. That's great." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
-
+{{< quote
+  text="You want your retrieval to be very fast. A low-latency platform helps the user experience a lot. And the second point is the quality of retrieval inside that latency. It's important that your vector search supports hybrid search, for example. That's great."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 ![Qdrant as enterprise retrieval backbone: four layers from 116K employees through the deep agent harness to Qdrant Hybrid Cloud and GxP-ready observability](/blog/case-study-bayer/qdrant-enterprise-retrieval-backbone.png)
 
 ## Composable Retrieval for Agents: Exposing Qdrant Directly to the Model
@@ -110,12 +126,22 @@ Crucially, Bayer exposes the Qdrant API directly to the model. Whether the reque
 
 A feature Bayer calls knowledge bases makes this concrete. Users start a project, drop in folders of data in any format, and the agent works against that data much like a coding agent works against a file system. Bayer extended the agent's command set so that when keyword search fails, it can escalate to semantic or hybrid search through the Qdrant API. It can also fan a single question into several reformulations (keywords, a question form, a hypothetical answer) and search them at once. The agent decides which retrieval strategy fits the moment.
 
-> "This is very powerful because the agent now decides: I didn't find anything with keyword search, so I can switch to semantic search, or I can use hybrid search that the API exposes to me. Two years ago, semantic search alone wasn't enough. Now with hybrid search it's way more powerful." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
-
+{{< quote
+  text="This is very powerful because the agent now decides: I didn't find anything with keyword search, so I can switch to semantic search, or I can use hybrid search that the API exposes to me. Two years ago, semantic search alone wasn't enough. Now with hybrid search it's way more powerful."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 This is also where the omnimodal direction pays off. Users upload meeting transcripts, images, audio, and video, and the agent discovers and connects them. Qdrant increasingly serves as the agent's memory, letting it recall what a user has been working on and tailor answers accordingly. Teams elsewhere in the company can point their own applications at a shared collection to build their own search experiences, from molecule search to internal enterprise search.
 
-> "People used to look at vector databases only for RAG applications. Now they're solving enterprise search problems. No one had an omnimodal search engine where you could search videos, audio, and every asset the company generates. We realized Qdrant was turning into that." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
-
+{{< quote
+  text="People used to look at vector databases only for RAG applications. Now they're solving enterprise search problems. No one had an omnimodal search engine where you could search videos, audio, and every asset the company generates. We realized Qdrant was turning into that."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 Retrieval quality benefits from a parallel query expansion strategy. A single user question generates four Qdrant searches simultaneously: the verbatim query, a question-form rewrite, extracted keywords, and a HYDE hypothetical answer. Results are fused, deduplicated with a diversity cap of three chunks per document, and optionally reranked. The approach is particularly effective for pharmaceutical literature, where the same concept appears under different nomenclatures across regulatory filings, clinical protocols, and marketing materials.
 
 Document parsing itself is agentic. Rather than pre-processing every upload through expensive OCR, the platform defers extraction until the agent actually needs a document's content. A lightweight sandbox-local parser handles simple formats instantly; complex PDFs with tables and figures fall through to server-side Docling OCR on demand. Results are cached and indexed into Qdrant on first use. With 450,000 documents uploaded and most never read beyond their metadata, this lazy parsing strategy cuts compute costs by roughly 80 percent compared to eager processing. This agentic parsing pipeline (the tiered extraction, the lazy on-demand OCR, and the path that turns a raw upload into Qdrant-indexed content the moment an agent reaches for it) was built by Balkrushn Hirani, myGenAssist's backend developer lead.
@@ -174,8 +200,13 @@ Bayer measures impact through KPI surveys run every six months across two user g
 
 The team is careful not to over-attribute. It does not isolate which component drives which fraction of the gain. But the connection to retrieval is direct: a large part of the efficiency comes from getting grounded responses, and grounding is impossible without the vector store underneath. Hallucinated answers tank survey scores; grounded answers lift them.
 
-> "We've seen 20% efficiency when it comes to using AI platforms. A big part of that gain is that you have to get results from AI that are grounded. If you get hallucinations, people are not satisfied. It wouldn't be possible without the components." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
-
+{{< quote
+  text="We've seen 20% efficiency when it comes to using AI platforms. A big part of that gain is that you have to get results from AI that are grounded. If you get hallucinations, people are not satisfied. It wouldn't be possible without the components."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 With the recent shift to more autonomous agents, the measurement problem itself is evolving. Earlier chatbot-style systems delivered incremental time savings: a faster email summary, a quicker draft. The new agents can run for 10 to 15 minutes unattended and return a completed task: research done, document written, a notification sent to the user's phone. That changes the question from "how much time did we save" to "how well was the whole task done," a harder thing to quantify but a larger prize.
 
 That last mile, meeting people where they already work, runs through myGenAssist Claw, the Microsoft Teams integration built by Hendrik Hogertz (myGenAssist senior developer), which lets an employee @-mention the assistant inside a Teams channel and hand it a task without ever leaving the conversation.
@@ -194,16 +225,26 @@ Traceability extends beyond user-facing citations into the infrastructure itself
 
 The Bayer team actively tracks Qdrant releases and adopts performance features as they ship. It uses incremental HNSW indexing to absorb the constant stream of document updates without full reindexing. It adopted binary quantization to compact points and reduce the memory footprint shortly after release. One engineer recently went through the latest Qdrant publications to update the team's search strategy and apply current optimizations.
 
-> "Qdrant is one of the more feature-rich platforms where you can do all those things directly inside the vector store. We always try to be on top of the features you push out to reduce the memory footprint and the latency." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
-
+{{< quote
+  text="Qdrant is one of the more feature-rich platforms where you can do all those things directly inside the vector store. We always try to be on top of the features you push out to reduce the memory footprint and the latency."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 This matters to Bayer because it reduces the gap between a published optimization and a deployed one. When Qdrant ships something like improved compression, Bayer can fold it into a live, compliance-bound, enterprise-scale platform without re-architecting.
 
 ## Why a Composable Engine, Not a Black Box
 
 Bayer's experience drove an architectural conviction to focus on retrieval rather than agent orchestration. Even when Bayer ships an end-to-end agent that handles everything, its users still prefer access to the underlying pieces. Developers building on the platform's API want lower-level components they can inspect and optimize, not an opaque pipeline they have to trust blindly.
 
-> "People still prefer to have access to these pieces themselves, like Qdrant. It's very important to give developers a platform that's composable, where they can optimize each part and build their own workflows. Not all agentic pipelines are applicable to all use cases." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
-
+{{< quote
+  text="People still prefer to have access to these pieces themselves, like Qdrant. It's very important to give developers a platform that's composable, where they can optimize each part and build their own workflows. Not all agentic pipelines are applicable to all use cases."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
 That preference is sharpened by the proliferation of hyperscaler agent frameworks. With Google, AWS, and Azure each pushing their own solutions, teams struggle to manage and optimize systems they cannot see into. A composable engine that exposes its retrieval primitives lets engineers build pipelines tuned to their specific workload, rather than accepting opaque defaults.
 
 ## What's Next
@@ -214,4 +255,10 @@ Bayer's roadmap continues to push on the dimensions that drew it to Qdrant in th
 
 Bayer started with a Redis prototype and a thousand users. Three years later, it runs a compliance-bound, Hybrid Cloud deployment serving 116,000 employees, processing millions of messages a month, grounding autonomous agents, and increasingly searching across every modality the company produces. Qdrant has been the constant underneath that evolution: the retrieval layer that keeps answers grounded, the API the agents call directly, and the composable foundation that has adapted as Bayer's AI workloads shifted from chatbots to agents.
 
-> "We're turning into the AI search engine for the company. There are various applications for a vector database even beyond simple RAG, beyond the chatbot. It supports memory for the agent, it powers enterprise search, and it lets any team build their own multimodal search engine on top." - Hooman Sedghamiz, Senior Director AI/ML - Precision Medicine & Insights, Bayer
+{{< quote
+  text="We're turning into the AI search engine for the company. There are various applications for a vector database even beyond simple RAG, beyond the chatbot. It supports memory for the agent, it powers enterprise search, and it lets any team build their own multimodal search engine on top."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML, Precision Medicine & Insights"
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}

--- a/qdrant-landing/content/blog/case-study-bayer.md
+++ b/qdrant-landing/content/blog/case-study-bayer.md
@@ -48,9 +48,7 @@ From there, it scaled into a full platform layer. Today, myGenAssist serves the 
   text="The whole stack of RAG is hidden from users. For them it's just a file upload, but it ends up going through several layers of retrieval-augmented generation, Qdrant being part of it. That has proven to be quite successful to bring grounding and reduce hallucinations for LLM applications."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 
 ## Choosing a Vector Search Engine, Three Years Ago
 
@@ -62,9 +60,7 @@ The team evaluated across several dimensions: price-performance ratio, latency, 
   text="There weren't many options back then. We did benchmarking across price-performance, latency, and other aspects. The first points we really liked: it was open source, we could test it very fast, latency was good, and it was written in Rust. We ended up going with Qdrant."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 
 ## From Self-Hosted to Hybrid Cloud: Meeting Compliance Without Drowning in Ops
 
@@ -78,9 +74,7 @@ Pure self-hosting satisfied the compliance side but became demanding for a team 
   text="Life science companies want data to stay inside and use the platform self-hosted if possible. But self-hosting was already quite demanding for us. Our team is not that big, so we decided to use hybrid management."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 
 ## Scaling to Millions of Messages and an Evolving Data Model
 
@@ -94,9 +88,7 @@ The data model itself is also expanding. Bayer is migrating toward an omnimodal 
   text="For every enterprise, it's very important to be able to find assets no matter what format they're in: images, text, a molecular image, anything. We've started looking at these not just for simple RAG applications, but to let people search across all the assets they're dealing with."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 The omnimodal pipeline is concrete, not aspirational. When a scientific PDF enters the system, a vision model generates search-optimized descriptions of every figure (content summary, OCR'd labels, key concepts) and injects them into the text stream before chunking.
 
 So searching "receptor binding affinity curve" returns the figure itself, not just paragraphs that mention it. Audio and video recordings are chunked, transcribed via Whisper, and vector-indexed alongside text documents. A lab meeting from three months ago becomes searchable in Qdrant within minutes of upload.
@@ -111,9 +103,7 @@ The second is retrieval quality. Grounded, high-quality answers are what keep us
   text="You want your retrieval to be very fast. A low-latency platform helps the user experience a lot. And the second point is the quality of retrieval inside that latency. It's important that your vector search supports hybrid search, for example. That's great."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 ![Qdrant as enterprise retrieval backbone: four layers from 116K employees through the deep agent harness to Qdrant Hybrid Cloud and GxP-ready observability](/blog/case-study-bayer/qdrant-enterprise-retrieval-backbone.png)
 
 ## Composable Retrieval for Agents: Exposing Qdrant Directly to the Model
@@ -130,18 +120,14 @@ A feature Bayer calls knowledge bases makes this concrete. Users start a project
   text="This is very powerful because the agent now decides: I didn't find anything with keyword search, so I can switch to semantic search, or I can use hybrid search that the API exposes to me. Two years ago, semantic search alone wasn't enough. Now with hybrid search it's way more powerful."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 This is also where the omnimodal direction pays off. Users upload meeting transcripts, images, audio, and video, and the agent discovers and connects them. Qdrant increasingly serves as the agent's memory, letting it recall what a user has been working on and tailor answers accordingly. Teams elsewhere in the company can point their own applications at a shared collection to build their own search experiences, from molecule search to internal enterprise search.
 
 {{< quote
   text="People used to look at vector databases only for RAG applications. Now they're solving enterprise search problems. No one had an omnimodal search engine where you could search videos, audio, and every asset the company generates. We realized Qdrant was turning into that."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 Retrieval quality benefits from a parallel query expansion strategy. A single user question generates four Qdrant searches simultaneously: the verbatim query, a question-form rewrite, extracted keywords, and a HYDE hypothetical answer. Results are fused, deduplicated with a diversity cap of three chunks per document, and optionally reranked. The approach is particularly effective for pharmaceutical literature, where the same concept appears under different nomenclatures across regulatory filings, clinical protocols, and marketing materials.
 
 Document parsing itself is agentic. Rather than pre-processing every upload through expensive OCR, the platform defers extraction until the agent actually needs a document's content. A lightweight sandbox-local parser handles simple formats instantly; complex PDFs with tables and figures fall through to server-side Docling OCR on demand. Results are cached and indexed into Qdrant on first use. With 450,000 documents uploaded and most never read beyond their metadata, this lazy parsing strategy cuts compute costs by roughly 80 percent compared to eager processing. This agentic parsing pipeline (the tiered extraction, the lazy on-demand OCR, and the path that turns a raw upload into Qdrant-indexed content the moment an agent reaches for it) was built by Balkrushn Hirani, myGenAssist's backend developer lead.
@@ -204,9 +190,7 @@ The team is careful not to over-attribute. It does not isolate which component d
   text="We've seen 20% efficiency when it comes to using AI platforms. A big part of that gain is that you have to get results from AI that are grounded. If you get hallucinations, people are not satisfied. It wouldn't be possible without the components."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 With the recent shift to more autonomous agents, the measurement problem itself is evolving. Earlier chatbot-style systems delivered incremental time savings: a faster email summary, a quicker draft. The new agents can run for 10 to 15 minutes unattended and return a completed task: research done, document written, a notification sent to the user's phone. That changes the question from "how much time did we save" to "how well was the whole task done," a harder thing to quantify but a larger prize.
 
 That last mile, meeting people where they already work, runs through myGenAssist Claw, the Microsoft Teams integration built by Hendrik Hogertz (myGenAssist senior developer), which lets an employee @-mention the assistant inside a Teams channel and hand it a task without ever leaving the conversation.
@@ -229,9 +213,7 @@ The Bayer team actively tracks Qdrant releases and adopts performance features a
   text="Qdrant is one of the more feature-rich platforms where you can do all those things directly inside the vector store. We always try to be on top of the features you push out to reduce the memory footprint and the latency."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 This matters to Bayer because it reduces the gap between a published optimization and a deployed one. When Qdrant ships something like improved compression, Bayer can fold it into a live, compliance-bound, enterprise-scale platform without re-architecting.
 
 ## Why a Composable Engine, Not a Black Box
@@ -242,9 +224,7 @@ Bayer's experience drove an architectural conviction to focus on retrieval rathe
   text="People still prefer to have access to these pieces themselves, like Qdrant. It's very important to give developers a platform that's composable, where they can optimize each part and build their own workflows. Not all agentic pipelines are applicable to all use cases."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}
 That preference is sharpened by the proliferation of hyperscaler agent frameworks. With Google, AWS, and Azure each pushing their own solutions, teams struggle to manage and optimize systems they cannot see into. A composable engine that exposes its retrieval primitives lets engineers build pipelines tuned to their specific workload, rather than accepting opaque defaults.
 
 ## What's Next
@@ -259,6 +239,4 @@ Bayer started with a Redis prototype and a thousand users. Three years later, it
   text="We're turning into the AI search engine for the company. There are various applications for a vector database even beyond simple RAG, beyond the chatbot. It supports memory for the agent, it powers enterprise search, and it lets any team build their own multimodal search engine on top."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML, Precision Medicine & Insights"
-  company="Bayer"
-  avatar="/img/customers/hooman-sedghamiz.svg"
-  logo="/img/brands/bayer.svg" >}}
+  company="Bayer" >}}

--- a/qdrant-landing/content/blog/case-study-bayer.md
+++ b/qdrant-landing/content/blog/case-study-bayer.md
@@ -28,7 +28,7 @@ Bayer is a global life sciences company operating at the intersection of two of 
 Turning that ambition into production systems for 116,000 employees is a hard infrastructure problem. It requires retrieval that stays fast under sustained load, grounds large language models (LLMs) in real data to suppress hallucinations, satisfies strict life sciences compliance requirements, and adapts as the underlying AI workloads shift from simple chatbots to autonomous agents. This is the story of how Bayer built that foundation, and why Qdrant has sat at the center of it for nearly three years.
 
 {{< quote
-  text="If you don't have a Qdrant vector store behind the scenes, it's very difficult to ground LLMs into reality. If you remove the search from the agent, the results go back to two years ago."
+  text="People used to look at vector databases only for RAG applications. Now they're solving enterprise search problems. No one had an omnimodal search engine where you could search videos, audio, and every asset the company generates. We realized Qdrant was turning into that."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer"
@@ -89,6 +89,7 @@ The data model itself is also expanding. Bayer is migrating toward an omnimodal 
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
+
 The omnimodal pipeline is concrete, not aspirational. When a scientific PDF enters the system, a vision model generates search-optimized descriptions of every figure (content summary, OCR'd labels, key concepts) and injects them into the text stream before chunking.
 
 So searching "receptor binding affinity curve" returns the figure itself, not just paragraphs that mention it. Audio and video recordings are chunked, transcribed via Whisper, and vector-indexed alongside text documents. A lab meeting from three months ago becomes searchable in Qdrant within minutes of upload.
@@ -104,11 +105,18 @@ The second is retrieval quality. Grounded, high-quality answers are what keep us
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
+
 ![Qdrant as enterprise retrieval backbone: four layers from 116K employees through the deep agent harness to Qdrant Hybrid Cloud and GxP-ready observability](/blog/case-study-bayer/qdrant-enterprise-retrieval-backbone.png)
 
 ## Composable Retrieval for Agents: Exposing Qdrant Directly to the Model
 
 The most significant shift in Bayer's architecture is the move from chatbot-style interactions to deep agents. Bayer now runs agentic applications on a LangGraph-based harness, comparable to the deep research and coding agents that have become common, and these agents are far hungrier for search than the simpler systems that preceded them. A single deep research run unrolls a long tool-calling loop, hundreds of steps deep, and can fire thousands of retrieval queries before it returns, which makes per-query latency matter even more than it did before. Every one of those tools, from web search to PubMed to the FDA connector, is itself backed by a Qdrant collection.
+
+{{< quote
+  text="If you don't have a Qdrant vector store behind the scenes, it's very difficult to ground LLMs into reality. If you remove the search from the agent, the results go back to two years ago."
+  name="Hooman Sedghamiz"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
+  company="Bayer" >}}
 
 Crucially, Bayer exposes the Qdrant API directly to the model. Whether the requester is a human or an agent, the same interface is available, and the agent can choose how to retrieve based on the task. This is exactly the composable model Qdrant is designed for: retrieval primitives the caller combines at query time, rather than a fixed pipeline hidden behind an opaque API. Under the hood, the hybrid path runs dense and sparse queries in parallel and fuses them with Reciprocal Rank Fusion before a BGE reranker sharpens the final ordering. The agent sees a clean set of tools, not that machinery.
 
@@ -121,13 +129,9 @@ A feature Bayer calls knowledge bases makes this concrete. Users start a project
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
+
 This is also where the omnimodal direction pays off. Users upload meeting transcripts, images, audio, and video, and the agent discovers and connects them. Qdrant increasingly serves as the agent's memory, letting it recall what a user has been working on and tailor answers accordingly. Teams elsewhere in the company can point their own applications at a shared collection to build their own search experiences, from molecule search to internal enterprise search.
 
-{{< quote
-  text="People used to look at vector databases only for RAG applications. Now they're solving enterprise search problems. No one had an omnimodal search engine where you could search videos, audio, and every asset the company generates. We realized Qdrant was turning into that."
-  name="Hooman Sedghamiz"
-  role="Senior Director AI/ML - Precision Medicine & Insights"
-  company="Bayer" >}}
 Retrieval quality benefits from a parallel query expansion strategy. A single user question generates four Qdrant searches simultaneously: the verbatim query, a question-form rewrite, extracted keywords, and a HYDE hypothetical answer. Results are fused, deduplicated with a diversity cap of three chunks per document, and optionally reranked. The approach is particularly effective for pharmaceutical literature, where the same concept appears under different nomenclatures across regulatory filings, clinical protocols, and marketing materials.
 
 Document parsing itself is agentic. Rather than pre-processing every upload through expensive OCR, the platform defers extraction until the agent actually needs a document's content. A lightweight sandbox-local parser handles simple formats instantly; complex PDFs with tables and figures fall through to server-side Docling OCR on demand. Results are cached and indexed into Qdrant on first use. With 450,000 documents uploaded and most never read beyond their metadata, this lazy parsing strategy cuts compute costs by roughly 80 percent compared to eager processing. This agentic parsing pipeline (the tiered extraction, the lazy on-demand OCR, and the path that turns a raw upload into Qdrant-indexed content the moment an agent reaches for it) was built by Balkrushn Hirani, myGenAssist's backend developer lead.
@@ -190,7 +194,10 @@ The team is careful not to over-attribute. It does not isolate which component d
   text="We've seen 20% efficiency when it comes to using AI platforms. A big part of that gain is that you have to get results from AI that are grounded. If you get hallucinations, people are not satisfied. It wouldn't be possible without the components."
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
-  company="Bayer" >}}
+  company="Bayer"
+  avatar="/img/customers/hooman-sedghamiz.svg"
+  logo="/img/brands/bayer.svg" >}}
+
 With the recent shift to more autonomous agents, the measurement problem itself is evolving. Earlier chatbot-style systems delivered incremental time savings: a faster email summary, a quicker draft. The new agents can run for 10 to 15 minutes unattended and return a completed task: research done, document written, a notification sent to the user's phone. That changes the question from "how much time did we save" to "how well was the whole task done," a harder thing to quantify but a larger prize.
 
 That last mile, meeting people where they already work, runs through myGenAssist Claw, the Microsoft Teams integration built by Hendrik Hogertz (myGenAssist senior developer), which lets an employee @-mention the assistant inside a Teams channel and hand it a task without ever leaving the conversation.
@@ -214,6 +221,7 @@ The Bayer team actively tracks Qdrant releases and adopts performance features a
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
+
 This matters to Bayer because it reduces the gap between a published optimization and a deployed one. When Qdrant ships something like improved compression, Bayer can fold it into a live, compliance-bound, enterprise-scale platform without re-architecting.
 
 ## Why a Composable Engine, Not a Black Box
@@ -225,6 +233,7 @@ Bayer's experience drove an architectural conviction to focus on retrieval rathe
   name="Hooman Sedghamiz"
   role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
+
 That preference is sharpened by the proliferation of hyperscaler agent frameworks. With Google, AWS, and Azure each pushing their own solutions, teams struggle to manage and optimize systems they cannot see into. A composable engine that exposes its retrieval primitives lets engineers build pipelines tuned to their specific workload, rather than accepting opaque defaults.
 
 ## What's Next

--- a/qdrant-landing/content/blog/case-study-bayer.md
+++ b/qdrant-landing/content/blog/case-study-bayer.md
@@ -30,7 +30,7 @@ Turning that ambition into production systems for 116,000 employees is a hard in
 {{< quote
   text="If you don't have a Qdrant vector store behind the scenes, it's very difficult to ground LLMs into reality. If you remove the search from the agent, the results go back to two years ago."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer"
   avatar="/img/customers/hooman-sedghamiz.svg"
   logo="/img/brands/bayer.svg"
@@ -47,7 +47,7 @@ From there, it scaled into a full platform layer. Today, myGenAssist serves the 
 {{< quote
   text="The whole stack of RAG is hidden from users. For them it's just a file upload, but it ends up going through several layers of retrieval-augmented generation, Qdrant being part of it. That has proven to be quite successful to bring grounding and reduce hallucinations for LLM applications."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 
 ## Choosing a Vector Search Engine, Three Years Ago
@@ -59,7 +59,7 @@ The team evaluated across several dimensions: price-performance ratio, latency, 
 {{< quote
   text="There weren't many options back then. We did benchmarking across price-performance, latency, and other aspects. The first points we really liked: it was open source, we could test it very fast, latency was good, and it was written in Rust. We ended up going with Qdrant."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 
 ## From Self-Hosted to Hybrid Cloud: Meeting Compliance Without Drowning in Ops
@@ -73,7 +73,7 @@ Pure self-hosting satisfied the compliance side but became demanding for a team 
 {{< quote
   text="Life science companies want data to stay inside and use the platform self-hosted if possible. But self-hosting was already quite demanding for us. Our team is not that big, so we decided to use hybrid management."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 
 ## Scaling to Millions of Messages and an Evolving Data Model
@@ -87,7 +87,7 @@ The data model itself is also expanding. Bayer is migrating toward an omnimodal 
 {{< quote
   text="For every enterprise, it's very important to be able to find assets no matter what format they're in: images, text, a molecular image, anything. We've started looking at these not just for simple RAG applications, but to let people search across all the assets they're dealing with."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 The omnimodal pipeline is concrete, not aspirational. When a scientific PDF enters the system, a vision model generates search-optimized descriptions of every figure (content summary, OCR'd labels, key concepts) and injects them into the text stream before chunking.
 
@@ -102,7 +102,7 @@ The second is retrieval quality. Grounded, high-quality answers are what keep us
 {{< quote
   text="You want your retrieval to be very fast. A low-latency platform helps the user experience a lot. And the second point is the quality of retrieval inside that latency. It's important that your vector search supports hybrid search, for example. That's great."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 ![Qdrant as enterprise retrieval backbone: four layers from 116K employees through the deep agent harness to Qdrant Hybrid Cloud and GxP-ready observability](/blog/case-study-bayer/qdrant-enterprise-retrieval-backbone.png)
 
@@ -119,14 +119,14 @@ A feature Bayer calls knowledge bases makes this concrete. Users start a project
 {{< quote
   text="This is very powerful because the agent now decides: I didn't find anything with keyword search, so I can switch to semantic search, or I can use hybrid search that the API exposes to me. Two years ago, semantic search alone wasn't enough. Now with hybrid search it's way more powerful."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 This is also where the omnimodal direction pays off. Users upload meeting transcripts, images, audio, and video, and the agent discovers and connects them. Qdrant increasingly serves as the agent's memory, letting it recall what a user has been working on and tailor answers accordingly. Teams elsewhere in the company can point their own applications at a shared collection to build their own search experiences, from molecule search to internal enterprise search.
 
 {{< quote
   text="People used to look at vector databases only for RAG applications. Now they're solving enterprise search problems. No one had an omnimodal search engine where you could search videos, audio, and every asset the company generates. We realized Qdrant was turning into that."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 Retrieval quality benefits from a parallel query expansion strategy. A single user question generates four Qdrant searches simultaneously: the verbatim query, a question-form rewrite, extracted keywords, and a HYDE hypothetical answer. Results are fused, deduplicated with a diversity cap of three chunks per document, and optionally reranked. The approach is particularly effective for pharmaceutical literature, where the same concept appears under different nomenclatures across regulatory filings, clinical protocols, and marketing materials.
 
@@ -189,7 +189,7 @@ The team is careful not to over-attribute. It does not isolate which component d
 {{< quote
   text="We've seen 20% efficiency when it comes to using AI platforms. A big part of that gain is that you have to get results from AI that are grounded. If you get hallucinations, people are not satisfied. It wouldn't be possible without the components."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 With the recent shift to more autonomous agents, the measurement problem itself is evolving. Earlier chatbot-style systems delivered incremental time savings: a faster email summary, a quicker draft. The new agents can run for 10 to 15 minutes unattended and return a completed task: research done, document written, a notification sent to the user's phone. That changes the question from "how much time did we save" to "how well was the whole task done," a harder thing to quantify but a larger prize.
 
@@ -212,7 +212,7 @@ The Bayer team actively tracks Qdrant releases and adopts performance features a
 {{< quote
   text="Qdrant is one of the more feature-rich platforms where you can do all those things directly inside the vector store. We always try to be on top of the features you push out to reduce the memory footprint and the latency."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 This matters to Bayer because it reduces the gap between a published optimization and a deployed one. When Qdrant ships something like improved compression, Bayer can fold it into a live, compliance-bound, enterprise-scale platform without re-architecting.
 
@@ -223,7 +223,7 @@ Bayer's experience drove an architectural conviction to focus on retrieval rathe
 {{< quote
   text="People still prefer to have access to these pieces themselves, like Qdrant. It's very important to give developers a platform that's composable, where they can optimize each part and build their own workflows. Not all agentic pipelines are applicable to all use cases."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}
 That preference is sharpened by the proliferation of hyperscaler agent frameworks. With Google, AWS, and Azure each pushing their own solutions, teams struggle to manage and optimize systems they cannot see into. A composable engine that exposes its retrieval primitives lets engineers build pipelines tuned to their specific workload, rather than accepting opaque defaults.
 
@@ -238,5 +238,5 @@ Bayer started with a Redis prototype and a thousand users. Three years later, it
 {{< quote
   text="We're turning into the AI search engine for the company. There are various applications for a vector database even beyond simple RAG, beyond the chatbot. It supports memory for the agent, it powers enterprise search, and it lets any team build their own multimodal search engine on top."
   name="Hooman Sedghamiz"
-  role="Senior Director AI/ML, Precision Medicine & Insights"
+  role="Senior Director AI/ML - Precision Medicine & Insights"
   company="Bayer" >}}

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -134,40 +134,15 @@ Key Observations:
 
 ![case-study-sprinklr-8](/blog/case-study-sprinklr/image8.png)
 
-```json
+```python
 data = [
-
-{'system': 'Qdrant', 'index_size': '1,000', 'MAP': 0.98, 'P95 Time': 0.22, 'Mean Time': 0.1, 'QPS': 280,
-
-'Upload Time': 1},
-
-{'system': 'Qdrant', 'index_size': '10,000', 'MAP': 0.99, 'P95 Time': 0.16, 'Mean Time': 0.09, 'QPS': 330,
-
-'Upload Time': 5},
-
-{'system': 'Qdrant', 'index_size': '100,000', 'MAP': 0.98, 'P95 Time': 0.3, 'Mean Time': 0.23, 'QPS': 145,
-
-'Upload Time': 100},
-
-{'system': 'Qdrant', 'index_size': '1,000,000', 'MAP': 0.99, 'P95 Time': 0.171, 'Mean Time': 0.162, 'QPS': 596,
-
-'Upload Time': 220},
-
-{'system': 'ElasticSearch', 'index_size': '1,000', 'MAP': 0.99, 'P95 Time': 0.42, 'Mean Time': 0.32, 'QPS': 95,
-
-'Upload Time': 10},
-
-{'system': 'ElasticSearch', 'index_size': '10,000', 'MAP': 0.98, 'P95 Time': 0.3, 'Mean Time': 0.24, 'QPS': 120,
-
-'Upload Time': 50},
-
-{'system': 'ElasticSearch', 'index_size': '100,000', 'MAP': 0.99, 'P95 Time': 0.48, 'Mean Time': 0.42, 'QPS': 80,
-
-'Upload Time': 1100},
-
-{'system': 'ElasticSearch', 'index_size': '1,000,000', 'MAP': 0.99, 'P95 Time': 0.37, 'Mean Time': 0.236,
-
-'QPS': 348, 'Upload Time': 1150}
-
+    {'system': 'Qdrant', 'index_size': '1,000', 'MAP': 0.98, 'P95 Time': 0.22, 'Mean Time': 0.1, 'QPS': 280, 'Upload Time': 1},
+    {'system': 'Qdrant', 'index_size': '10,000', 'MAP': 0.99, 'P95 Time': 0.16, 'Mean Time': 0.09, 'QPS': 330, 'Upload Time': 5},
+    {'system': 'Qdrant', 'index_size': '100,000', 'MAP': 0.98, 'P95 Time': 0.3, 'Mean Time': 0.23, 'QPS': 145, 'Upload Time': 100},
+    {'system': 'Qdrant', 'index_size': '1,000,000', 'MAP': 0.99, 'P95 Time': 0.171, 'Mean Time': 0.162, 'QPS': 596, 'Upload Time': 220},
+    {'system': 'ElasticSearch', 'index_size': '1,000', 'MAP': 0.99, 'P95 Time': 0.42, 'Mean Time': 0.32, 'QPS': 95, 'Upload Time': 10},
+    {'system': 'ElasticSearch', 'index_size': '10,000', 'MAP': 0.98, 'P95 Time': 0.3, 'Mean Time': 0.24, 'QPS': 120, 'Upload Time': 50},
+    {'system': 'ElasticSearch', 'index_size': '100,000', 'MAP': 0.99, 'P95 Time': 0.48, 'Mean Time': 0.42, 'QPS': 80, 'Upload Time': 1100},
+    {'system': 'ElasticSearch', 'index_size': '1,000,000', 'MAP': 0.99, 'P95 Time': 0.37, 'Mean Time': 0.236, 'QPS': 348, 'Upload Time': 1150},
 ]
 ```

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -41,7 +41,8 @@ To support various AI-driven applications, Sprinklr needed an efficient vector d
   text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board."
   name="Raghav Sonavane"
   role="Associate Director of Machine Learning Engineering"
-  company="Sprinklr" >}}
+  company="Sprinklr"
+  logo="/img/customer-logo/sprinklr.svg" >}}
 
 Last year, Sprinklr undertook a comprehensive evaluation of its existing search infrastructure. The goals were to identify current capability gaps, benchmark performance for speed and cost, and explore opportunities to improve the developer experience through enhanced scalability and stronger data privacy controls. It became clear that an advanced vector database was essential to meet these needs, and Qdrant emerged as the ideal solution.
 

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -29,7 +29,14 @@ Raghav Sonavane, Associate Director of Machine Learning Engineering at Sprinklr,
 
 *Figure:* Sprinklr’s RAG architecture
 
-Sprinklr’s platform is composed of four key product suites - Sprinklr Service, Sprinklr Marketing, Sprinklr Social, and Sprinklr Insights. Each suite is embedded with AI-first features such as assist agents, post-call analysis, and real-time analytics, which are crucial for managing large-scale contact center operations. “These AI-driven capabilities, supported by Qdrant’s advanced vector search, enhance Sprinklr’s customer-facing tools such as FAQ bots, transactional bots, conversational services, and product recommendation engines,” says Sonavane.
+Sprinklr’s platform is composed of four key product suites - Sprinklr Service, Sprinklr Marketing, Sprinklr Social, and Sprinklr Insights. Each suite is embedded with AI-first features such as assist agents, post-call analysis, and real-time analytics, which are crucial for managing large-scale contact center operations.
+
+{{< quote
+  text="These AI-driven capabilities, supported by Qdrant’s advanced vector search, enhance Sprinklr’s customer-facing tools such as FAQ bots, transactional bots, conversational services, and product recommendation engines."
+  name="Raghav Sonavane"
+  role="Associate Director of Machine Learning Engineering"
+  company="Sprinklr"
+  logo="/img/customer-logo/sprinklr.svg" >}}
 
 These self-serve applications rely heavily on advanced vector search to analyze and optimize community content and refine knowledge bases, ensuring efficient and relevant responses. For customers requiring further assistance, Sprinklr equips support agents with powerful search capabilities, enabling them to quickly access similar cases and draw from past interactions, enhancing the quality and speed of customer support.
 
@@ -41,8 +48,7 @@ To support various AI-driven applications, Sprinklr needed an efficient vector d
   text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board."
   name="Raghav Sonavane"
   role="Associate Director of Machine Learning Engineering"
-  company="Sprinklr"
-  logo="/img/customer-logo/sprinklr.svg" >}}
+  company="Sprinklr" >}}
 
 Last year, Sprinklr undertook a comprehensive evaluation of its existing search infrastructure. The goals were to identify current capability gaps, benchmark performance for speed and cost, and explore opportunities to improve the developer experience through enhanced scalability and stronger data privacy controls. It became clear that an advanced vector database was essential to meet these needs, and Qdrant emerged as the ideal solution.
 
@@ -63,9 +69,21 @@ After evaluating several options of vector DBs, including Pinecone, Weaviate, an
 
 Sprinklr’s transition to Qdrant was carefully managed, starting with 10% of their workloads before gradually scaling up. The transition was seamless, thanks in part to Qdrant’s configurable [Web UI](https://qdrant.tech/documentation/interfaces/web-ui/), which allowed Sprinklr to fully utilize its capabilities within the existing infrastructure.
 
-“Qdrant’s ability to index [multiple vectors](https://qdrant.tech/documentation/manage-data/vectors/#multivectors) simultaneously and retrieve and re-rank with precision brought significant improvements to our workflow,” Sonavane remarks. This feature reduced the need for repeated retrieval processes, significantly improving efficiency. Additionally, Qdrant’s [quantization](https://qdrant.tech/documentation/manage-data/quantization/) and [memory mapping](https://qdrant.tech/documentation/manage-data/storage/#configuring-memmap-storage) features enabled Sprinklr to reduce RAM usage, leading to substantial cost savings.
+{{< quote
+  text="Qdrant’s ability to index [multiple vectors](https://qdrant.tech/documentation/manage-data/vectors/#multivectors) simultaneously and retrieve and re-rank with precision brought significant improvements to our workflow."
+  name="Raghav Sonavane"
+  role="Associate Director of Machine Learning Engineering"
+  company="Sprinklr" >}}
 
-Qdrant now plays a key supportive role in enhancing Sprinklr’s vector search capabilities within its AI-driven applications, which is designed to be cloud- and LLM-agnostic. The platform supports various AI-driven tasks, from retrieval and re-ranking to serving advanced customer experiences. “Retrieval is the foundation of all our AI tasks, and Qdrant’s resilience and speed have made it an integral part of our system,” Sonavane emphasizes. Sprinklr operates [Qdrant as a managed service on AWS](https://qdrant.tech/cloud/), ensuring scalability, reliability, and ease of use.
+This feature reduced the need for repeated retrieval processes, significantly improving efficiency. Additionally, Qdrant’s [quantization](https://qdrant.tech/documentation/manage-data/quantization/) and [memory mapping](https://qdrant.tech/documentation/manage-data/storage/#configuring-memmap-storage) features enabled Sprinklr to reduce RAM usage, leading to substantial cost savings.
+
+Qdrant now plays a key supportive role in enhancing Sprinklr’s vector search capabilities within its AI-driven applications, which is designed to be cloud- and LLM-agnostic. The platform supports various AI-driven tasks, from retrieval and re-ranking to serving advanced customer experiences. Sprinklr operates [Qdrant as a managed service on AWS](https://qdrant.tech/cloud/), ensuring scalability, reliability, and ease of use.
+
+{{< quote
+  text="Retrieval is the foundation of all our AI tasks, and Qdrant’s resilience and speed have made it an integral part of our system."
+  name="Raghav Sonavane"
+  role="Associate Director of Machine Learning Engineering"
+  company="Sprinklr" >}}
 
 ### Key Outcomes with Qdrant
 
@@ -80,7 +98,11 @@ The Sprinklr team conducted a thorough internal benchmark on applications requir
 - **Low Latency for Real-Time Applications:** In Sprinklr's benchmark, Qdrant delivered a P99 latency of 20ms for searches on 1 million vectors, making it ideal for real-time use cases like live chat, where Elasticsearch and Milvus both exceeded 100ms.
 - **High Throughput for Heavy Query Loads**: In Sprinklr's benchmark, Qdrant handled up to 250 requests per second (RPS) under similar configurations, significantly outperforming Elasticsearch's 100 RPS, making it ideal for environments with heavy query loads.
 
-“Qdrant is a very fast and high quality retrieval system,” Sonavane points out.
+{{< quote
+  text="Qdrant is a very fast and high quality retrieval system."
+  name="Raghav Sonavane"
+  role="Associate Director of Machine Learning Engineering"
+  company="Sprinklr" >}}
 
 ![case-study-sprinklr-3](/blog/case-study-sprinklr/image3.png)
 

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -35,7 +35,13 @@ These self-serve applications rely heavily on advanced vector search to analyze 
 
 ## The Need for a Vector Database
 
-To support various AI-driven applications, Sprinklr needed an efficient vector database. "The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board," explains Sonavane.
+To support various AI-driven applications, Sprinklr needed an efficient vector database.
+
+{{< quote
+  text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board."
+  name="Raghav Sonavane"
+  role="Associate Director of Machine Learning Engineering"
+  company="Sprinklr" >}}
 
 Last year, Sprinklr undertook a comprehensive evaluation of its existing search infrastructure. The goals were to identify current capability gaps, benchmark performance for speed and cost, and explore opportunities to improve the developer experience through enhanced scalability and stronger data privacy controls. It became clear that an advanced vector database was essential to meet these needs, and Qdrant emerged as the ideal solution.
 

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -38,7 +38,7 @@ These self-serve applications rely heavily on advanced vector search to analyze 
 To support various AI-driven applications, Sprinklr needed an efficient vector database.
 
 {{< quote
-  text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board."
+  text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board,"
   name="Raghav Sonavane"
   role="Associate Director of Machine Learning Engineering"
   company="Sprinklr"

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -38,7 +38,7 @@ These self-serve applications rely heavily on advanced vector search to analyze 
 To support various AI-driven applications, Sprinklr needed an efficient vector database.
 
 {{< quote
-  text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board,"
+  text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board."
   name="Raghav Sonavane"
   role="Associate Director of Machine Learning Engineering"
   company="Sprinklr"

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -42,13 +42,7 @@ These self-serve applications rely heavily on advanced vector search to analyze 
 
 ## The Need for a Vector Database
 
-To support various AI-driven applications, Sprinklr needed an efficient vector database.
-
-{{< quote
-  text="The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board."
-  name="Raghav Sonavane"
-  role="Associate Director of Machine Learning Engineering"
-  company="Sprinklr" >}}
+To support various AI-driven applications, Sprinklr needed an efficient vector database. "The key challenge was to provide the highest quality and fastest search capabilities for retrieval tasks across the board," explains Sonavane.
 
 Last year, Sprinklr undertook a comprehensive evaluation of its existing search infrastructure. The goals were to identify current capability gaps, benchmark performance for speed and cost, and explore opportunities to improve the developer experience through enhanced scalability and stronger data privacy controls. It became clear that an advanced vector database was essential to meet these needs, and Qdrant emerged as the ideal solution.
 

--- a/qdrant-landing/content/blog/case-study-tripadvisor.md
+++ b/qdrant-landing/content/blog/case-study-tripadvisor.md
@@ -22,6 +22,15 @@ partition: case-studies
 
 ![How Tripadvisor Drives 2–3x More Revenue with Qdrant-Powered AI](/blog/case-study-tripadvisor/case-study-tripadvisor-summary-dark.jpg)
 
+{{< quote
+  text="Qdrant has been crucial for our transformation. … Now, we can represent everything from hotel preferences to restaurant choices to user behavior in a unified way. And we’re seeing real business results. Users engaging with our AI-powered features like trip planning are showing 2-3x more revenue."
+  name="Rahul Todkar"
+  role="Head of Data and AI"
+  company="Tripadvisor"
+  avatar="/img/customers/rahul-todkar.svg"
+  logo="/img/brands/tripadvisor.svg"
+  featured="true" >}}
+
 Tripadvisor, the world’s largest travel guidance platform, is undergoing a deep transformation. With hundreds of millions of monthly users and over a billion reviews and contributions, it holds one of the richest datasets in the travel industry. And until recently, that data, particularly its unstructured content, had incredible untapped potential. Now, with the rise of generative AI and the adoption of tools like Qdrant’s vector database, Tripadvisor is unlocking its full potential to deliver intelligent, personalized, and high-impact travel experiences.
 
 ## Activating Billions of Data Assets
@@ -53,10 +62,6 @@ To support all of this, Tripadvisor needed a way to store and retrieve complex, 
 The team is using Qdrant to build a **user graph**, a multidimensional representation of how users engage with different aspects of a trip: hotels, attractions, food, travel styles, and more. Vector-based retrieval allows them to query this data flexibly and serve responses that feel genuinely personalized.
 
 And unlike traditional databases, Qdrant is built for **real-time, unstructured data**, making it ideal for powering conversational AI, search augmentation, and recommendation engines.
-
-*“Qdrant has been crucial for our transformation. When you're dealing with over a billion plus user-generated, multi-modal pieces of content from hundreds of millions of monthly active users across 21 countries, 11M businesses and all the complex user interactions that come with it, you need a way to bring it all together. Now, we can represent everything from hotel preferences to restaurant choices to user behavior in a unified way. And we’re seeing real business results. Users engaging with our AI-powered features like trip planning are showing 2-3x more revenue.”*
-
-[*Rahul Todkar*](https://www.linkedin.com/in/rahultodkar) *\- Head of Data and AI*
 
 ## What’s Next
 

--- a/qdrant-landing/content/blog/case-study-tripadvisor.md
+++ b/qdrant-landing/content/blog/case-study-tripadvisor.md
@@ -25,6 +25,7 @@ partition: case-studies
 {{< quote
   text="Qdrant has been crucial for our transformation. When you're dealing with over a billion plus user-generated, multi-modal pieces of content from hundreds of millions of monthly active users across 21 countries, 11M businesses and all the complex user interactions that come with it, you need a way to bring it all together. Now, we can represent everything from hotel preferences to restaurant choices to user behavior in a unified way. And we’re seeing real business results. Users engaging with our AI-powered features like trip planning are showing 2-3x more revenue."
   name="Rahul Todkar"
+  name_url="https://www.linkedin.com/in/rahultodkar"
   role="Head of Data and AI"
   company="Tripadvisor"
   avatar="/img/customers/rahul-todkar.svg"

--- a/qdrant-landing/content/blog/case-study-tripadvisor.md
+++ b/qdrant-landing/content/blog/case-study-tripadvisor.md
@@ -23,7 +23,7 @@ partition: case-studies
 ![How Tripadvisor Drives 2–3x More Revenue with Qdrant-Powered AI](/blog/case-study-tripadvisor/case-study-tripadvisor-summary-dark.jpg)
 
 {{< quote
-  text="Qdrant has been crucial for our transformation. … Now, we can represent everything from hotel preferences to restaurant choices to user behavior in a unified way. And we’re seeing real business results. Users engaging with our AI-powered features like trip planning are showing 2-3x more revenue."
+  text="Qdrant has been crucial for our transformation. When you're dealing with over a billion plus user-generated, multi-modal pieces of content from hundreds of millions of monthly active users across 21 countries, 11M businesses and all the complex user interactions that come with it, you need a way to bring it all together. Now, we can represent everything from hotel preferences to restaurant choices to user behavior in a unified way. And we’re seeing real business results. Users engaging with our AI-powered features like trip planning are showing 2-3x more revenue."
   name="Rahul Todkar"
   role="Head of Data and AI"
   company="Tripadvisor"

--- a/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
@@ -7,6 +7,7 @@
 @import 'partials/pagination';
 @import 'partials/newsletter';
 @import 'partials/qdrant-post';
+@import 'partials/customer-quote';
 @import 'partials/qdrant-articles-hero';
 @import 'partials/qdrant-articles-posts';
 @import 'partials/carousel';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
@@ -32,6 +32,7 @@
 @import 'partials/pagination';
 @import 'partials/newsletter';
 @import 'partials/qdrant-post';
+@import 'partials/customer-quote';
 @import 'partials/carousel';
 @import 'partials/leadership';
 @import 'partials/open-roles';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
@@ -1,0 +1,110 @@
+@use '../helpers/functions' as *;
+
+// Descendants are nested (rather than written with `&__`) so each rule carries
+// two classes of specificity. The article stylesheet styles bare elements via
+// `.qdrant-post__content blockquote / p / figcaption`, which would otherwise
+// win over a single-class selector and re-apply its own card and margins.
+.customer-quote {
+  margin: $spacer * 3 0;
+  padding: pxToRem(32) pxToRem(40);
+  border-radius: $spacer * 0.5;
+  background: linear-gradient(180deg, $neutral-20 0%, #0e1424 100%);
+
+  .customer-quote__quote {
+    margin: 0;
+    padding: 0;
+    background: none;
+    border-radius: 0;
+  }
+
+  .customer-quote__text {
+    margin-bottom: pxToRem(24);
+    font-size: pxToRem(20);
+    line-height: pxToRem(30);
+    text-align: left;
+    color: $neutral-98;
+
+    a {
+      color: $neutral-98;
+      text-decoration: underline;
+    }
+  }
+
+  .customer-quote__attribution {
+    display: flex;
+    align-items: center;
+    gap: $spacer;
+    text-align: left;
+  }
+
+  .customer-quote__avatar {
+    flex-shrink: 0;
+    width: pxToRem(48);
+    height: pxToRem(48);
+    margin: 0;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .customer-quote__meta {
+    min-width: 0;
+    text-align: left;
+  }
+
+  // text-align is set on each <p> rather than inherited from __meta: the
+  // article stylesheet centers figcaption paragraphs directly, so inheritance
+  // never reaches them.
+  .customer-quote__name {
+    margin: 0;
+    font-size: pxToRem(16);
+    line-height: pxToRem(24);
+    text-align: left;
+    color: $neutral-94;
+  }
+
+  .customer-quote__role {
+    margin: 0;
+    font-size: pxToRem(14);
+    line-height: pxToRem(21);
+    text-align: left;
+    color: $neutral-60;
+  }
+
+  .customer-quote__logo {
+    flex-shrink: 0;
+    margin: 0 0 0 auto;
+    max-width: pxToRem(120);
+    max-height: pxToRem(32);
+    // Company logos are authored for light backgrounds; this card is dark.
+    filter: brightness(0) invert(1);
+    opacity: 0.75;
+  }
+
+  // Lead quote: sits directly under the hero, before the article body.
+  &.customer-quote_featured {
+    margin-top: 0;
+
+    .customer-quote__text {
+      font-size: pxToRem(24);
+      line-height: pxToRem(36);
+    }
+  }
+
+  @include media-breakpoint-down(md) {
+    padding: pxToRem(24);
+
+    .customer-quote__text {
+      font-size: pxToRem(18);
+      line-height: pxToRem(28);
+    }
+
+    .customer-quote__logo {
+      display: none;
+    }
+
+    &.customer-quote_featured .customer-quote__text {
+      font-size: pxToRem(20);
+      line-height: pxToRem(30);
+    }
+  }
+}

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
@@ -15,18 +15,20 @@
     padding: 0;
     background: none;
     border-radius: 0;
-  }
 
-  .customer-quote__text {
-    margin-bottom: pxToRem(24);
-    font-size: pxToRem(20);
-    line-height: pxToRem(30);
-    text-align: left;
-    color: $neutral-98;
-
-    a {
+    // Nested one level deeper than the other rules so this beats the article
+    // stylesheet's `blockquote p:last-child { margin-bottom: 0 }`.
+    .customer-quote__text {
+      margin-bottom: 1.5rem;
+      font-size: 1.125rem;
+      line-height: 1.65rem;
+      text-align: left;
       color: $neutral-98;
-      text-decoration: underline;
+
+      a {
+        color: $neutral-98;
+        text-decoration: underline;
+      }
     }
   }
 
@@ -102,11 +104,6 @@
 
   @include media-breakpoint-down(md) {
     padding: pxToRem(24);
-
-    .customer-quote__text {
-      font-size: pxToRem(18);
-      line-height: pxToRem(28);
-    }
 
     .customer-quote__logo {
       display: none;

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
@@ -60,6 +60,16 @@
     line-height: pxToRem(24);
     text-align: left;
     color: $neutral-94;
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+      text-decoration-color: $neutral-50;
+
+      &:hover {
+        text-decoration-color: $neutral-94;
+      }
+    }
   }
 
   .customer-quote__role {

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
@@ -98,11 +98,6 @@
   // Lead quote: sits directly under the hero, before the article body.
   &.customer-quote_featured {
     margin-top: 0;
-
-    .customer-quote__text {
-      font-size: pxToRem(24);
-      line-height: pxToRem(36);
-    }
   }
 
   @include media-breakpoint-down(md) {
@@ -120,11 +115,6 @@
     // No logo at this width, so the company name has to carry it again.
     &.customer-quote_has-logo .customer-quote__company {
       display: inline;
-    }
-
-    &.customer-quote_featured .customer-quote__text {
-      font-size: pxToRem(20);
-      line-height: pxToRem(30);
     }
   }
 }

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_customer-quote.scss
@@ -80,6 +80,11 @@
     color: $neutral-60;
   }
 
+  // The logo already says which company this is.
+  &.customer-quote_has-logo .customer-quote__company {
+    display: none;
+  }
+
   .customer-quote__logo {
     flex-shrink: 0;
     margin: 0 0 0 auto;
@@ -110,6 +115,11 @@
 
     .customer-quote__logo {
       display: none;
+    }
+
+    // No logo at this width, so the company name has to carry it again.
+    &.customer-quote_has-logo .customer-quote__company {
+      display: inline;
     }
 
     &.customer-quote_featured .customer-quote__text {

--- a/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/quote.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/quote.html
@@ -1,0 +1,69 @@
+{{- /*
+  Customer quote block for case studies and blog posts.
+
+  Usage:
+    {{< quote
+        text="Qdrant has been crucial for our transformation."
+        name="Rahul Todkar"
+        role="Head of Data and AI"
+        company="Tripadvisor"
+        avatar="/img/customers/rahul-todkar.svg"
+        logo="/img/brands/tripadvisor.svg"
+        featured="true" >}}
+
+  Only `text` and `name` carry the quote; every other param degrades
+  gracefully, so a quote with no avatar or logo still renders correctly.
+  `featured="true"` is the lead quote that sits above the article body.
+
+  `text` is rendered as markdown, so inline links work:
+    text="See our [docs](https://qdrant.tech/documentation/) for details."
+
+  Use `&quot;` for a literal double quote inside `text`.
+*/ -}}
+
+{{- $page := .Page -}}
+{{- $text := .Get "text" | default "" -}}
+{{- $name := .Get "name" -}}
+{{- $role := .Get "role" -}}
+{{- $company := .Get "company" -}}
+{{- $avatar := .Get "avatar" -}}
+{{- $logo := .Get "logo" -}}
+{{- $featured := eq (.Get "featured" | default "false") "true" -}}
+
+{{- if not $text -}}
+  {{- errorf "quote shortcode in %q needs a `text` param" $page.Path -}}
+{{- end -}}
+
+<figure class="customer-quote{{ if $featured }} customer-quote_featured{{ end }}">
+  <blockquote class="customer-quote__quote">
+    <p class="customer-quote__text">{{ $page.RenderString (trim $text "\n ") }}</p>
+  </blockquote>
+
+  {{- if $name }}
+  <figcaption class="customer-quote__attribution">
+    {{- with $avatar }}
+    <img
+      class="customer-quote__avatar"
+      src="{{ . }}"
+      alt="{{ $name }}"
+      width="48"
+      height="48"
+      loading="lazy"
+    />
+    {{- end }}
+    <div class="customer-quote__meta">
+      <p class="customer-quote__name">{{ $name }}</p>
+      {{- if or $role $company }}
+      <p class="customer-quote__role">
+        {{- $role -}}
+        {{- if and $role $company }}, {{ end -}}
+        {{- $company -}}
+      </p>
+      {{- end }}
+    </div>
+    {{- with $logo }}
+    <img class="customer-quote__logo" src="{{ . }}" alt="" loading="lazy" />
+    {{- end }}
+  </figcaption>
+  {{- end }}
+</figure>

--- a/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/quote.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/quote.html
@@ -5,6 +5,7 @@
     {{< quote
         text="Qdrant has been crucial for our transformation."
         name="Rahul Todkar"
+        name_url="https://www.linkedin.com/in/rahultodkar"
         role="Head of Data and AI"
         company="Tripadvisor"
         avatar="/img/customers/rahul-todkar.svg"
@@ -24,6 +25,7 @@
 {{- $page := .Page -}}
 {{- $text := .Get "text" | default "" -}}
 {{- $name := .Get "name" -}}
+{{- $nameURL := .Get "name_url" -}}
 {{- $role := .Get "role" -}}
 {{- $company := .Get "company" -}}
 {{- $avatar := .Get "avatar" -}}
@@ -52,7 +54,9 @@
     />
     {{- end }}
     <div class="customer-quote__meta">
-      <p class="customer-quote__name">{{ $name }}</p>
+      <p class="customer-quote__name">
+        {{- with $nameURL }}<a href="{{ . }}">{{ $name }}</a>{{ else }}{{ $name }}{{ end -}}
+      </p>
       {{- if or $role $company }}
       <p class="customer-quote__role">
         {{- $role -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/quote.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/quote.html
@@ -36,7 +36,12 @@
   {{- errorf "quote shortcode in %q needs a `text` param" $page.Path -}}
 {{- end -}}
 
-<figure class="customer-quote{{ if $featured }} customer-quote_featured{{ end }}">
+{{- /* The company name is redundant next to the logo, so it is hidden when
+       one is shown. It is marked up rather than dropped because the logo is
+       hidden on narrow screens, where the name has to come back. */ -}}
+<figure class="customer-quote
+  {{- if $featured }} customer-quote_featured{{ end }}
+  {{- if $logo }} customer-quote_has-logo{{ end }}">
   <blockquote class="customer-quote__quote">
     <p class="customer-quote__text">{{ $page.RenderString (trim $text "\n ") }}</p>
   </blockquote>
@@ -60,8 +65,9 @@
       {{- if or $role $company }}
       <p class="customer-quote__role">
         {{- $role -}}
-        {{- if and $role $company }}, {{ end -}}
-        {{- $company -}}
+        {{- with $company -}}
+          <span class="customer-quote__company">{{ if $role }}, {{ end }}{{ . }}</span>
+        {{- end -}}
       </p>
       {{- end }}
     </div>


### PR DESCRIPTION
<!-- drag quote-before-after.png in here -->

I'm suggesting a small improvement in our testimonials page to highlight the quote from the customer possibly with their photo and standardizing the same component. Imo, that's the most important part in a testimonial. Most people skip architecture diagram but quotation catches their eye. 

This PR adds a quote component and applies it to three case studies as a starting point:

- **Bayer** — all twelve quotes converted
- **Tripadvisor** — the "2-3x revenue" quote moved up from the bottom of the page
- **Sprinklr** — quote lifted out of the paragraph it was buried in

Every word is already published, so nothing here needs new customer sign-off. I'll apply this component to all testimonials in the next PR if you agree.

<img width="760" height="930" alt="2-tripadvisor" src="https://github.com/user-attachments/assets/fb9f3254-0443-4a68-9888-d28bc988a2b7" />
