### PR TITLE
Add encryption at rest docs for Managed Cloud

### DIFF
--- a/qdrant-landing/content/documentation/cloud-premium.md
+++ b/qdrant-landing/content/documentation/cloud-premium.md
@@ -17,7 +17,7 @@ Qdrant Cloud offers an optional premium tier for customers who require additiona
 * **99.9% Uptime SLA**: We guarantee 99.9% uptime for your Qdrant Cloud clusters (compared to 99.5% in standard).
 * **Single Sign-On (SSO)**: Premium customers can use their existing SSO provider to manage access to Qdrant Cloud.
 * **VPC Private Links**: Premium customers can connect their Qdrant Cloud clusters to their VPCs using private links.
-* **Storage encryption with shared keys**: Premium customers can encrypt their data at rest using their own keys.
+* **Storage encryption with shared keys**: Premium customers can [encrypt their data at rest using their own keys](/documentation/cloud/encryption/).
 * **Topology Aware Multi-AZ Setup**: Premium customers can deploy their clusters across multiple availability zones for higher availability and resilience. This guarantees a **99.95% uptime SLA** for Multi-AZ clusters. Multi-AZ is independent of replication factor; see [Multi-AZ Deployments](/documentation/scaling/resilience/#multi-az-deployments) for the distinction.
 
 Please refer to the [Qdrant Cloud SLA](https://qdrant.to/sla/) for a detailed definition on uptime and support SLAs.

--- a/qdrant-landing/content/documentation/cloud-security.md
+++ b/qdrant-landing/content/documentation/cloud-security.md
@@ -20,7 +20,7 @@ Qdrant is committed to maintaining high standards of security and compliance. We
 
 All Qdrant clusters running in Qdrant Managed Cloud are isolated from each other in hardened, unprivileged containers. Each cluster is sealed off with strict network policies, ensuring that no other customer can access your data, and outbound network access is restricted to prevent data exfiltration.  Paid clusters are running on their own dedicated resources to ensure stable performance and further security.
 
-All storage volumes are encrypted at rest. [Premium customers](/documentation/cloud-premium/) can also bring their own encryption keys for storage volumes. 
+All storage volumes are encrypted at rest. [Premium customers](/documentation/cloud-premium/) can also [bring their own encryption keys for storage volumes](/documentation/cloud/encryption/).
 
 Data in transit is protected with Transport-Layer-Security (TLS). It is possible to restrict the [IP ranges](/documentation/cloud/configure-cluster/#client-ip-restrictions) that are allowed to access a cluster.
 

--- a/qdrant-landing/content/documentation/cloud/encryption.md
+++ b/qdrant-landing/content/documentation/cloud/encryption.md
@@ -1,0 +1,69 @@
+---
+title: Encryption at Rest
+short_description: "Use your own AWS KMS, GCP Cloud KMS, or Azure Key Vault key to encrypt Qdrant Managed Cloud storage volumes as a Premium customer."
+description: "Enable customer-managed encryption keys (BYOK) for Qdrant Managed Cloud storage volumes on AWS, GCP, or Azure as a Premium customer by opening a support ticket."
+weight: 27
+---
+
+# Encryption at Rest
+
+Qdrant Managed Cloud encrypts all storage volumes at rest by default. [Premium customers](/documentation/cloud-premium/), can also use their own cloud key management service (KMS) key for additional control over their encryption. To enable this, complete the key setup described on this page and open a support ticket.
+
+## Prerequisites
+
+- A [Premium Managed Cloud](/documentation/cloud-premium/) subscription
+- An existing cluster in Qdrant Cloud (create one before requesting encryption)
+- Whether your cluster is empty or contains data (empty clusters are simpler to migrate; Qdrant Support will advise on the approach when you open your ticket)
+
+## Create Your Encryption Key
+
+Complete the steps for your cloud provider before continuing to the next section.
+
+### AWS
+
+1. In the AWS KMS console, create a new **Symmetric** key with key usage **Encrypt and Decrypt**. Create it in the same region as your Qdrant cluster, or use a multi-regional key if you need it across regions.
+2. In the **Define key usage permissions** step, add an external AWS account and enter `337975577518` (Qdrant's AWS account ID).
+3. Confirm that the resulting key policy grants `arn:aws:iam::337975577518:root` the following actions:
+   - `kms:Encrypt`, `kms:Decrypt`, `kms:ReEncrypt*`, `kms:GenerateDataKey*`, `kms:DescribeKey`
+   - `kms:CreateGrant`, `kms:ListGrants`, `kms:RevokeGrant` (with condition `kms:GrantIsForAWSResource: true`)
+4. Copy the Key ARN. You'll need it when you open your support ticket.
+
+> Scoping the key grant to a specific IAM role isn't currently supported. The grant must cover the full Qdrant account (`arn:aws:iam::337975577518:root`).
+
+### GCP
+
+1. In Cloud KMS, create a key ring in the same region as your Qdrant cluster.
+2. Create a key in the key ring with these settings:
+   - **Protection level**: Software
+   - **Purpose**: Symmetric encrypt/decrypt
+   - **Rotation period**: None
+3. Grant the role `roles/cloudkms.cryptoKeyEncrypterDecrypter` on that key to Qdrant's Compute Engine service agent: `service-936711710023@compute-system.iam.gserviceaccount.com`.
+4. Copy the Key ID. You'll need it when you open your support ticket.
+
+### Azure
+
+Azure setup requires Qdrant's Entra application ID, which Qdrant Support provides. [Contact support](#open-a-support-ticket) first to get the Application ID (client ID), then complete the following steps.
+
+1. Install Qdrant's multi-tenant Entra application into your Azure tenant using the Application ID provided by Qdrant Support. This creates a service principal in your tenant. You need one of the following roles: Global Administrator, Cloud Application Administrator, or Application Administrator.
+
+   ```bash
+   az ad sp create --id <application-id>
+   ```
+2. Create an Azure Key Vault in the same region as your Qdrant cluster with these settings enabled (requires the **Key Vault Contributor** role):
+   - **Purge protection**
+   - **Azure role-based access control (RBAC) authorization**
+3. Create an encryption key in the Key Vault (requires the **Key Vault Crypto Officer** role).
+4. Assign the **Key Vault Crypto Service Encryption User** role to Qdrant's service principal on the Key Vault.
+5. Copy the Key URL. You'll need it when you open your support ticket.
+
+## Open a Support Ticket
+
+With your key set up, open a support ticket via the [Qdrant Cloud Console](https://cloud.qdrant.io/) and include the following:
+
+- Your cluster ID
+- Your cloud provider (AWS, GCP, or Azure)
+- Whether the cluster is empty or contains data
+- Your key identifier: Key ARN (AWS), Key ID (GCP), or Key URL (Azure)
+
+Qdrant Support will configure encryption for your cluster.
+

--- a/qdrant-landing/content/documentation/cloud/encryption.md
+++ b/qdrant-landing/content/documentation/cloud/encryption.md
@@ -7,63 +7,52 @@ weight: 27
 
 # Encryption at Rest
 
-Qdrant Managed Cloud encrypts all storage volumes at rest by default. [Premium customers](/documentation/cloud-premium/), can also use their own cloud key management service (KMS) key for additional control over their encryption. To enable this, complete the key setup described on this page and open a support ticket.
+Qdrant Managed Cloud encrypts all storage volumes at rest by default. [Premium customers](/documentation/cloud-premium/) can also use their own cloud key management service (KMS) key for additional control over their encryption. Enabling this requires opening a support ticket. Qdrant Support provides the cloud-specific identifiers and detailed setup instructions, then configures your cluster once your key is in place.
 
 ## Prerequisites
 
 - A [Premium Managed Cloud](/documentation/cloud-premium/) subscription
 - An existing cluster in Qdrant Cloud (create one before requesting encryption)
-- Whether your cluster is empty or contains data (empty clusters are simpler to migrate; Qdrant Support will advise on the approach when you open your ticket)
+- Whether your cluster is empty or contains data (empty clusters are simpler to migrate; Qdrant Support will advise on the approach)
 
-## Create Your Encryption Key
+## Step 1: Open a Support Ticket
 
-Complete the steps for your cloud provider before continuing to the next section.
-
-### AWS
-
-1. In the AWS KMS console, create a new **Symmetric** key with key usage **Encrypt and Decrypt**. Create it in the same region as your Qdrant cluster, or use a multi-regional key if you need it across regions.
-2. In the **Define key usage permissions** step, add an external AWS account and enter `337975577518` (Qdrant's AWS account ID).
-3. Confirm that the resulting key policy grants `arn:aws:iam::337975577518:root` the following actions:
-   - `kms:Encrypt`, `kms:Decrypt`, `kms:ReEncrypt*`, `kms:GenerateDataKey*`, `kms:DescribeKey`
-   - `kms:CreateGrant`, `kms:ListGrants`, `kms:RevokeGrant` (with condition `kms:GrantIsForAWSResource: true`)
-4. Copy the Key ARN. You'll need it when you open your support ticket.
-
-> Scoping the key grant to a specific IAM role isn't currently supported. The grant must cover the full Qdrant account (`arn:aws:iam::337975577518:root`).
-
-### GCP
-
-1. In Cloud KMS, create a key ring in the same region as your Qdrant cluster.
-2. Create a key in the key ring with these settings:
-   - **Protection level**: Software
-   - **Purpose**: Symmetric encrypt/decrypt
-   - **Rotation period**: None
-3. Grant the role `roles/cloudkms.cryptoKeyEncrypterDecrypter` on that key to Qdrant's Compute Engine service agent: `service-936711710023@compute-system.iam.gserviceaccount.com`.
-4. Copy the Key ID. You'll need it when you open your support ticket.
-
-### Azure
-
-Azure setup requires Qdrant's Entra application ID, which Qdrant Support provides. [Contact support](#open-a-support-ticket) first to get the Application ID (client ID), then complete the following steps.
-
-1. Install Qdrant's multi-tenant Entra application into your Azure tenant using the Application ID provided by Qdrant Support. This creates a service principal in your tenant. You need one of the following roles: Global Administrator, Cloud Application Administrator, or Application Administrator.
-
-   ```bash
-   az ad sp create --id <application-id>
-   ```
-2. Create an Azure Key Vault in the same region as your Qdrant cluster with these settings enabled (requires the **Key Vault Contributor** role):
-   - **Purge protection**
-   - **Azure role-based access control (RBAC) authorization**
-3. Create an encryption key in the Key Vault (requires the **Key Vault Crypto Officer** role).
-4. Assign the **Key Vault Crypto Service Encryption User** role to Qdrant's service principal on the Key Vault.
-5. Copy the Key URL. You'll need it when you open your support ticket.
-
-## Open a Support Ticket
-
-With your key set up, open a support ticket via the [Qdrant Cloud Console](https://cloud.qdrant.io/) and include the following:
+Open a support ticket via the [Qdrant Cloud Console](https://cloud.qdrant.io/) and include:
 
 - Your cluster ID
 - Your cloud provider (AWS, GCP, or Azure)
 - Whether the cluster is empty or contains data
-- Your key identifier: Key ARN (AWS), Key ID (GCP), or Key URL (Azure)
+
+Qdrant Support will respond with the cloud-specific identifier you need to complete the next step:
+
+- **AWS**: Qdrant's AWS account ID
+- **GCP**: Qdrant's Compute Engine service agent email
+- **Azure**: Qdrant's Entra application ID (client ID)
+
+Support will also provide detailed setup instructions.
+
+## Step 2: Create Your Encryption Key
+
+Follow the instructions from Qdrant Support to complete the key setup for your cloud provider.
+
+### AWS
+
+In AWS KMS, create a symmetric key in the same region as your cluster and grant Qdrant's account access to it using the identifier provided by Support. Copy the resulting **Key ARN**.
+
+### GCP
+
+In Cloud KMS, create a key ring and symmetric encrypt/decrypt key in the same region as your cluster and grant Qdrant's service agent access to it using the identifier provided by Support. Copy the resulting **Key ID**.
+
+### Azure
+
+Install Qdrant's Entra application into your Azure tenant using the application ID provided by Support, create a Key Vault with an encryption key in the same region as your cluster, and grant Qdrant's service principal access to it. Copy the resulting **Key URL**.
+
+## Step 3: Reply to the Support Ticket
+
+Send Qdrant Support your key identifier:
+
+- **AWS**: Key ARN
+- **GCP**: Key ID
+- **Azure**: Key URL
 
 Qdrant Support will configure encryption for your cluster.
-

--- a/qdrant-landing/content/documentation/cloud/encryption.md
+++ b/qdrant-landing/content/documentation/cloud/encryption.md
@@ -13,7 +13,7 @@ Qdrant Managed Cloud encrypts all storage volumes at rest by default. [Premium c
 
 - A [Premium Managed Cloud](/documentation/cloud-premium/) subscription
 - An existing cluster in Qdrant Cloud (create one before requesting encryption)
-- Whether your cluster is empty or contains data (empty clusters are simpler to migrate; Qdrant Support will advise on the approach)
+- Whether your cluster is empty or contains data. We recommend starting with an empty cluster where possible.
 
 ## Step 1: Open a Support Ticket
 


### PR DESCRIPTION
[Preview](https://deploy-preview-2661--condescending-goldwasser-91acf0.netlify.app/documentation/cloud/encryption/)

Adds documentation for premium Managed Cloud customers who want to use their own key for encryption at rest.