### PR TITLE
docs: Remove references to the deprecated search API

### DIFF
--- a/qdrant-landing/content/articles/binary-quantization.md
+++ b/qdrant-landing/content/articles/binary-quantization.md
@@ -158,9 +158,9 @@ client.update_collection(
 When setting search parameters, we specify that we want to use `oversampling` and `rescore`. Here is an example snippet:
 
 ```python
-client.search(
+client.query_points(
     collection_name="{collection_name}",
-    query_vector=[0.2, 0.1, 0.9, 0.7, ...],
+    query=[0.2, 0.1, 0.9, 0.7, ...],
     search_params=models.SearchParams(
         quantization=models.QuantizationSearchParams(
             ignore=False,

--- a/qdrant-landing/content/articles/multitenancy.md
+++ b/qdrant-landing/content/articles/multitenancy.md
@@ -127,7 +127,7 @@ client.upsert(
 The access control setup is completed as you specify the criteria for data retrieval. When searching for vectors, you need to use a `query_filter` along with `group_id` to filter vectors for each user. 
 
 ```python
-client.search(
+client.query_points(
     collection_name="{tenant_data}",
     query_filter=models.Filter(
         must=[
@@ -139,7 +139,7 @@ client.search(
             ),
         ]
     ),
-    query_vector=[0.1, 0.1, 0.9],
+    query=[0.1, 0.1, 0.9],
     limit=10,
 )
 ```
@@ -188,7 +188,6 @@ Qdrant is ready to support a massive-scale architecture for your machine learnin
 To spin up a free instance of Qdrant, sign up for [Qdrant Cloud](https://qdrant.to/cloud) - no strings attached.
 
 Get support or share ideas in our [Discord](https://qdrant.to/discord) community. This is where we talk about vector search theory, publish examples and demos and discuss vector database setups.
-
 
 
 

--- a/qdrant-landing/content/articles/neural-search-tutorial.md
+++ b/qdrant-landing/content/articles/neural-search-tutorial.md
@@ -259,15 +259,15 @@ The search function looks as simple as possible:
         vector = self.model.encode(text).tolist()
 
         # Use `vector` for search for closest vectors in the collection
-        search_result = self.qdrant_client.search(
+        search_result = self.qdrant_client.query_points(
             collection_name=self.collection_name,
-            query_vector=vector,
+            query=vector,
             query_filter=None,  # We don't want any filters for now
-            top=5  # 5 the most closest results is enough
+            limit=5  # 5 the most closest results is enough
         )
         # `search_result` contains found vector ids with similarity scores along with the stored payload
         # In this function we are interested in payload only
-        payloads = [hit.payload for hit in search_result]
+        payloads = [hit.payload for hit in search_result.points]
         return payloads
 ```
 
@@ -291,11 +291,11 @@ from qdrant_client.models import Filter
         }]
     })
 
