### PR TITLE
Fix anchor scroll hiding headings under sticky docs nav

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/css/core.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/core.scss
@@ -10,6 +10,7 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 100px;
 
   &::-webkit-scrollbar {
     width: 8px;


### PR DESCRIPTION
When navigating directly to a URL with a hash anchor (e.g. `/documentation/search/explore/#discovery-api`), the browser's native scroll places the heading at y=0 — hidden behind the 80px sticky docs header.

The site already uses a JS-based offset (`DOCS_HEADER_OFFSET = 100`) to re-scroll on DOMContentLoaded and on in-page anchor clicks.

This PR adds `scroll-padding-top: 100px` to `html` in `core.scss`, matching the existing `DOCS_HEADER_OFFSET` value. `scroll-padding-top` is the CSS-native mechanism the browser applies to all anchor scrolls automatically. It has no effect on `window.scrollTo()` calls, so the JS handler continues to work independently with no double-offsetting.

## Validation

Compare:
https://qdrant.tech/documentation/search/explore/#discovery-api
vs:
https://deploy-preview-2647--condescending-goldwasser-91acf0.netlify.app/documentation/search/explore/#discovery-api