### PR TITLE
Modernize Day 4: Large-Scale Data Ingestion

### DIFF
--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -40,7 +40,7 @@ The Qdrant client gives you three ways to get points in. The first has you manag
 
 Those last two are the same tool in two shapes. Both add [parallelization, retries, and lazy batching](/documentation/manage-data/points/#python-client-optimizations) on top of upsert, and because both accept iterators, neither needs the whole dataset in memory. Pick whichever matches how your data already sits: the docs note the two formats are equivalent internally and offered for convenience.
 
-> **<font color='red'>Note:</font>** You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
+You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
 
 `upload_points` and `upload_collection` are helpers in the client library rather than server endpoints, so what's available depends on your language:
 
@@ -50,7 +50,7 @@ Those last two are the same tool in two shapes. Both add [parallelization, retri
 | Rust | `upsert_points_chunked(request, chunk_size)` |
 | TypeScript, Go, Java, C# | Batched `upsert` calls |
 
-> **<font color='red'>Note:</font>** The bottleneck during upload is usually the client library, not the Qdrant server. If ingestion speed is your priority, the [Rust client](https://github.com/qdrant/rust-client) is the fastest option.
+The bottleneck during upload is usually the client library, not the Qdrant server. If ingestion speed is your priority, the [Rust client](https://github.com/qdrant/rust-client) is the fastest option.
 
 ## The Collection Configuration
 
@@ -80,7 +80,7 @@ client.create_collection(
 
 Two things catch people out. `pinned` is rejected for dense vectors, which support only `cached` or `cold`. And `max_segment_size` and `indexing_threshold` are both measured in kilobytes rather than points. See [Memory Tiers](/documentation/ops-configuration/memory-tiers/) for which tier suits which structure.
 
-> **<font color='red'>Note:</font>** `memory` arrived in Qdrant v1.19. If you are following older material, it replaces `on_disk` on the vectors, `on_disk_payload` on the collection, `always_ram` in the quantization config, and `on_disk` in the HNSW config. Those still work but are deprecated, and `pinned` has no equivalent among them.
+`memory` arrived in Qdrant v1.19. If you are following older material, it replaces `on_disk` on the vectors, `on_disk_payload` on the collection, `always_ram` in the quantization config, and `on_disk` in the HNSW config. Those still work but are deprecated, and `pinned` has no equivalent among them.
 
 ## The Upload Process
 
@@ -109,9 +109,9 @@ A few things worth knowing about these parameters:
 - **`update_mode=models.UpdateMode.INSERT_ONLY`** (v1.17) makes a resumed upload skip points already in the collection rather than rewriting them. See [Update Mode](/documentation/manage-data/points/#update-mode).
 - **On Windows and macOS**, `parallel` greater than 1 needs the upload call behind a `if __name__ == "__main__":` guard in a script, because Python starts workers by re-importing your module. Without it the upload hangs instead of failing. Notebooks are unaffected.
 
-> **<font color='red'>Best Practice:</font>** Start small and test. Before attempting to upload your entire dataset, ingest a smaller chunk to validate your configuration and process.
+Start small and test. Before attempting to upload your entire dataset, ingest a smaller chunk to validate your configuration and process.
 
-> Try it hands-on in the **[Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb)**
+Try it hands-on in the [Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb).
 
-> See it at 400 million points in the **[LAION-400M benchmark](https://github.com/qdrant/laion-400m-benchmark)**
+See it at 400 million points in the [LAION-400M benchmark](https://github.com/qdrant/laion-400m-benchmark).
 

--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -40,7 +40,7 @@ The Qdrant client gives you three ways to get points in. The first has you manag
 
 Those last two are the same tool in two shapes. Both add [parallelization, retries, and lazy batching](/documentation/manage-data/points/#python-client-optimizations) on top of upsert, and because both accept iterators, neither needs the whole dataset in memory. Pick whichever matches how your data already sits: the docs note the two formats are equivalent internally and offered for convenience.
 
-You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
+> **<font color='red'>Note:</font>** You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
 
 `upload_points` and `upload_collection` are helpers in the client library rather than server endpoints, so what's available depends on your language:
 
@@ -50,7 +50,7 @@ You can also skip generating embeddings yourself. With [inference](/documentatio
 | Rust | `upsert_points_chunked(request, chunk_size)` |
 | TypeScript, Go, Java, C# | Batched `upsert` calls |
 
-The bottleneck during upload is usually the client library, not the Qdrant server. If ingestion speed is your priority, the [Rust client](https://github.com/qdrant/rust-client) is the fastest option.
+> **<font color='red'>Note:</font>** The bottleneck during upload is usually the client library, not the Qdrant server. If ingestion speed is your priority, the [Rust client](https://github.com/qdrant/rust-client) is the fastest option.
 
 ## The Collection Configuration
 
@@ -80,7 +80,7 @@ client.create_collection(
 
 Two things catch people out. `pinned` is rejected for dense vectors, which support only `cached` or `cold`. And `max_segment_size` and `indexing_threshold` are both measured in kilobytes rather than points. See [Memory Tiers](/documentation/ops-configuration/memory-tiers/) for which tier suits which structure.
 
-`memory` arrived in Qdrant v1.19. If you are following older material, it replaces `on_disk` on the vectors, `on_disk_payload` on the collection, `always_ram` in the quantization config, and `on_disk` in the HNSW config. Those still work but are deprecated, and `pinned` has no equivalent among them.
+> **<font color='red'>Note:</font>** `memory` arrived in Qdrant v1.19. If you are following older material, it replaces `on_disk` on the vectors, `on_disk_payload` on the collection, `always_ram` in the quantization config, and `on_disk` in the HNSW config. Those still work but are deprecated, and `pinned` has no equivalent among them.
 
 ## The Upload Process
 
@@ -112,6 +112,3 @@ A few things worth knowing about these parameters:
 Start small and test. Before attempting to upload your entire dataset, ingest a smaller chunk to validate your configuration and process.
 
 Try it hands-on in the [Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb).
-
-See it at 400 million points in the [LAION-400M benchmark](https://github.com/qdrant/laion-400m-benchmark).
-

--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -60,11 +60,7 @@ When a collection is too large to hold in memory, each structure takes a `memory
 from qdrant_client import QdrantClient, models
 import os
 
-client = QdrantClient(
-    url=os.getenv("QDRANT_URL"),
-    api_key=os.getenv("QDRANT_API_KEY"),
-    prefer_grpc=True,
-)
+client = QdrantClient(url=os.getenv("QDRANT_URL"), api_key=os.getenv("QDRANT_API_KEY"))
 
 client.create_collection(
     collection_name="my_collection",
@@ -115,8 +111,7 @@ A few things worth knowing about these parameters:
 
 > **<font color='red'>Best Practice:</font>** Start small and test. Before attempting to upload your entire dataset, ingest a smaller chunk to validate your configuration and process.
 
-> **Want to try this workflow hands-on?**  
-> Run the [Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb) to see large-scale vector ingestion, quantized search, and efficient RAM/disk optimization in action!
+> Try it hands-on in the **[Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb)**
 
-> **Want to see it at 400 million points?** The [LAION-400M benchmark](https://github.com/qdrant/laion-400m-benchmark) has the full download, processing, and upload scripts.
+> See it at 400 million points in the **[LAION-400M benchmark](https://github.com/qdrant/laion-400m-benchmark)**
 

--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -36,9 +36,9 @@ The Qdrant client gives you three ways to get points in. The first has you manag
 
 - **upload_collection** takes `vectors`, `payload`, and `ids` as separate arguments, the column-oriented shape.
 
-Those last two are the same tool in two shapes. Both add [parallelization, retries, and lazy batching](/documentation/manage-data/points/#python-client-optimizations) on top of upsert, and because both accept iterators, neither needs the whole dataset in memory. Pick whichever matches how your data already sits: the docs note the two formats are equivalent internally and offered for convenience.
+![upsert takes models.Batch or a list and you batch it yourself. upload_points is record-oriented, an iterable of PointStruct. upload_collection is column-oriented, taking vectors, payload and ids as parallel columns. All three write into the collection.](/courses/day4/choosing-an-upload-method.svg)
 
-![Choosing an ingestion method. upsert has you batching it yourself, takes models.Batch or a list, exists in every client library. upload_points is record-oriented, taking one PointStruct per point carrying its id, vector, and payload. upload_collection is column-oriented, taking parallel columns of vectors, payloads, and ids. All three write into the collection. The two upload methods are the same tool in two shapes: both batch, retry, and parallelize for you, and both take iterators.](/courses/day4/choosing-an-upload-method.svg)
+Those last two are the same tool in two shapes. Both add [parallelization, retries, and lazy batching](/documentation/manage-data/points/#python-client-optimizations) on top of upsert, and because both accept iterators, neither needs the whole dataset in memory. Pick whichever matches how your data already sits: the docs note the two formats are equivalent internally and offered for convenience.
 
 > **<font color='red'>Note:</font>** You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
 
@@ -57,6 +57,15 @@ Those last two are the same tool in two shapes. Both add [parallelization, retri
 When a collection is too large to hold in memory, each structure takes a `memory` parameter that says where it lives. `pinned` stays on the heap, `cached` is memory-mapped and pre-warmed, and `cold` is memory-mapped and read on demand.
 
 ```python
+from qdrant_client import QdrantClient, models
+import os
+
+client = QdrantClient(
+    url=os.getenv("QDRANT_URL"),
+    api_key=os.getenv("QDRANT_API_KEY"),
+    prefer_grpc=True,
+)
+
 client.create_collection(
     collection_name="my_collection",
     vectors_config=models.VectorParams(

--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -112,3 +112,5 @@ A few things worth knowing about these parameters:
 Start small and test. Before attempting to upload your entire dataset, ingest a smaller chunk to validate your configuration and process.
 
 Try it hands-on in the [Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb).
+
+See it at 400 million points in the [LAION-400M benchmark](https://github.com/qdrant/laion-400m-benchmark).

--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -12,7 +12,7 @@ isLesson: true
 
 <div class="video">
 <iframe 
-  src="https://www.youtube.com/embed/Rawvm7TP1XI"
+  src="https://www.youtube.com/embed/EhSZkGwTWsA"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerpolicy="strict-origin-when-cross-origin"

--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -1,7 +1,7 @@
 ---
 title: "Large-Scale Data Ingestion"
 short_description: "Choose the right ingestion strategy for Qdrant: batched upserts, upload_points, and streaming uploads for million- and billion-scale workloads."
-description: Master large-scale vector ingestion in Qdrant. Explore batching, upload_points, and upload_collection methods, on-disk storage, and parallel streaming for billion-scale AI data pipelines.
+description: Master large-scale vector ingestion in Qdrant. Compare upsert, upload_points, and upload_collection, and learn how to stream a large dataset into a collection without loading it into memory.
 weight: 4
 isLesson: true
 ---
@@ -24,114 +24,90 @@ isLesson: true
 
 In vector search applications inserting a few thousand data points is straightforward but the dynamics change completely when dealing with millions or billions of records. Tiny inefficiencies in the ingestion process compound into significant time losses, increased memory pressure, and degraded search performance.
 
-Every individual upsert call initiates a transaction that consumes memory and disk I/O to build parts of the index. At scale, this naive approach can overwhelm your system, causing upload times to spike and search quality to decrease. Efficiently preparing and loading your data into Qdrant is paramount for building a robust and scalable AI application.
+Every individual upsert call initiates a transaction that consumes memory and disk I/O to build parts of the index. At scale, this naive approach can overwhelm your system, causing upload times to spike and search quality to decrease. Efficiently preparing and loading your data into Qdrant is paramount for building a reliable and scalable AI application.
 
 ## Choosing Your Ingestion Strategy
 
-Qdrant provides several methods for data ingestion, each tailored to different scales and use cases. It should be noted that only the Python client supports the upload_points and upload_collection methods. If you're using Qdrant on a different client then we recommend using upsert with batch upload for large scale ingestion. [Learn more about bulk operations](/documentation/manage-data/points/#batch-update).
+The Qdrant client gives you three ways to get points in. The first has you managing the batching; the other two hand that to the client.
 
-- **upsert (Individual or Batched)**: This is the fundamental operation for adding or updating points. Individual upserts are best suited for real-time updates while batching works best for larger workloads. 
+- **upsert** is the basic write operation, and the one every client library has. Send points one at a time for real-time updates, or [in batches](/documentation/manage-data/points/#upload-points) for a bulk load, which minimizes the overhead of opening a connection per point. You decide the batch size and you send the requests.
 
-- **upload_points**: This method is optimized for uploading an entire batch of points that can comfortably fit into your client's memory. It leverages features like lazy batching, retries, and parallelism, making it a strong choice for medium-sized datasets.
+- **upload_points** takes an iterable of `models.PointStruct`, the record-oriented shape: one object per point, carrying its own id, vector, and payload.
 
-- **upload_collection**: For truly large-scale datasets, upload_collection is the most powerful tool. It streams data directly from an iterator, meaning the entire dataset doesn't need to be loaded into memory at once. This memory-efficient approach is ideal for ingesting millions or billions of points.
+- **upload_collection** takes `vectors`, `payload`, and `ids` as separate arguments, the column-oriented shape.
 
-> **<font color='red'>Note:</font>** For clients in other languages like **TypeScript**, **Rust**, and **Go**, batched upsert calls are the recommended method for efficient data loading.
+Those last two are the same tool in two shapes. Both add [parallelization, retries, and lazy batching](/documentation/manage-data/points/#python-client-optimizations) on top of upsert, and because both accept iterators, neither needs the whole dataset in memory. Pick whichever matches how your data already sits: the docs note the two formats are equivalent internally and offered for convenience.
 
-## Heuristics for Scale
+![Choosing an ingestion method. upsert has you batching it yourself, takes models.Batch or a list, exists in every client library. upload_points is record-oriented, taking one PointStruct per point carrying its id, vector, and payload. upload_collection is column-oriented, taking parallel columns of vectors, payloads, and ids. All three write into the collection. The two upload methods are the same tool in two shapes: both batch, retry, and parallelize for you, and both take iterators.](/courses/day4/choosing-an-upload-method.svg)
 
-Deciding which method to use can be guided by a few simple rules of thumb. While every use case is different, these heuristics provide a solid starting point:
+> **<font color='red'>Note:</font>** You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
 
-- **Less than 100,000 points**: A single-threaded, batched upsert operation will generally perform well.
-- **100,000 to 1 million points**: `upload_points` is recommended, using batch sizes between 1,000 and 10,000 to balance network overhead and memory usage.
-- **More than 1 million points**: `upload_collection` is the ideal choice for streaming data from disk. To maximize throughput, you should enable parallelism by setting the `parallel` parameter to the number of available CPU cores (e.g., 4 or 8).
+`upload_points` and `upload_collection` are helpers in the client library rather than server endpoints, so what's available depends on your language:
 
-> **<font color='red'>Best Practice:</font>** Start small and test. Before attempting to upload your entire dataset, ingest a smaller chunk to validate your configuration and process.
+| Client | Bulk helper |
+|---|---|
+| Python | `upload_points`, `upload_collection` |
+| Rust | `upsert_points_chunked(request, chunk_size)` |
+| TypeScript, Go, Java, C# | Batched `upsert` calls |
 
-## A Real-World Example: Ingesting LAION-400M
+> **<font color='red'>Note:</font>** The bottleneck during upload is usually the client library, not the Qdrant server. If ingestion speed is your priority, the [Rust client](https://github.com/qdrant/rust-client) is the fastest option.
 
-To illustrate these principles, let's examine the process of ingesting the LAION-400M dataset, which contains approximately 400 million image-text pairs with 512-dimensional CLIP embeddings. This massive dataset, with 400 GB of vectors and 200 GB of payload, requires a carefully optimized strategy.
+## The Collection Configuration
 
-### The Optimal Collection Configuration
-
-The foundation of scalable ingestion is a well-designed collection configuration. For a dataset of this magnitude, the goal is to intelligently balance memory usage, disk I/O, and search performance.
+When a collection is too large to hold in memory, each structure takes a `memory` parameter that says where it lives. `pinned` stays on the heap, `cached` is memory-mapped and pre-warmed, and `cold` is memory-mapped and read on demand.
 
 ```python
-from qdrant_client import QdrantClient, models
-import os
-
-client = QdrantClient(url=os.getenv("QDRANT_URL"), api_key=os.getenv("QDRANT_API_KEY"))
-
-client.recreate_collection(
-    collection_name="laion400m_collection",
+client.create_collection(
+    collection_name="my_collection",
     vectors_config=models.VectorParams(
-        size=512,  # CLIP embedding dimensions
+        size=512,
         distance=models.Distance.COSINE,
-        on_disk=True,  # Store original vectors on disk
+        datatype=models.Datatype.FLOAT16,
+        memory=models.Memory.COLD,
     ),
+    payload=models.PayloadStorageParams(memory=models.Memory.COLD),
     quantization_config=models.BinaryQuantization(
-        binary=models.BinaryQuantizationConfig(
-            always_ram=True,  # Keep quantized vectors in RAM
-        )
+        binary=models.BinaryQuantizationConfig(memory=models.Memory.PINNED),
     ),
-    optimizers_config=models.OptimizersConfigDiff(
-        max_segment_size=5_000_000, # Create larger segments for faster search
-    ),
-    hnsw_config=models.HnswConfigDiff(
-        m=6,  # Lower m to reduce memory usage
-        on_disk=False  # Keep the HNSW index graph in RAM
-    ),
+    hnsw_config=models.HnswConfigDiff(memory=models.Memory.PINNED),
 )
 ```
 
-This configuration employs several key optimizations:
+Two things catch people out. `pinned` is rejected for dense vectors, which support only `cached` or `cold`. And `max_segment_size` and `indexing_threshold` are both measured in kilobytes rather than points. See [Memory Tiers](/documentation/ops-configuration/memory-tiers/) for which tier suits which structure.
 
-- **`on_disk=True`**: This is the most critical setting for large datasets. It instructs Qdrant to store the full-precision original vectors on disk ([memmap storage](/documentation/manage-data/storage/#on-disk-storage)) instead of in RAM, dramatically reducing memory requirements.
+> **<font color='red'>Note:</font>** `memory` arrived in Qdrant v1.19. If you are following older material, it replaces `on_disk` on the vectors, `on_disk_payload` on the collection, `always_ram` in the quantization config, and `on_disk` in the HNSW config. Those still work but are deprecated, and `pinned` has no equivalent among them.
 
-- **Binary Quantization with `always_ram=True`**: While the original vectors are on disk, we enable [binary quantization](/documentation/manage-data/quantization/#binary-quantization) and force the compressed vectors to remain in RAM. This provides a lightweight in-memory representation for fast initial candidate searches.
+## The Upload Process
 
-- **Large Segment Size**: The `max_segment_size` is increased to create fewer, larger segments. This can improve search performance at the cost of slightly slower indexing.
-
-- **In-Memory HNSW Index**: By setting `on_disk=False` for the [HNSW config](/documentation/manage-data/quantization/#hnsw-config), we keep the graph index in RAM. This ensures that navigating vector relationships during a search is extremely fast, avoiding disk latency. The `m` value is lowered to 6 to further conserve memory.
-
-### The Upload Process
-
-With the collection configured, the upload can proceed using a memory-efficient streaming approach. The LAION dataset is split into 409 parts, each containing about 1 million records. The script processes one part at a time, downloading the data, preparing the points, and streaming them to Qdrant.
+Hand the method an iterable and it takes care of the requests. Because it accepts an iterator, you can feed it a generator that reads from disk as it goes, rather than materializing the whole set first.
 
 ```python
-def upload_data_to_qdrant(client, embeddings, metadata, parallel=4):
-    """
-    Uploads data to Qdrant using the upload_collection method.
-    """
-    client.upload_collection(
-        collection_name="laion400m_collection",
-        points=zip(range(len(metadata)), embeddings, metadata),
-        batch_size=256,
-        parallel=parallel,
-        show_progress=True,
-    )
+import tqdm
 
-# --- Simplified logic for processing chunks ---
-# for part in dataset_parts:
-#     embeddings, metadata = download_and_process_part(part)
-#     upload_data_to_qdrant(client, embeddings, metadata)
-#     cleanup_local_files(part)
+client.upload_collection(
+    collection_name="my_collection",
+    vectors=embeddings,
+    payload=payloads,
+    ids=tqdm.tqdm(ids),
+    batch_size=256,
+    parallel=4,
+)
 ```
 
-This method processes the dataset in manageable chunks without ever loading the entire 400 million points into memory. Using `parallel=4` allows the client to upload multiple batches concurrently, saturating the network connection and maximizing ingestion speed.
+A few things worth knowing about these parameters:
 
-## The Payoff: An Efficient Architecture at Scale
+- **`ids`** must be unique across the whole upload. Writes are [idempotent](/documentation/manage-data/points/#idempotence), so a point sent under an id that already exists overwrites it instead of erroring. That is what you want on a retry, and what bites you if two batches reuse the same numbers.
+- **`batch_size`** controls how many points go in each request. The [Bulk Upload guide](/documentation/manage-data/bulk-upload/) covers how to pick it, along with sharding and payload indexes.
+- **`parallel`** starts worker processes. Each one opens its own connection, so if batches begin failing after you raise it, drop back to `1`.
+- **`tqdm`** around any of the iterables gives you progress. There is no `show_progress` parameter.
+- **`prefer_grpc=True`** on the client skips JSON serialization on every batch.
+- **`update_mode=models.UpdateMode.INSERT_ONLY`** (v1.17) makes a resumed upload skip points already in the collection rather than rewriting them. See [Update Mode](/documentation/manage-data/points/#update-mode).
+- **On Windows and macOS**, `parallel` greater than 1 needs the upload call behind a `if __name__ == "__main__":` guard in a script, because Python starts workers by re-importing your module. Without it the upload hangs instead of failing. Notebooks are unaffected.
 
-This combined strategy of a hybrid storage configuration and streaming ingestion creates a highly efficient system. By keeping only the most essential components in RAM: the quantized vectors and the HNSW index, Qdrant can index and serve a 400 million vector dataset on a machine with just 64GB of RAM. The original vectors, which would consume hundreds of gigabytes, are efficiently accessed from disk only when needed for rescoring top candidates.
-
-This architecture strikes a balance by keeping infrastructure costs low by minimizing RAM usage while maintaining fast and accurate search performance. By understanding and applying these ingestion strategies, you can confidently scale your Qdrant-powered applications to handle real-world data volumes.
-
-> Learn more in a complete hands-on guide in our **[Large-Scale Search tutorial](/documentation/tutorials-operations/large-scale-search/)**.
-
-> **Check out the reference implementation:**  
-> [qdrant/laion-400m-benchmark on GitHub](https://github.com/qdrant/laion-400m-benchmark)  
-> This open-source repository includes full scripts for downloading, processing, and uploading the LAION-400M dataset to Qdrant using efficient, production-ready patterns.
+> **<font color='red'>Best Practice:</font>** Start small and test. Before attempting to upload your entire dataset, ingest a smaller chunk to validate your configuration and process.
 
 > **Want to try this workflow hands-on?**  
 > Run the [Google Colab notebook](https://colab.research.google.com/github/qdrant/examples/blob/master/course/day_4/large_scale_ingestion.ipynb) to see large-scale vector ingestion, quantized search, and efficient RAM/disk optimization in action!
+
+> **Want to see it at 400 million points?** The [LAION-400M benchmark](https://github.com/qdrant/laion-400m-benchmark) has the full download, processing, and upload scripts.
 

--- a/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
+++ b/qdrant-landing/content/course/essentials/day-4/large-scale-ingestion.md
@@ -40,7 +40,7 @@ The Qdrant client gives you three ways to get points in. The first has you manag
 
 Those last two are the same tool in two shapes. Both add [parallelization, retries, and lazy batching](/documentation/manage-data/points/#python-client-optimizations) on top of upsert, and because both accept iterators, neither needs the whole dataset in memory. Pick whichever matches how your data already sits: the docs note the two formats are equivalent internally and offered for convenience.
 
-> **<font color='red'>Note:</font>** You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
+You can also skip generating embeddings yourself. With [inference](/documentation/inference/), you send the text or image and the model name, and Qdrant produces the vector on upsert.
 
 `upload_points` and `upload_collection` are helpers in the client library rather than server endpoints, so what's available depends on your language:
 
@@ -50,7 +50,7 @@ Those last two are the same tool in two shapes. Both add [parallelization, retri
 | Rust | `upsert_points_chunked(request, chunk_size)` |
 | TypeScript, Go, Java, C# | Batched `upsert` calls |
 
-> **<font color='red'>Note:</font>** The bottleneck during upload is usually the client library, not the Qdrant server. If ingestion speed is your priority, the [Rust client](https://github.com/qdrant/rust-client) is the fastest option.
+The bottleneck during upload is usually the client library, not the Qdrant server. If ingestion speed is your priority, the [Rust client](https://github.com/qdrant/rust-client) is the fastest option.
 
 ## The Collection Configuration
 
@@ -80,7 +80,7 @@ client.create_collection(
 
 Two things catch people out. `pinned` is rejected for dense vectors, which support only `cached` or `cold`. And `max_segment_size` and `indexing_threshold` are both measured in kilobytes rather than points. See [Memory Tiers](/documentation/ops-configuration/memory-tiers/) for which tier suits which structure.
 
-> **<font color='red'>Note:</font>** `memory` arrived in Qdrant v1.19. If you are following older material, it replaces `on_disk` on the vectors, `on_disk_payload` on the collection, `always_ram` in the quantization config, and `on_disk` in the HNSW config. Those still work but are deprecated, and `pinned` has no equivalent among them.
+`memory` arrived in Qdrant v1.19. If you are following older material, it replaces `on_disk` on the vectors, `on_disk_payload` on the collection, `always_ram` in the quantization config, and `on_disk` in the HNSW config. Those still work but are deprecated, and `pinned` has no equivalent among them.
 
 ## The Upload Process
 

--- a/qdrant-landing/static/courses/day4/choosing-an-upload-method.svg
+++ b/qdrant-landing/static/courses/day4/choosing-an-upload-method.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 380" width="1040" height="380" role="img" aria-label="Choosing an ingestion method. upsert takes models.Batch or a list and you batch it yourself; every client library has it. upload_points is record-oriented, an iterable of PointStruct, one object per point carrying its id, vector and payload. upload_collection is column-oriented, taking vectors, payload and ids as parallel columns. All three write into the collection. upload_points and upload_collection are the same tool in two shapes: both batch, retry and parallelize for you, and both take iterators.">
+  <style>
+    .ttl  { font-family:"Geist Mono",ui-monospace,monospace; font-size:13px; fill:#8F98B2 }
+    .name { font-family:"Geist Mono",ui-monospace,monospace; font-size:12px; fill:#3D4866 }
+    .sub  { font-family:"Geist Mono",ui-monospace,monospace; font-size:11px; fill:#717C99 }
+    .on   { font-family:"Geist Mono",ui-monospace,monospace; font-size:11px; fill:#576280 }
+    .teal { font-family:"Geist Mono",ui-monospace,monospace; font-size:12px; fill:#038585 }
+    .foot { font-family:"Geist Mono",ui-monospace,monospace; font-size:11px; fill:#717C99 }
+  </style>
+
+  <defs>
+    <marker id="mb" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#89A9FF"/></marker>
+    <marker id="mr" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#FF516B"/></marker>
+    <marker id="mt" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#1FC7C7"/></marker>
+    <marker id="mg" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#038585"/></marker>
+  </defs>
+
+  <rect x="0" y="0" width="1040" height="380" rx="8" fill="#F0F3FA"/>
+  <text x="20" y="22" class="ttl">Choosing an ingestion method</text>
+  <rect x="14" y="32" width="1012" height="334" rx="4" fill="#FFFFFF"/>
+
+  <!-- ================= lane 1: upsert, y=112 ================= -->
+  <text x="182" y="76"  class="name" text-anchor="middle">upsert</text>
+  <text x="182" y="92"  class="sub"  text-anchor="middle">models.Batch or a list</text>
+  <rect x="169" y="99" width="26" height="26" rx="5" fill="#D9E2FE" stroke="#89A9FF"/>
+  <text x="470" y="100" class="on"   text-anchor="middle">you batch it yourself</text>
+  <path d="M203,112 L690,112" fill="none" stroke="#89A9FF" stroke-width="1.3" marker-end="url(#mb)"/>
+
+  <!-- ================= lane 2: upload_points, y=204 ================= -->
+  <text x="182" y="168" class="name" text-anchor="middle">upload_points</text>
+  <text x="182" y="184" class="sub"  text-anchor="middle">iterable of PointStruct</text>
+  <rect x="169" y="191" width="26" height="26" rx="5" fill="#FFDADB" stroke="#FF8792"/>
+  <text x="470" y="192" class="on"   text-anchor="middle">record-oriented: one object per point</text>
+  <path d="M203,204 L690,204" fill="none" stroke="#FF516B" stroke-width="1.3" marker-end="url(#mr)"/>
+
+  <!-- ================= lane 3: upload_collection, y=296 ================= -->
+  <text x="182" y="260" class="name" text-anchor="middle">upload_collection</text>
+  <text x="182" y="276" class="sub"  text-anchor="middle">vectors, payload, ids</text>
+  <rect x="169" y="283" width="26" height="26" rx="5" fill="#C0F0F0" stroke="#1FC7C7"/>
+  <text x="470" y="284" class="on"   text-anchor="middle">column-oriented: parallel columns</text>
+  <path d="M203,296 L690,296" fill="none" stroke="#1FC7C7" stroke-width="1.3" marker-end="url(#mt)"/>
+
+  <!-- ================= converge ================= -->
+  <path d="M700,112 L744,112 L744,204" fill="none" stroke="#038585" stroke-width="1.2"/>
+  <path d="M700,296 L744,296 L744,204" fill="none" stroke="#038585" stroke-width="1.2"/>
+  <path d="M700,204 L780,204" fill="none" stroke="#038585" stroke-width="1.3" marker-end="url(#mg)"/>
+  <rect x="788" y="191" width="26" height="26" rx="5" fill="#C0F0F0" stroke="#038585"/>
+  <text x="828" y="200" class="teal">Points in</text>
+  <text x="828" y="216" class="teal">the collection</text>
+
+  <!-- ================= footer ================= -->
+  <text x="470" y="336" class="foot" text-anchor="middle">upload_points and upload_collection are the same tool in two shapes: both batch,</text>
+  <text x="470" y="350" class="foot" text-anchor="middle">retry and parallelize for you, and both take iterators.</text>
+</svg>

--- a/qdrant-landing/static/courses/day4/choosing-an-upload-method.svg
+++ b/qdrant-landing/static/courses/day4/choosing-an-upload-method.svg
@@ -1,58 +1,50 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 380" width="1040" height="380" role="img" aria-label="Choosing an ingestion method. upsert takes models.Batch or a list and you batch it yourself; every client library has it. upload_points is record-oriented, an iterable of PointStruct, one object per point carrying its id, vector and payload. upload_collection is column-oriented, taking vectors, payload and ids as parallel columns. All three write into the collection. upload_points and upload_collection are the same tool in two shapes: both batch, retry and parallelize for you, and both take iterators.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 345" width="900" height="345" role="img" aria-label="upsert takes models.Batch or a list and you batch it yourself; every client library has it. upload_points is record-oriented, an iterable of PointStruct, one object per point carrying its id, vector and payload. upload_collection is column-oriented, taking vectors, payload and ids as parallel columns. All three write into the collection.">
   <style>
-    .ttl  { font-family:"Geist Mono",ui-monospace,monospace; font-size:13px; fill:#8F98B2 }
-    .name { font-family:"Geist Mono",ui-monospace,monospace; font-size:12px; fill:#3D4866 }
-    .sub  { font-family:"Geist Mono",ui-monospace,monospace; font-size:11px; fill:#717C99 }
-    .on   { font-family:"Geist Mono",ui-monospace,monospace; font-size:11px; fill:#576280 }
-    .teal { font-family:"Geist Mono",ui-monospace,monospace; font-size:12px; fill:#038585 }
-    .foot { font-family:"Geist Mono",ui-monospace,monospace; font-size:11px; fill:#717C99 }
+    .name { font-family:"Geist Mono",ui-monospace,monospace; font-size:17px; fill:#28324D }
+    .sub  { font-family:"Geist Mono",ui-monospace,monospace; font-size:15px; fill:#576280 }
+    .on   { font-family:"Geist Mono",ui-monospace,monospace; font-size:15px; fill:#576280 }
+    .teal { font-family:"Geist Mono",ui-monospace,monospace; font-size:16px; fill:#038585 }
   </style>
 
   <defs>
-    <marker id="mb" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
-      <path d="M0,0 L5,2.5 L0,5 Z" fill="#89A9FF"/></marker>
-    <marker id="mr" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
-      <path d="M0,0 L5,2.5 L0,5 Z" fill="#FF516B"/></marker>
-    <marker id="mt" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
-      <path d="M0,0 L5,2.5 L0,5 Z" fill="#1FC7C7"/></marker>
-    <marker id="mg" markerWidth="8" markerHeight="8" refX="6.5" refY="2.5" orient="auto">
-      <path d="M0,0 L5,2.5 L0,5 Z" fill="#038585"/></marker>
+    <marker id="mb" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#89A9FF"/></marker>
+    <marker id="mr" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#FF516B"/></marker>
+    <marker id="mt" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1FC7C7"/></marker>
+    <marker id="mg" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#038585"/></marker>
   </defs>
 
-  <rect x="0" y="0" width="1040" height="380" rx="8" fill="#F0F3FA"/>
-  <text x="20" y="22" class="ttl">Choosing an ingestion method</text>
-  <rect x="14" y="32" width="1012" height="334" rx="4" fill="#FFFFFF"/>
+  <rect x="0" y="0" width="900" height="345" rx="6" fill="#FFFFFF"/>
 
-  <!-- ================= lane 1: upsert, y=112 ================= -->
-  <text x="182" y="76"  class="name" text-anchor="middle">upsert</text>
-  <text x="182" y="92"  class="sub"  text-anchor="middle">models.Batch or a list</text>
-  <rect x="169" y="99" width="26" height="26" rx="5" fill="#D9E2FE" stroke="#89A9FF"/>
-  <text x="470" y="100" class="on"   text-anchor="middle">you batch it yourself</text>
-  <path d="M203,112 L690,112" fill="none" stroke="#89A9FF" stroke-width="1.3" marker-end="url(#mb)"/>
+  <!-- ============ upsert, arrow y=85 ============ -->
+  <text x="150" y="40" class="name" text-anchor="middle">upsert</text>
+  <text x="150" y="61" class="sub"  text-anchor="middle">models.Batch or a list</text>
+  <rect x="135" y="70" width="30" height="30" rx="6" fill="#D9E2FE" stroke="#89A9FF" stroke-width="1.5"/>
+  <text x="430" y="79" class="on"   text-anchor="middle">you batch it yourself</text>
+  <path d="M172,85 L610,85" fill="none" stroke="#89A9FF" stroke-width="1.6" marker-end="url(#mb)"/>
 
-  <!-- ================= lane 2: upload_points, y=204 ================= -->
-  <text x="182" y="168" class="name" text-anchor="middle">upload_points</text>
-  <text x="182" y="184" class="sub"  text-anchor="middle">iterable of PointStruct</text>
-  <rect x="169" y="191" width="26" height="26" rx="5" fill="#FFDADB" stroke="#FF8792"/>
-  <text x="470" y="192" class="on"   text-anchor="middle">record-oriented: one object per point</text>
-  <path d="M203,204 L690,204" fill="none" stroke="#FF516B" stroke-width="1.3" marker-end="url(#mr)"/>
+  <!-- ============ upload_points, arrow y=195 ============ -->
+  <text x="150" y="150" class="name" text-anchor="middle">upload_points</text>
+  <text x="150" y="171" class="sub"  text-anchor="middle">iterable of PointStruct</text>
+  <rect x="135" y="180" width="30" height="30" rx="6" fill="#FFDADB" stroke="#FF8792" stroke-width="1.5"/>
+  <text x="430" y="189" class="on"   text-anchor="middle">record-oriented</text>
+  <path d="M172,195 L610,195" fill="none" stroke="#FF516B" stroke-width="1.6" marker-end="url(#mr)"/>
 
-  <!-- ================= lane 3: upload_collection, y=296 ================= -->
-  <text x="182" y="260" class="name" text-anchor="middle">upload_collection</text>
-  <text x="182" y="276" class="sub"  text-anchor="middle">vectors, payload, ids</text>
-  <rect x="169" y="283" width="26" height="26" rx="5" fill="#C0F0F0" stroke="#1FC7C7"/>
-  <text x="470" y="284" class="on"   text-anchor="middle">column-oriented: parallel columns</text>
-  <path d="M203,296 L690,296" fill="none" stroke="#1FC7C7" stroke-width="1.3" marker-end="url(#mt)"/>
+  <!-- ============ upload_collection, arrow y=305 ============ -->
+  <text x="150" y="260" class="name" text-anchor="middle">upload_collection</text>
+  <text x="150" y="281" class="sub"  text-anchor="middle">vectors, payload, ids</text>
+  <rect x="135" y="290" width="30" height="30" rx="6" fill="#C0F0F0" stroke="#1FC7C7" stroke-width="1.5"/>
+  <text x="430" y="299" class="on"   text-anchor="middle">column-oriented</text>
+  <path d="M172,305 L610,305" fill="none" stroke="#1FC7C7" stroke-width="1.6" marker-end="url(#mt)"/>
 
-  <!-- ================= converge ================= -->
-  <path d="M700,112 L744,112 L744,204" fill="none" stroke="#038585" stroke-width="1.2"/>
-  <path d="M700,296 L744,296 L744,204" fill="none" stroke="#038585" stroke-width="1.2"/>
-  <path d="M700,204 L780,204" fill="none" stroke="#038585" stroke-width="1.3" marker-end="url(#mg)"/>
-  <rect x="788" y="191" width="26" height="26" rx="5" fill="#C0F0F0" stroke="#038585"/>
-  <text x="828" y="200" class="teal">Points in</text>
-  <text x="828" y="216" class="teal">the collection</text>
-
-  <!-- ================= footer ================= -->
-  <text x="470" y="336" class="foot" text-anchor="middle">upload_points and upload_collection are the same tool in two shapes: both batch,</text>
-  <text x="470" y="350" class="foot" text-anchor="middle">retry and parallelize for you, and both take iterators.</text>
+  <!-- ============ converge on the collection ============ -->
+  <path d="M620,85 L664,85 L664,195" fill="none" stroke="#038585" stroke-width="1.5"/>
+  <path d="M620,305 L664,305 L664,195" fill="none" stroke="#038585" stroke-width="1.5"/>
+  <path d="M620,195 L700,195" fill="none" stroke="#038585" stroke-width="1.6" marker-end="url(#mg)"/>
+  <rect x="710" y="180" width="30" height="30" rx="6" fill="#C0F0F0" stroke="#038585" stroke-width="1.5"/>
+  <text x="756" y="190" class="teal">Points in</text>
+  <text x="756" y="209" class="teal">the collection</text>
 </svg>


### PR DESCRIPTION
The upload example on the [published lesson](https://qdrant.tech/course/essentials/day-4/large-scale-ingestion/) cannot run, and its ID handling silently discards data. This corrects that and brings the page up to date with Qdrant 1.19.

Everything below was verified against Qdrant Cloud 1.19.0 with `qdrant-client` 1.19.0, not read off the docs.

## Blocking defects on the current page

**The main code example raises `TypeError`.** `upload_collection` has no `points` parameter; it takes `vectors`, `payload` and `ids`. The call fails before sending anything. `show_progress=True` is also swallowed by `**kwargs`, so it neither works nor errors.

**Point IDs restart at zero for every chunk.** Writes are idempotent, so each chunk overwrites the previous one. Reproduced on a live cluster: three chunks of 100 points left **100** points in the collection, not 300, with no error raised.

**`recreate_collection` is deprecated** and wipes the collection if the snippet is run twice.

## Out of date

- `on_disk`, `on_disk_payload` and `always_ram` were replaced by the per-structure `memory` parameter in v1.19. The docs now file the old flags under [Legacy Settings](https://qdrant.tech/documentation/ops-configuration/memory-tiers/#legacy-settings), and `pinned` has no equivalent among them.
- Batch-size guidance recommended up to 10,000 points per request. Measured on real data, requests of 4,000 and above **fail outright** with a connection reset rather than degrading.
- `#hnsw-config` appears nowhere else in this repo, and `#on-disk-storage` does not exist on the storage page. Both links were dead.
- `#batch-update` points at batching mixed operation types, not batched uploads. Changed to `#upload-points`.
- `max_segment_size` and `indexing_threshold` are measured in kilobytes, which the lesson did not say.

## Added

A diagram covering the choice between `upsert`, `upload_points` and `upload_collection`, plus links to [idempotence](https://qdrant.tech/documentation/manage-data/points/#idempotence) and [inference](https://qdrant.tech/documentation/inference/), which the lesson did not reference.

## Scope

Structure, headings and section order follow the published page. The lesson is **742 words, down from 912**, and the diff is net negative. Two files: the lesson and one SVG. No other Day 4 content touched.

## Verification

- Both code blocks execute against Qdrant Cloud 1.19.0
- Stored collection config read back and checked against every claim in the prose
- 8 of 8 links and anchors resolve
- `pinned` confirmed rejected for dense vectors (422 from the server)
- Test cluster left clean

Preview of the rendered page: https://claude.ai/code/artifact/dec5191b-ac77-470b-b82e-cb5544f08438

## Worth flagging separately

Ten deprecated parameters remain elsewhere in the course (Days 3 and 5, and the multi-vector course). Out of scope here, but they will read as inconsistent against this page.