-    search_result = self.qdrant_client.search(
+    search_result = self.qdrant_client.query_points(
         collection_name=self.collection_name,
-        query_vector=vector,
+        query=vector,
         query_filter=city_filter,
-        top=5
+        limit=5
     )
     ...
 

--- a/qdrant-landing/content/articles/qa-with-cohere-and-qdrant.md
+++ b/qdrant-landing/content/articles/qa-with-cohere-and-qdrant.md
@@ -190,13 +190,13 @@ was present in the first *k* results.
 k_max = 10
 answer_positions = []
 for embedding, pubid in tqdm(zip(question_response.embeddings, ids)):
-    response = qdrant_client.search(
+    response = qdrant_client.query_points(
         collection_name="pubmed_qa",
-        query_vector=embedding,
+        query=embedding,
         limit=k_max,
     )
 
-    answer_ids = [record.id for record in response]
+    answer_ids = [record.id for record in response.points]
     if pubid in answer_ids:
         answer_positions.append(answer_ids.index(pubid))
     else:

--- a/qdrant-landing/content/articles/sparse-vectors.md
+++ b/qdrant-landing/content/articles/sparse-vectors.md
@@ -359,22 +359,20 @@ After setting up the collection and inserting sparse vectors, the next critical 
 
 ```python
 # Searching for similar documents
-result = client.search(
+result = client.query_points(
     collection_name=COLLECTION_NAME,
-    query_vector=models.NamedSparseVector(
-        name="text",
-        vector=models.SparseVector(
-            indices=query_indices,
-            values=query_values,
-        ),
+    query=models.SparseVector(
+        indices=query_indices,
+        values=query_values,
     ),
+    using="text",
     with_vectors=True,
-)
+).points
 
 result
 ```
 
-In the above code, we execute a search against our collection using the prepared sparse vector query. The `client.search` method takes the collection name and the query vector as inputs. The query vector is constructed using the `models.NamedSparseVector`, which includes the indices and values derived from the query text. This is a crucial step in efficiently retrieving relevant documents. 
+The `client.query_points` method takes the collection name and the sparse query vector as inputs. The `using` parameter selects the named vector.
 
 ```python
 ScoredPoint(

--- a/qdrant-landing/content/articles/storing-multiple-vectors-per-object-in-qdrant.md
+++ b/qdrant-landing/content/articles/storing-multiple-vectors-per-object-in-qdrant.md
@@ -180,14 +180,10 @@ The created vectors might be easily put into Qdrant. For the sake of simplicity,
 If you decided to describe each object with several [neural embeddings](https://qdrant.tech/articles/neural-search-tutorial/), then at each search operation you need to provide the vector name along with the [vector embedding](https://qdrant.tech/articles/what-are-embeddings/), so the engine knows which one to use. The interface of the search operation is pretty straightforward and requires an instance of NamedVector.
 
 ```python
-from qdrant_client.http.models import NamedVector
-
-text_results = client.search(
+text_results = client.query_points(
    collection_name="ms-coco-2017",
-   query_vector=NamedVector(
-       name="text",
-       vector=row["text_vector"],
-   ),
+   query=row["text_vector"],
+   using="text",
    limit=5,
    with_vectors=False,
    with_payload=True,

--- a/qdrant-landing/content/articles/vector-search-resource-optimization.md
+++ b/qdrant-landing/content/articles/vector-search-resource-optimization.md
@@ -342,9 +342,9 @@ The filterable vector index is Qdrant's solves pre and post-filtering problems b
 **Example:**
 
 ```python
-results = client.search(
+results = client.query_points(
     collection_name="my_collection",
-    query_vector=[0.1, 0.2, 0.3],
+    query=[0.1, 0.2, 0.3],
     query_filter=models.Filter(must=[
         models.FieldCondition(
             key="category",
@@ -456,7 +456,7 @@ The rescoring process maps the quantized vectors to their corresponding original
 ```python
 client.query_points(
     collection_name="my_collection",
-    query_vector=[0.22, -0.01, -0.98, 0.37],
+    query=[0.22, -0.01, -0.98, 0.37],
     search_params=models.SearchParams(
         quantization=models.QuantizationSearchParams(
             rescore=True,   # Enables rescoring with original vectors

--- a/qdrant-landing/content/articles/what-is-quantization.md
+++ b/qdrant-landing/content/articles/what-is-quantization.md
@@ -255,7 +255,7 @@ POST /collections/{collection_name}/points/search
 ```python
 client.query_points(
     collection_name="my_collection",
-    query_vector=[0.22, -0.01, -0.98, 0.37],  # Your query vector
+    query=[0.22, -0.01, -0.98, 0.37],  # Your query vector
     search_params=models.SearchParams(
         quantization=models.QuantizationSearchParams(
             rescore=True  # Enables rescoring with original vectors
@@ -347,7 +347,7 @@ POST /collections/{collection_name}/points/search
 ```python
 client.query_points(
     collection_name="my_collection",
-    query_vector=[0.22, -0.01, -0.98, 0.37],
+    query=[0.22, -0.01, -0.98, 0.37],
     search_params=models.SearchParams(
         quantization=models.QuantizationSearchParams(
             rescore=True,   # Enables rescoring with original vectors

--- a/qdrant-landing/content/blog/legal-tech-builders-guide.md
+++ b/qdrant-landing/content/blog/legal-tech-builders-guide.md
@@ -95,13 +95,16 @@ Utilize [ColBERT](https://qdrant.tech/articles/late-interaction-models/) for hig
 
 ```python
 # Step 1: Retrieve hybrid results using dense and sparse queries
-hybrid_results = client.search(
+hybrid_results = client.query_points(
     collection_name="legal-hybrid-search",
-    query_vector=dense_vector,
-    query_sparse_vector=sparse_vector,
+    prefetch=[
+        models.Prefetch(query=dense_vector, using="dense", limit=50),
+        models.Prefetch(query=sparse_vector, using="sparse", limit=50),
+    ],
+    query=models.FusionQuery(fusion=models.Fusion.RRF),
     limit=20,
     with_payload=True
-)
+).points
 
 # Step 2: Tokenize the query using ColBERT
 colbert_query_tokens = colbert_model.query_tokenize(query_text)
@@ -111,7 +114,7 @@ reranked = sorted(
     hybrid_results,
     key=lambda doc: colbert_model.score(
         colbert_query_tokens,
-        colbert_model.doc_tokenize(doc["payload"]["document"])
+        colbert_model.doc_tokenize(doc.payload["document"])
     ),
     reverse=True
 )

--- a/qdrant-landing/content/blog/neural-search-tutorial.md
+++ b/qdrant-landing/content/blog/neural-search-tutorial.md
@@ -201,16 +201,16 @@ class NeuralSearcher:
         vector = self.model.encode(text).tolist()
 
         # Use `vector` for search for closest vectors in the collection
-        search_result = self.qdrant_client.search(
+        search_result = self.qdrant_client.query_points(
             collection_name=self.collection_name,
-            query_vector=vector,
+            query=vector,
             query_filter=None,  # We don't want any filters for now
-            top=5  # 5 the most closest results is enough
+            limit=5  # 5 the most closest results is enough
         )
 
         # `search_result` contains found vector ids with similarity scores along with the stored payload
         # In this function we are interested in payload only
-        payloads = [hit.payload for hit in search_result]
+        payloads = [hit.payload for hit in search_result.points]
         return payloads
 ```
 

--- a/qdrant-landing/content/documentation/embeddings/mistral.md
+++ b/qdrant-landing/content/documentation/embeddings/mistral.md
@@ -80,9 +80,9 @@ client.upsert(collection_name, points)
 Once the documents are indexed, you can search for the most relevant documents using the same model with the `retrieval_query` task type:
 
 ```python
-client.search(
+client.query_points(
     collection_name=collection_name,
-    query_vector=mistral_client.embeddings(
+    query=mistral_client.embeddings(
         model="mistral-embed", input=["What is the best to use for vector search scaling?"]
     ).data[0].embedding,
 )

--- a/qdrant-landing/content/documentation/embeddings/nomic.md
+++ b/qdrant-landing/content/documentation/embeddings/nomic.md
@@ -72,9 +72,9 @@ output = embed.text(
     task_type="search_query",
 )
 
-client.search(
+client.query_points(
     collection_name="my-collection",
-    query_vector=output["embeddings"][0],
+    query=output["embeddings"][0],
 )
 ```
 
@@ -83,9 +83,9 @@ client.search(
 ```python
 output = next(model.embed("What is the best vector database?"))
 
-client.search(
+client.query_points(
     collection_name="my-collection",
-    query_vector=output.tolist(),
+    query=output.tolist(),
 )
 ```
 

--- a/qdrant-landing/content/documentation/embeddings/nvidia.md
+++ b/qdrant-landing/content/documentation/embeddings/nvidia.md
@@ -162,9 +162,9 @@ response_body = nvidia_session.post(
     NVIDIA_BASE_URL, headers=headers, json=payload
 ).json()
 
-client.search(
+client.query_points(
     collection_name=collection_name,
-    query_vector=response_body["data"][0]["embedding"],
+    query=response_body["data"][0]["embedding"],
 )
 ```
 
@@ -183,7 +183,7 @@ response = await fetch(NVIDIA_BASE_URL, {
 
 response_body = await response.json()
 
-await client.search(COLLECTION_NAME, {
-    vector: response_body.data[0].embedding,
+await client.query(COLLECTION_NAME, {
+    query: response_body.data[0].embedding,
 });
 ```

--- a/qdrant-landing/content/documentation/embeddings/openai.md
+++ b/qdrant-landing/content/documentation/embeddings/openai.md
@@ -80,9 +80,9 @@ client.upsert(collection_name, points)
 Once the documents are indexed, you can search for the most relevant documents using the same model.
 
 ```python
-client.search(
+client.query_points(
     collection_name=collection_name,
-    query_vector=openai_client.embeddings.create(
+    query=openai_client.embeddings.create(
         input=["What is the best to use for vector search scaling?"],
         model=embedding_model,
     )

--- a/qdrant-landing/content/documentation/embeddings/premai.md
+++ b/qdrant-landing/content/documentation/embeddings/premai.md
@@ -205,13 +205,13 @@ query_embedding = get_embeddings(
     documents=query
 )
 
-qdrant_client.search(collection_name=COLLECTION_NAME, query_vector=query_embedding[0])
+qdrant_client.query_points(collection_name=COLLECTION_NAME, query=query_embedding[0])
 ```
 ```typescript
 const query = "what is the extension of javascript document"
 const query_embedding_response = await getEmbeddings(PROJECT_ID, EMBEDDING_MODEL, query)
 
-await qdrantClient.search(COLLECTION_NAME, {
-    vector: query_embedding_response.data[0].embedding
+await qdrantClient.query(COLLECTION_NAME, {
+    query: query_embedding_response.data[0].embedding
 });
 ```

--- a/qdrant-landing/content/documentation/embeddings/snowflake.md
+++ b/qdrant-landing/content/documentation/embeddings/snowflake.md
@@ -116,9 +116,9 @@ Once the documents are added, you can search for the most relevant documents.
 ```python
 query_embedding = next(embedding_model.query_embed("What is the best to use for vector search scaling?"))
 
-qclient.search(
+qclient.query_points(
     collection_name=COLLECTION_NAME,
-    query_vector=query_embedding,
+    query=query_embedding,
 )
 ```
 
@@ -128,7 +128,7 @@ const query_embedding = await extractor("What is the best to use for vector sear
     pooling: 'cls'
 });
 
-await client.search(COLLECTION_NAME, {
-    vector: query_embedding.tolist()[0],
+await client.query(COLLECTION_NAME, {
+    query: query_embedding.tolist()[0],
 });
 ```

--- a/qdrant-landing/content/documentation/embeddings/upstage.md
+++ b/qdrant-landing/content/documentation/embeddings/upstage.md
@@ -161,9 +161,9 @@ response_body = upstage_session.post(
     UPSTAGE_BASE_URL, headers=headers, json=body
 ).json()
 
-client.search(
+client.query_points(
     collection_name=collection_name,
-    query_vector=response_body["data"][0]["embedding"],
+    query=response_body["data"][0]["embedding"],
 )
 ```
 
@@ -181,7 +181,7 @@ response = await fetch(UPSTAGE_BASE_URL, {
 
 response_body = await response.json()
 
-await client.search(COLLECTION_NAME, {
-    vector: response_body.data[0].embedding,
+await client.query(COLLECTION_NAME, {
+    query: response_body.data[0].embedding,
 });
 ```

--- a/qdrant-landing/content/documentation/embeddings/voyage.md
+++ b/qdrant-landing/content/documentation/embeddings/voyage.md
@@ -141,9 +141,9 @@ response = vclient.embed(
     input_type="query",
 )
 
-qclient.search(
+qclient.query_points(
     collection_name=COLLECTION_NAME,
-    query_vector=response.embeddings[0],
+    query=response.embeddings[0],
 )
 ```
 
@@ -162,7 +162,7 @@ response = await fetch(VOYAGEAI_BASE_URL, {
 
 response_body = await response.json();
 
-await client.search(COLLECTION_NAME, {
-    vector: response_body.data[0].embedding,
+await client.query(COLLECTION_NAME, {
+    query: response_body.data[0].embedding,
 });
 ```

--- a/qdrant-landing/content/documentation/tutorials-build-essentials/agentic-rag-crewai-zoom.md
+++ b/qdrant-landing/content/documentation/tutorials-build-essentials/agentic-rag-crewai-zoom.md
@@ -219,11 +219,11 @@ class SearchMeetingsTool(BaseTool):
         )
         query_vector = response.data[0].embedding
         
-        return self.qdrant_client.search(
+        return self.qdrant_client.query_points(
             collection_name='zoom_recordings',
-            query_vector=query_vector,
+            query=query_vector,
             limit=10
-        )
+        ).points
 ```
 
 The search results then feed into our analysis tool, which uses Claude to provide deeper insights:


### PR DESCRIPTION
The search API was deprecated in favour of the query API.