### PR TITLE
Order pages with subpages in a section by weight

### DIFF
--- a/qdrant-landing/content/documentation/search/text-search/_index.md
+++ b/qdrant-landing/content/documentation/search/text-search/_index.md
@@ -2,7 +2,7 @@
 title: Text Search
 short_description: "Combine semantic vector search with lexical text features in Qdrant, including BM25 and full-text payload filters."
 description: "Run text search in Qdrant by mixing semantic vector retrieval with BM25 lexical search and full-text payload filters for robust hybrid search experiences."
-weight: 25
+weight: 40
 cta: "Test full-text and vector search together in Qdrant Cloud."
 aliases:
   - ../text-search

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/documentation/sidebar-menu.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/documentation/sidebar-menu.html
@@ -137,26 +137,25 @@
 
                   <nav>
                     <ul class="docs-menu__links-submenu">
-                      {{ range .RegularPages }}
-                        {{ if (eq .Params.type "external-link") }}
-                          <li class="docs-menu__links-submenu-item">
-                            <a href="{{ .Params.external_url }}" target="_blank">
-                              {{ .Title }}
-                              {{ partial "svg" "external-link.svg" }}
-                            </a>
-                          </li>
-                        {{ else if not .Params.hideInSidebar }}
-                          <li
-                            class="docs-menu__links-submenu-item{{ if eq .File.UniqueID $currentNode.File.UniqueID }}
-                              active
-                            {{ end }}"
-                          >
-                            <a href="{{ .Permalink }}">{{ .Title }}</a>
-                          </li>
-                        {{ end }}
-                      {{ end }}
-                      {{ range .Sections }}
-                        {{ if not .Params.hideInSidebar }}
+                      {{ range .Pages }}
+                        {{ if .IsPage }}
+                          {{ if (eq .Params.type "external-link") }}
+                            <li class="docs-menu__links-submenu-item">
+                              <a href="{{ .Params.external_url }}" target="_blank">
+                                {{ .Title }}
+                                {{ partial "svg" "external-link.svg" }}
+                              </a>
+                            </li>
+                          {{ else if not .Params.hideInSidebar }}
+                            <li
+                              class="docs-menu__links-submenu-item{{ if eq .File.UniqueID $currentNode.File.UniqueID }}
+                                active
+                              {{ end }}"
+                            >
+                              <a href="{{ .Permalink }}">{{ .Title }}</a>
+                            </li>
+                          {{ end }}
+                        {{ else if and .IsSection (not .Params.hideInSidebar) }}
                           {{ $subIsActive := false }}
                           {{ if eq .File.UniqueID $currentNode.File.UniqueID }}
                             {{ $subIsActive = true }}


### PR DESCRIPTION
Follow-up to https://github.com/qdrant/landing_page/pull/2454

In the original implementation to increase the navigation depth, pages with subpages at level 3 were always rendered last in a section, ignoring the weight. This PR fixes that, by iterating over `.Pages`, instead of two separate loops over `.RegularPages` and `.Sections`.

A side effect of this change is that the Text Search page moved. I've updated the weight to keep it in its original position.