### PR TITLE
Multitenancy clarifications

### DIFF
--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/generated/python.md
@@ -1,6 +1,4 @@
 ```python
-from qdrant_client import QdrantClient, models
-
 client.create_collection(
     collection_name="{collection_name}",
     shard_number=1,

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/generated/typescript.md
@@ -1,6 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
 client.createCollection("{collection_name}", {
     shard_number: 1,
     sharding_method: "custom",

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/python.py
@@ -1,4 +1,4 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
 # @hide-start
 client = QdrantClient(url="http://localhost:6333")

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-custom-sharding/typescript.ts
@@ -1,4 +1,4 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
 // @hide-start
 const client = new QdrantClient({ host: "localhost", port: 6333 });

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/csharp.cs
@@ -5,7 +5,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.CreateCollectionAsync(
 			collectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/csharp.md
@@ -2,8 +2,6 @@
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.CreateCollectionAsync(
 	collectionName: "{collection_name}",
 	vectorsConfig: new VectorParams { Size = 768, Distance = Distance.Cosine },

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.CreateCollection(context.Background(), &qdrant.CreateCollection{
 	CollectionName: "{collection_name}",
 	VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/java.md
@@ -7,9 +7,6 @@ import io.qdrant.client.grpc.Collections.HnswConfigDiff;
 import io.qdrant.client.grpc.Collections.VectorParams;
 import io.qdrant.client.grpc.Collections.VectorsConfig;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client
     .createCollectionAsync(
         CreateCollection.newBuilder()

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/python.md
@@ -1,8 +1,4 @@
 ```python
-from qdrant_client import QdrantClient, models
-
-client = QdrantClient(url="http://localhost:6333")
-
 client.create_collection(
     collection_name="{collection_name}",
     vectors_config=models.VectorParams(size=768, distance=models.Distance.COSINE),

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/rust.md
@@ -4,8 +4,6 @@ use qdrant_client::qdrant::{
 };
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 client
     .create_collection(
         CreateCollectionBuilder::new("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.createCollection("{collection_name}", {
   vectors: {
     size: 768,

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.CreateCollection(context.Background(), &qdrant.CreateCollection{
 		CollectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/java.java
@@ -10,8 +10,10 @@ import io.qdrant.client.grpc.Collections.VectorsConfig;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client
                     .createCollectionAsync(

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/python.py
@@ -1,6 +1,6 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
-client = QdrantClient(url="http://localhost:6333")
+client = QdrantClient(url="http://localhost:6333")  # @hide
 
 client.create_collection(
     collection_name="{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/rust.rs
@@ -4,7 +4,7 @@ use qdrant_client::qdrant::{
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     client
         .create_collection(

--- a/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/create-collection/with-disabled-global-hnsw/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.createCollection("{collection_name}", {
   vectors: {

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/csharp.cs
@@ -5,7 +5,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.CreatePayloadIndexAsync(
 			collectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/csharp.md
@@ -2,8 +2,6 @@
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.CreatePayloadIndexAsync(
 	collectionName: "{collection_name}",
 	fieldName: "group_id",

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.CreateFieldIndex(context.Background(), &qdrant.CreateFieldIndexCollection{
 	CollectionName: "{collection_name}",
 	FieldName:      "group_id",

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/java.md
@@ -5,9 +5,6 @@ import io.qdrant.client.grpc.Collections.KeywordIndexParams;
 import io.qdrant.client.grpc.Collections.PayloadIndexParams;
 import io.qdrant.client.grpc.Collections.PayloadSchemaType;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client
     .createPayloadIndexAsync(
         "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/generated/rust.md
@@ -6,8 +6,6 @@ use qdrant_client::qdrant::{
 };
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 client.create_field_index(
         CreateFieldIndexCollectionBuilder::new(
             "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.CreateFieldIndex(context.Background(), &qdrant.CreateFieldIndexCollection{
 		CollectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/java.java
@@ -8,8 +8,10 @@ import io.qdrant.client.grpc.Collections.PayloadSchemaType;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client
                     .createPayloadIndexAsync(

--- a/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/rust.rs
@@ -6,7 +6,7 @@ use qdrant_client::qdrant::{
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     client.create_field_index(
             CreateFieldIndexCollectionBuilder::new(

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/csharp.cs
@@ -5,7 +5,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.CreateShardKeyAsync(
 		    "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/csharp.cs
@@ -9,7 +9,7 @@ public class Snippet
 
 		await client.CreateShardKeyAsync(
 		    "{collection_name}",
-		    new CreateShardKey { ShardKey = new ShardKey { Keyword = "default", } }
+		    new CreateShardKey { ShardKey = new ShardKey { Keyword = "default", }, ShardsNumber = 1 }
 		    );
 	}
 }

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/csharp.md
@@ -6,6 +6,6 @@ var client = new QdrantClient("localhost", 6334);
 
 await client.CreateShardKeyAsync(
     "{collection_name}",
-    new CreateShardKey { ShardKey = new ShardKey { Keyword = "default", } }
+    new CreateShardKey { ShardKey = new ShardKey { Keyword = "default", }, ShardsNumber = 1 }
     );
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/csharp.md
@@ -2,8 +2,6 @@
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.CreateShardKeyAsync(
     "{collection_name}",
     new CreateShardKey { ShardKey = new ShardKey { Keyword = "default", }, ShardsNumber = 1 }

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/go.md
@@ -11,6 +11,7 @@ client, err := qdrant.NewClient(&qdrant.Config{
 })
 
 client.CreateShardKey(context.Background(), "{collection_name}", &qdrant.CreateShardKey{
-	ShardKey: qdrant.NewShardKey("default"),
+	ShardKey:     qdrant.NewShardKey("default"),
+	ShardsNumber: qdrant.PtrOf(uint32(1)),
 })
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.CreateShardKey(context.Background(), "{collection_name}", &qdrant.CreateShardKey{
 	ShardKey:     qdrant.NewShardKey("default"),
 	ShardsNumber: qdrant.PtrOf(uint32(1)),

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/java.md
@@ -6,9 +6,6 @@ import io.qdrant.client.QdrantGrpcClient;
 import io.qdrant.client.grpc.Collections.CreateShardKey;
 import io.qdrant.client.grpc.Collections.CreateShardKeyRequest;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client.createShardKeyAsync(CreateShardKeyRequest.newBuilder()
                 .setCollectionName("{collection_name}")
                 .setRequest(CreateShardKey.newBuilder()

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/java.md
@@ -13,6 +13,7 @@ client.createShardKeyAsync(CreateShardKeyRequest.newBuilder()
                 .setCollectionName("{collection_name}")
                 .setRequest(CreateShardKey.newBuilder()
                                 .setShardKey(shardKey("default"))
+                                .setShardsNumber(1)
                                 .build())
                 .build()).get();
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/python.md
@@ -3,5 +3,5 @@ from qdrant_client import QdrantClient, models
 
 client = QdrantClient(url="http://localhost:6333")
 
-client.create_shard_key("{collection_name}", "default")
+client.create_shard_key("{collection_name}", "default", shards_number=1)
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/python.md
@@ -1,7 +1,3 @@
 ```python
-from qdrant_client import QdrantClient, models
-
-client = QdrantClient(url="http://localhost:6333")
-
 client.create_shard_key("{collection_name}", "default", shards_number=1)
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/rust.md
@@ -4,8 +4,6 @@ use qdrant_client::qdrant::{
 };
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 client
     .create_shard_key(
         CreateShardKeyRequestBuilder::new("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/rust.md
@@ -9,7 +9,7 @@ let client = Qdrant::from_url("http://localhost:6334").build()?;
 client
     .create_shard_key(
         CreateShardKeyRequestBuilder::new("{collection_name}")
-            .request(CreateShardKeyBuilder::default().shard_key("default".to_string())),
+            .request(CreateShardKeyBuilder::default().shard_key("default".to_string()).shards_number(1)),
     )
     .await?;
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/typescript.md
@@ -4,6 +4,7 @@ import { QdrantClient } from "@qdrant/js-client-rest";
 const client = new QdrantClient({ host: "localhost", port: 6333 });
 
 client.createShardKey("{collection_name}", {
-    shard_key: "default"
+    shard_key: "default",
+    shards_number: 1
 });
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.createShardKey("{collection_name}", {
     shard_key: "default",
     shards_number: 1

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/go.go
@@ -15,6 +15,7 @@ func Main() {
 	if err != nil { panic(err) } // @hide
 
 	client.CreateShardKey(context.Background(), "{collection_name}", &qdrant.CreateShardKey{
-		ShardKey: qdrant.NewShardKey("default"),
+		ShardKey:     qdrant.NewShardKey("default"),
+		ShardsNumber: qdrant.PtrOf(uint32(1)),
 	})
 }

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.CreateShardKey(context.Background(), "{collection_name}", &qdrant.CreateShardKey{
 		ShardKey:     qdrant.NewShardKey("default"),

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/http.md
@@ -1,6 +1,7 @@
 ```http
 PUT /collections/{collection_name}/shards
 {
-  "shard_key": "default"
+  "shard_key": "default",
+  "shards_number": 1
 }
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/java.java
@@ -9,8 +9,10 @@ import io.qdrant.client.grpc.Collections.CreateShardKeyRequest;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client.createShardKeyAsync(CreateShardKeyRequest.newBuilder()
                                 .setCollectionName("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/java.java
@@ -16,6 +16,7 @@ public class Snippet {
                                 .setCollectionName("{collection_name}")
                                 .setRequest(CreateShardKey.newBuilder()
                                                 .setShardKey(shardKey("default"))
+                                                .setShardsNumber(1)
                                                 .build())
                                 .build()).get();
         }

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/python.py
@@ -1,5 +1,5 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
-client = QdrantClient(url="http://localhost:6333")
+client = QdrantClient(url="http://localhost:6333")  # @hide
 
 client.create_shard_key("{collection_name}", "default", shards_number=1)

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/python.py
@@ -2,4 +2,4 @@ from qdrant_client import QdrantClient, models
 
 client = QdrantClient(url="http://localhost:6333")
 
-client.create_shard_key("{collection_name}", "default")
+client.create_shard_key("{collection_name}", "default", shards_number=1)

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/rust.rs
@@ -9,7 +9,7 @@ pub async fn main() -> anyhow::Result<()> {
     client
         .create_shard_key(
             CreateShardKeyRequestBuilder::new("{collection_name}")
-                .request(CreateShardKeyBuilder::default().shard_key("default".to_string())),
+                .request(CreateShardKeyBuilder::default().shard_key("default".to_string()).shards_number(1)),
         )
         .await?;
 

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/rust.rs
@@ -4,7 +4,7 @@ use qdrant_client::qdrant::{
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     client
         .create_shard_key(

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.createShardKey("{collection_name}", {
     shard_key: "default",

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-default/typescript.ts
@@ -3,5 +3,6 @@ import { QdrantClient } from "@qdrant/js-client-rest";
 const client = new QdrantClient({ host: "localhost", port: 6333 });
 
 client.createShardKey("{collection_name}", {
-    shard_key: "default"
+    shard_key: "default",
+    shards_number: 1
 });

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/csharp.cs
@@ -9,8 +9,10 @@ public class Snippet
 
 		await client.CreateShardKeyAsync(
 		    "{collection_name}",
-		    new CreateShardKey { 
+		    new CreateShardKey {
 		        ShardKey = new ShardKey { Keyword = "default" },
+		        ShardsNumber = 1,
+		        ReplicationFactor = 1,
 		        InitialState = ReplicaState.Partial
 		    }
 		);

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/csharp.cs
@@ -5,7 +5,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.CreateShardKeyAsync(
 		    "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/csharp.md
@@ -2,8 +2,6 @@
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.CreateShardKeyAsync(
     "{collection_name}",
     new CreateShardKey {

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/csharp.md
@@ -6,8 +6,10 @@ var client = new QdrantClient("localhost", 6334);
 
 await client.CreateShardKeyAsync(
     "{collection_name}",
-    new CreateShardKey { 
+    new CreateShardKey {
         ShardKey = new ShardKey { Keyword = "default" },
+        ShardsNumber = 1,
+        ReplicationFactor = 1,
         InitialState = ReplicaState.Partial
     }
 );

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/go.md
@@ -14,8 +14,10 @@ client.CreateShardKey(
 	context.Background(),
 	"{collection_name}",
 	&qdrant.CreateShardKey{
-		ShardKey: qdrant.NewShardKey("default"),
-		InitialState: qdrant.PtrOf(qdrant.ReplicaState_Partial),
+		ShardKey:          qdrant.NewShardKey("default"),
+		ShardsNumber:      qdrant.PtrOf(uint32(1)),
+		ReplicationFactor: qdrant.PtrOf(uint32(1)),
+		InitialState:      qdrant.PtrOf(qdrant.ReplicaState_Partial),
 	},
 )
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.CreateShardKey(
 	context.Background(),
 	"{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/java.md
@@ -8,9 +8,6 @@ import io.qdrant.client.grpc.Collections.CreateShardKeyRequest;
 import io.qdrant.client.grpc.Collections.ReplicaState;
 import io.qdrant.client.grpc.Common.Filter;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client.createShardKeyAsync(CreateShardKeyRequest.newBuilder()
                 .setCollectionName("{collection_name}")
                 .setRequest(CreateShardKey.newBuilder()

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/java.md
@@ -15,6 +15,8 @@ client.createShardKeyAsync(CreateShardKeyRequest.newBuilder()
                 .setCollectionName("{collection_name}")
                 .setRequest(CreateShardKey.newBuilder()
                                 .setShardKey(shardKey("default"))
+                                .setShardsNumber(1)
+                                .setReplicationFactor(1)
                                 .setInitialState(ReplicaState.Partial)
                                 .build())
                 .build()).get();

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/python.md
@@ -6,6 +6,8 @@ client = QdrantClient(url="http://localhost:6333")
 client.create_shard_key(
     "{collection_name}",
     shard_key="user_1",
+    shards_number=1,
+    replication_factor=1,
     initial_state=models.ReplicaState.PARTIAL
 )
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/python.md
@@ -1,8 +1,4 @@
 ```python
-from qdrant_client import QdrantClient, models
-
-client = QdrantClient(url="http://localhost:6333")
-
 client.create_shard_key(
     "{collection_name}",
     shard_key="user_1",

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/rust.md
@@ -5,8 +5,6 @@ use qdrant_client::qdrant::{
 use qdrant_client::qdrant::ReplicaState;
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 client
     .create_shard_key(
         CreateShardKeyRequestBuilder::new("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/rust.md
@@ -13,6 +13,8 @@ client
             .request(
                 CreateShardKeyBuilder::default()
                     .shard_key("user_1".to_string())
+                    .shards_number(1)
+                    .replication_factor(1)
                     .initial_state(ReplicaState::Partial)
             ),
     )

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.createShardKey("{collection_name}", {
     shard_key: "default",
     shards_number: 1,

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/generated/typescript.md
@@ -5,6 +5,8 @@ const client = new QdrantClient({ host: "localhost", port: 6333 });
 
 client.createShardKey("{collection_name}", {
     shard_key: "default",
+    shards_number: 1,
+    replication_factor: 1,
     initial_state: "Partial"
 });
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/go.go
@@ -18,8 +18,10 @@ func Main() {
 		context.Background(),
 		"{collection_name}",
 		&qdrant.CreateShardKey{
-			ShardKey: qdrant.NewShardKey("default"),
-			InitialState: qdrant.PtrOf(qdrant.ReplicaState_Partial),
+			ShardKey:          qdrant.NewShardKey("default"),
+			ShardsNumber:      qdrant.PtrOf(uint32(1)),
+			ReplicationFactor: qdrant.PtrOf(uint32(1)),
+			InitialState:      qdrant.PtrOf(qdrant.ReplicaState_Partial),
 		},
 	)
 }

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.CreateShardKey(
 		context.Background(),

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/http.md
@@ -2,6 +2,8 @@
 PUT /collections/{collection_name}/shards
 {
   "shard_key": "user_1",
+  "shards_number": 1,
+  "replication_factor": 1,
   "initial_state": "Partial"
 }
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/java.java
@@ -18,6 +18,8 @@ public class Snippet {
                                 .setCollectionName("{collection_name}")
                                 .setRequest(CreateShardKey.newBuilder()
                                                 .setShardKey(shardKey("default"))
+                                                .setShardsNumber(1)
+                                                .setReplicationFactor(1)
                                                 .setInitialState(ReplicaState.Partial)
                                                 .build())
                                 .build()).get();

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/java.java
@@ -11,8 +11,10 @@ import io.qdrant.client.grpc.Common.Filter;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client.createShardKeyAsync(CreateShardKeyRequest.newBuilder()
                                 .setCollectionName("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/python.py
@@ -5,5 +5,7 @@ client = QdrantClient(url="http://localhost:6333")
 client.create_shard_key(
     "{collection_name}",
     shard_key="user_1",
+    shards_number=1,
+    replication_factor=1,
     initial_state=models.ReplicaState.PARTIAL
 )

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/python.py
@@ -1,6 +1,6 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
-client = QdrantClient(url="http://localhost:6333")
+client = QdrantClient(url="http://localhost:6333")  # @hide
 
 client.create_shard_key(
     "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/rust.rs
@@ -13,6 +13,8 @@ pub async fn main() -> anyhow::Result<()> {
                 .request(
                     CreateShardKeyBuilder::default()
                         .shard_key("user_1".to_string())
+                        .shards_number(1)
+                        .replication_factor(1)
                         .initial_state(ReplicaState::Partial)
                 ),
         )

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/rust.rs
@@ -5,7 +5,7 @@ use qdrant_client::qdrant::ReplicaState;
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     client
         .create_shard_key(

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/typescript.ts
@@ -4,5 +4,7 @@ const client = new QdrantClient({ host: "localhost", port: 6333 });
 
 client.createShardKey("{collection_name}", {
     shard_key: "default",
+    shards_number: 1,
+    replication_factor: 1,
     initial_state: "Partial"
 });

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.createShardKey("{collection_name}", {
     shard_key: "default",

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/generated/python.md
@@ -1,5 +1,3 @@
 ```python
-from qdrant_client import QdrantClient, models
-
 client.create_shard_key("{collection_name}", "{shard_key}")
 ```

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/generated/typescript.md
@@ -1,6 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
 client.createShardKey("{collection_name}", {
     shard_key: "{shard_key}"
 });

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/python.py
@@ -1,4 +1,4 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
 # @hide-start
 client = QdrantClient(url="http://localhost:6333")

--- a/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/create-shard/create-named-shard/typescript.ts
@@ -1,4 +1,4 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
 // @hide-start
 const client = new QdrantClient({ host: "localhost", port: 6333 });

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/generated/python.md
@@ -1,6 +1,4 @@
 ```python
-from qdrant_client import QdrantClient, models
-
 client.upsert(
     collection_name="{collection_name}",
     points=[

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/generated/typescript.md
@@ -1,6 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
 client.upsert("{collection_name}", {
     points: [
         {

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/python.py
@@ -1,4 +1,4 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
 # @hide-start
 client = QdrantClient(url="http://localhost:6333")

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-custom-shard/typescript.ts
@@ -1,4 +1,4 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
 // @hide-start
 const client = new QdrantClient({ host: "localhost", port: 6333 });

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/csharp.cs
@@ -5,7 +5,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.UpsertAsync(
 			collectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/csharp.md
@@ -2,8 +2,6 @@
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.UpsertAsync(
 	collectionName: "{collection_name}",
 	points: new List<PointStruct>

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.Upsert(context.Background(), &qdrant.UpsertPoints{
 	CollectionName: "{collection_name}",
 	Points: []*qdrant.PointStruct{

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/java.md
@@ -12,9 +12,6 @@ import io.qdrant.client.grpc.Points.UpsertPoints;
 import java.util.List;
 import java.util.Map;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client
     .upsertAsync(
         UpsertPoints.newBuilder()

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/rust.md
@@ -2,8 +2,6 @@
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::{PointStruct, ShardKeySelectorBuilder, UpsertPointsBuilder};
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 let shard_key_selector = ShardKeySelectorBuilder::with_shard_key("user_1")
     .fallback("default")
     .build();

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.upsert("{collection_name}", {
   points: [
     {

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.Upsert(context.Background(), &qdrant.UpsertPoints{
 		CollectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/java.java
@@ -15,8 +15,10 @@ import java.util.Map;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client
                     .upsertAsync(

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/rust.rs
@@ -2,7 +2,7 @@ use qdrant_client::Qdrant;
 use qdrant_client::qdrant::{PointStruct, ShardKeySelectorBuilder, UpsertPointsBuilder};
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     let shard_key_selector = ShardKeySelectorBuilder::with_shard_key("user_1")
         .fallback("default")

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.upsert("{collection_name}", {
   points: [

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/csharp.cs
@@ -5,7 +5,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.UpsertAsync(
 			collectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/csharp.md
@@ -2,8 +2,6 @@
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.UpsertAsync(
 	collectionName: "{collection_name}",
 	points: new List<PointStruct>

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.Upsert(context.Background(), &qdrant.UpsertPoints{
 	CollectionName: "{collection_name}",
 	Points: []*qdrant.PointStruct{

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/java.md
@@ -9,9 +9,6 @@ import io.qdrant.client.grpc.Points.PointStruct;
 import java.util.List;
 import java.util.Map;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client
     .upsertAsync(
         "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/rust.md
@@ -2,8 +2,6 @@
 use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 client
     .upsert_points(UpsertPointsBuilder::new(
         "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.upsert("{collection_name}", {
   points: [
     {

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.Upsert(context.Background(), &qdrant.UpsertPoints{
 		CollectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/java.java
@@ -12,8 +12,10 @@ import java.util.Map;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client
                     .upsertAsync(

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/rust.rs
@@ -2,7 +2,7 @@ use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     client
         .upsert_points(UpsertPointsBuilder::new(

--- a/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/insert-points/with-tenant-group-id/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.upsert("{collection_name}", {
   points: [

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/_description.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/_description.md
@@ -1,0 +1,1 @@
+Query a collection using a shard key selector with fallback, and filter results by `group_id`. The shard key selector routes to the tenant's dedicated shard if it exists, or falls back to the shared shard.

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/csharp.cs
@@ -1,0 +1,22 @@
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using static Qdrant.Client.Grpc.Conditions;
+
+public class Snippet
+{
+	public static async Task Run()
+	{
+		var client = new QdrantClient("localhost", 6334);
+
+		await client.QueryAsync(
+			collectionName: "{collection_name}",
+			query: new float[] { 0.1f, 0.1f, 0.9f },
+			filter: MatchKeyword("group_id", "user_1"),
+			shardKeySelector: new ShardKeySelector {
+				ShardKeys = { new List<ShardKey> { "user_1" } },
+				Fallback = new ShardKey { Keyword = "default" }
+			},
+			limit: 10
+		);
+	}
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/csharp.cs
@@ -6,7 +6,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.QueryAsync(
 			collectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/csharp.md
@@ -1,0 +1,18 @@
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using static Qdrant.Client.Grpc.Conditions;
+
+var client = new QdrantClient("localhost", 6334);
+
+await client.QueryAsync(
+	collectionName: "{collection_name}",
+	query: new float[] { 0.1f, 0.1f, 0.9f },
+	filter: MatchKeyword("group_id", "user_1"),
+	shardKeySelector: new ShardKeySelector {
+		ShardKeys = { new List<ShardKey> { "user_1" } },
+		Fallback = new ShardKey { Keyword = "default" }
+	},
+	limit: 10
+);
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/csharp.md
@@ -3,8 +3,6 @@ using Qdrant.Client;
 using Qdrant.Client.Grpc;
 using static Qdrant.Client.Grpc.Conditions;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.QueryAsync(
 	collectionName: "{collection_name}",
 	query: new float[] { 0.1f, 0.1f, 0.9f },

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/go.md
@@ -1,0 +1,26 @@
+```go
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+	Host: "localhost",
+	Port: 6334,
+})
+
+client.Query(context.Background(), &qdrant.QueryPoints{
+	CollectionName: "{collection_name}",
+	Query:          qdrant.NewQuery(0.1, 0.1, 0.9),
+	Filter: &qdrant.Filter{
+		Must: []*qdrant.Condition{
+			qdrant.NewMatch("group_id", "user_1"),
+		},
+	},
+	ShardKeySelector: &qdrant.ShardKeySelector{
+		ShardKeys: []*qdrant.ShardKey{qdrant.NewShardKey("user_1")},
+		Fallback:  qdrant.NewShardKey("default"),
+	},
+})
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.Query(context.Background(), &qdrant.QueryPoints{
 	CollectionName: "{collection_name}",
 	Query:          qdrant.NewQuery(0.1, 0.1, 0.9),

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/java.md
@@ -1,0 +1,29 @@
+```java
+import static io.qdrant.client.ConditionFactory.matchKeyword;
+import static io.qdrant.client.QueryFactory.nearest;
+import static io.qdrant.client.ShardKeyFactory.shardKey;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Common.Filter;
+import io.qdrant.client.grpc.Points.QueryPoints;
+import io.qdrant.client.grpc.Points.ShardKeySelector;
+
+QdrantClient client =
+    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+client.queryAsync(
+        QueryPoints.newBuilder()
+                .setCollectionName("{collection_name}")
+                .setFilter(
+                        Filter.newBuilder().addMust(matchKeyword("group_id", "user_1")).build())
+                .setQuery(nearest(0.1f, 0.1f, 0.9f))
+                .setLimit(10)
+                .setShardKeySelector(
+                        ShardKeySelector.newBuilder()
+                                .addShardKeys(shardKey("user_1"))
+                                .setFallback(shardKey("default"))
+                                .build())
+                .build())
+        .get();
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/java.md
@@ -9,9 +9,6 @@ import io.qdrant.client.grpc.Common.Filter;
 import io.qdrant.client.grpc.Points.QueryPoints;
 import io.qdrant.client.grpc.Points.ShardKeySelector;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client.queryAsync(
         QueryPoints.newBuilder()
                 .setCollectionName("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/python.md
@@ -1,0 +1,19 @@
+```python
+client.query_points(
+    collection_name="{collection_name}",
+    query=[0.1, 0.1, 0.9],
+    query_filter=models.Filter(
+        must=[
+            models.FieldCondition(
+                key="group_id",
+                match=models.MatchValue(value="user_1"),
+            )
+        ]
+    ),
+    shard_key_selector=models.ShardKeyWithFallback(
+        target="user_1",
+        fallback="default"
+    ),
+    limit=10,
+)
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/rust.md
@@ -1,0 +1,23 @@
+```rust
+use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder, ShardKeySelectorBuilder};
+use qdrant_client::Qdrant;
+
+let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+let shard_key_selector = ShardKeySelectorBuilder::with_shard_key("user_1")
+    .fallback("default")
+    .build();
+
+client
+    .query(
+        QueryPointsBuilder::new("{collection_name}")
+            .query(vec![0.1, 0.1, 0.9])
+            .limit(10)
+            .filter(Filter::must([Condition::matches(
+                "group_id",
+                "user_1".to_string(),
+            )]))
+            .shard_key_selector(shard_key_selector),
+    )
+    .await?;
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/rust.md
@@ -2,8 +2,6 @@
 use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder, ShardKeySelectorBuilder};
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 let shard_key_selector = ShardKeySelectorBuilder::with_shard_key("user_1")
     .fallback("default")
     .build();

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.query("{collection_name}", {
     query: [0.1, 0.1, 0.9],
     filter: {

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/generated/typescript.md
@@ -1,0 +1,14 @@
+```typescript
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.query("{collection_name}", {
+    query: [0.1, 0.1, 0.9],
+    filter: {
+        must: [{ key: "group_id", match: { value: "user_1" } }],
+    },
+    shard_key: { target: "user_1", fallback: "default" },
+    limit: 10,
+});
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/go.go
@@ -1,0 +1,30 @@
+package snippet
+
+import (
+	"context"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+func Main() {
+	client, err := qdrant.NewClient(&qdrant.Config{
+		Host: "localhost",
+		Port: 6334,
+	})
+
+	if err != nil { panic(err) } // @hide
+
+	client.Query(context.Background(), &qdrant.QueryPoints{
+		CollectionName: "{collection_name}",
+		Query:          qdrant.NewQuery(0.1, 0.1, 0.9),
+		Filter: &qdrant.Filter{
+			Must: []*qdrant.Condition{
+				qdrant.NewMatch("group_id", "user_1"),
+			},
+		},
+		ShardKeySelector: &qdrant.ShardKeySelector{
+			ShardKeys: []*qdrant.ShardKey{qdrant.NewShardKey("user_1")},
+			Fallback:  qdrant.NewShardKey("default"),
+		},
+	})
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.Query(context.Background(), &qdrant.QueryPoints{
 		CollectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/http.md
@@ -1,0 +1,21 @@
+```http
+POST /collections/{collection_name}/points/query
+{
+    "query": [0.1, 0.1, 0.9],
+    "filter": {
+        "must": [
+            {
+                "key": "group_id",
+                "match": {
+                    "value": "user_1"
+                }
+            }
+        ]
+    },
+    "shard_key": {
+        "fallback": "default",
+        "target": "user_1"
+    },
+    "limit": 10
+}
+```

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/java.java
@@ -1,0 +1,33 @@
+package com.example.snippets_amalgamation;
+
+import static io.qdrant.client.ConditionFactory.matchKeyword;
+import static io.qdrant.client.QueryFactory.nearest;
+import static io.qdrant.client.ShardKeyFactory.shardKey;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Common.Filter;
+import io.qdrant.client.grpc.Points.QueryPoints;
+import io.qdrant.client.grpc.Points.ShardKeySelector;
+
+public class Snippet {
+        public static void run() throws Exception {
+                QdrantClient client =
+                    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+                client.queryAsync(
+                        QueryPoints.newBuilder()
+                                .setCollectionName("{collection_name}")
+                                .setFilter(
+                                        Filter.newBuilder().addMust(matchKeyword("group_id", "user_1")).build())
+                                .setQuery(nearest(0.1f, 0.1f, 0.9f))
+                                .setLimit(10)
+                                .setShardKeySelector(
+                                        ShardKeySelector.newBuilder()
+                                                .addShardKeys(shardKey("user_1"))
+                                                .setFallback(shardKey("default"))
+                                                .build())
+                                .build())
+                        .get();
+        }
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/java.java
@@ -12,8 +12,10 @@ import io.qdrant.client.grpc.Points.ShardKeySelector;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client.queryAsync(
                         QueryPoints.newBuilder()

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/python.py
@@ -1,0 +1,21 @@
+from qdrant_client import QdrantClient, models  # @hide
+
+client = QdrantClient(url="http://localhost:6333")  # @hide
+
+client.query_points(
+    collection_name="{collection_name}",
+    query=[0.1, 0.1, 0.9],
+    query_filter=models.Filter(
+        must=[
+            models.FieldCondition(
+                key="group_id",
+                match=models.MatchValue(value="user_1"),
+            )
+        ]
+    ),
+    shard_key_selector=models.ShardKeyWithFallback(
+        target="user_1",
+        fallback="default"
+    ),
+    limit=10,
+)

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/rust.rs
@@ -1,0 +1,25 @@
+use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder, ShardKeySelectorBuilder};
+use qdrant_client::Qdrant;
+
+pub async fn main() -> anyhow::Result<()> {
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    let shard_key_selector = ShardKeySelectorBuilder::with_shard_key("user_1")
+        .fallback("default")
+        .build();
+
+    client
+        .query(
+            QueryPointsBuilder::new("{collection_name}")
+                .query(vec![0.1, 0.1, 0.9])
+                .limit(10)
+                .filter(Filter::must([Condition::matches(
+                    "group_id",
+                    "user_1".to_string(),
+                )]))
+                .shard_key_selector(shard_key_selector),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/rust.rs
@@ -2,7 +2,7 @@ use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder, ShardKeySelec
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     let shard_key_selector = ShardKeySelectorBuilder::with_shard_key("user_1")
         .fallback("default")

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.query("{collection_name}", {
     query: [0.1, 0.1, 0.9],

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/typescript.ts
@@ -1,0 +1,12 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+const client = new QdrantClient({ host: "localhost", port: 6333 });
+
+client.query("{collection_name}", {
+    query: [0.1, 0.1, 0.9],
+    filter: {
+        must: [{ key: "group_id", match: { value: "user_1" } }],
+    },
+    shard_key: { target: "user_1", fallback: "default" },
+    limit: 10,
+});

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/csharp.cs
@@ -6,7 +6,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.QueryAsync(
 			collectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/csharp.md
@@ -3,8 +3,6 @@ using Qdrant.Client;
 using Qdrant.Client.Grpc;
 using static Qdrant.Client.Grpc.Conditions;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.QueryAsync(
 	collectionName: "{collection_name}",
 	query: new float[] { 0.1f, 0.1f, 0.9f },

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.Query(context.Background(), &qdrant.QueryPoints{
 	CollectionName: "{collection_name}",
 	Query:          qdrant.NewQuery(0.1, 0.1, 0.9),

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/java.md
@@ -8,9 +8,6 @@ import io.qdrant.client.grpc.Common.Filter;
 import io.qdrant.client.grpc.Points.QueryPoints;
 import java.util.List;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client.queryAsync(
         QueryPoints.newBuilder()
                 .setCollectionName("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/python.md
@@ -1,8 +1,4 @@
 ```python
-from qdrant_client import QdrantClient, models
-
-client = QdrantClient(url="http://localhost:6333")
-
 client.query_points(
     collection_name="{collection_name}",
     query=[0.1, 0.1, 0.9],

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/rust.md
@@ -2,8 +2,6 @@
 use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder};
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 client
     .query(
         QueryPointsBuilder::new("{collection_name}")

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.query("{collection_name}", {
     query: [0.1, 0.1, 0.9],
     filter: {

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.Query(context.Background(), &qdrant.QueryPoints{
 		CollectionName: "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/java.java
@@ -11,8 +11,10 @@ import java.util.List;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
                 client.queryAsync(
                         QueryPoints.newBuilder()

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/python.py
@@ -1,6 +1,6 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
-client = QdrantClient(url="http://localhost:6333")
+client = QdrantClient(url="http://localhost:6333")  # @hide
 
 client.query_points(
     collection_name="{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/rust.rs
@@ -2,7 +2,7 @@ use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder};
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     client
         .query(

--- a/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/query-points/with-filter-by-group-id/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.query("{collection_name}", {
     query: [0.1, 0.1, 0.9],

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/csharp.cs
@@ -6,7 +6,7 @@ public class Snippet
 {
 	public static async Task Run()
 	{
-		var client = new QdrantClient("localhost", 6334);
+		var client = new QdrantClient("localhost", 6334); // @hide
 
 		await client.UpdateCollectionClusterSetupAsync(new()
 		{

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/csharp.md
@@ -3,8 +3,6 @@ using Qdrant.Client;
 using Qdrant.Client.Grpc;
 using static Qdrant.Client.Grpc.Conditions;
 
-var client = new QdrantClient("localhost", 6334);
-
 await client.UpdateCollectionClusterSetupAsync(new()
 {
     CollectionName = "{collection_name}",

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/go.md
@@ -5,11 +5,6 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-client, err := qdrant.NewClient(&qdrant.Config{
-	Host: "localhost",
-	Port: 6334,
-})
-
 client.UpdateClusterCollectionSetup(context.Background(), qdrant.NewUpdateCollectionClusterReplicatePoints(
 	"{collection_name}", &qdrant.ReplicatePoints{
 		FromShardKey: qdrant.NewShardKey("default"),

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/java.md
@@ -9,9 +9,6 @@ import io.qdrant.client.grpc.Collections.ReplicatePoints;
 import io.qdrant.client.grpc.Collections.UpdateCollectionClusterSetupRequest;
 import io.qdrant.client.grpc.Common.Filter;
 
-QdrantClient client =
-    new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
-
 client
     .updateCollectionClusterSetupAsync(
         UpdateCollectionClusterSetupRequest.newBuilder()

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/python.md
@@ -1,8 +1,4 @@
 ```python
-from qdrant_client import QdrantClient, models
-
-client = QdrantClient(url="http://localhost:6333")
-
 client.cluster_collection_update(
     collection_name="{collection_name}",
     cluster_operation=models.ReplicatePointsOperation(

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/rust.md
@@ -5,8 +5,6 @@ use qdrant_client::qdrant::{
 };
 use qdrant_client::Qdrant;
 
-let client = Qdrant::from_url("http://localhost:6334").build()?;
-
 client
     .update_collection_cluster_setup(UpdateCollectionClusterSetupRequest {
         collection_name: "{collection_name}".to_string(),

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/generated/typescript.md
@@ -1,8 +1,4 @@
 ```typescript
-import { QdrantClient } from "@qdrant/js-client-rest";
-
-const client = new QdrantClient({ host: "localhost", port: 6333 });
-
 client.updateCollectionCluster("{collection_name}", {
     replicate_points: {
         filter: {

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/go.go
@@ -7,12 +7,14 @@ import (
 )
 
 func Main() {
+	// @hide-start
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host: "localhost",
 		Port: 6334,
 	})
 
-	if err != nil { panic(err) } // @hide
+	if err != nil { panic(err) }
+	// @hide-end
 
 	client.UpdateClusterCollectionSetup(context.Background(), qdrant.NewUpdateCollectionClusterReplicatePoints(
 		"{collection_name}", &qdrant.ReplicatePoints{

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/java.java
@@ -12,8 +12,10 @@ import io.qdrant.client.grpc.Common.Filter;
 
 public class Snippet {
         public static void run() throws Exception {
+                // @hide-start
                 QdrantClient client =
                     new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+                // @hide-end
 
 
                 client

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/python.py
@@ -1,6 +1,6 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
-client = QdrantClient(url="http://localhost:6333")
+client = QdrantClient(url="http://localhost:6333")  # @hide
 
 
 client.cluster_collection_update(

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/rust.rs
@@ -5,7 +5,7 @@ use qdrant_client::qdrant::{
 use qdrant_client::Qdrant;
 
 pub async fn main() -> anyhow::Result<()> {
-    let client = Qdrant::from_url("http://localhost:6334").build()?;
+    let client = Qdrant::from_url("http://localhost:6334").build()?; // @hide
 
     client
         .update_collection_cluster_setup(UpdateCollectionClusterSetupRequest {

--- a/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/shard-transfer/with-filter/typescript.ts
@@ -1,6 +1,6 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
-const client = new QdrantClient({ host: "localhost", port: 6333 });
+const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
 client.updateCollectionCluster("{collection_name}", {
     replicate_points: {

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/csharp.cs
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/csharp.cs
@@ -9,14 +9,14 @@ public class Snippet
         var client = new QdrantClient("localhost", 6334); // @hide
 
         await client.QueryAsync(
-            collectionName: "books",
+            collectionName: "{collection_name}",
             query: new Document { Text = "time travel", Model = "qdrant/bm25" },
             usingVector: "title-bm25",
             filter: new Filter
             {
                 Must =
                 {
-                    MatchKeyword("tenant", "acme"),
+                    MatchKeyword("group_id", "user_1"),
                     Match("year", 2024),
                 },
             },
@@ -26,7 +26,7 @@ public class Snippet
                 {
                     Corpus = new Filter
                     {
-                        Must = { MatchKeyword("tenant", "acme") },
+                        Must = { MatchKeyword("group_id", "user_1") },
                     },
                 },
             },

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/csharp.md
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/csharp.md
@@ -4,14 +4,14 @@ using Qdrant.Client.Grpc;
 using static Qdrant.Client.Grpc.Conditions;
 
 await client.QueryAsync(
-    collectionName: "books",
+    collectionName: "{collection_name}",
     query: new Document { Text = "time travel", Model = "qdrant/bm25" },
     usingVector: "title-bm25",
     filter: new Filter
     {
         Must =
         {
-            MatchKeyword("tenant", "acme"),
+            MatchKeyword("group_id", "user_1"),
             Match("year", 2024),
         },
     },
@@ -21,7 +21,7 @@ await client.QueryAsync(
         {
             Corpus = new Filter
             {
-                Must = { MatchKeyword("tenant", "acme") },
+                Must = { MatchKeyword("group_id", "user_1") },
             },
         },
     },

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/go.md
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/go.md
@@ -1,6 +1,6 @@
 ```go
 client.Query(context.Background(), &qdrant.QueryPoints{
-	CollectionName: "books",
+	CollectionName: "{collection_name}",
 	Query: qdrant.NewQueryNearest(
 		qdrant.NewVectorInputDocument(&qdrant.Document{
 			Model: "qdrant/bm25",
@@ -10,7 +10,7 @@ client.Query(context.Background(), &qdrant.QueryPoints{
 	Using: qdrant.PtrOf("title-bm25"),
 	Filter: &qdrant.Filter{
 		Must: []*qdrant.Condition{
-			qdrant.NewMatch("tenant", "acme"),
+			qdrant.NewMatch("group_id", "user_1"),
 			qdrant.NewMatchInt("year", 2024),
 		},
 	},
@@ -18,7 +18,7 @@ client.Query(context.Background(), &qdrant.QueryPoints{
 		Idf: &qdrant.IdfParams{
 			Corpus: &qdrant.Filter{
 				Must: []*qdrant.Condition{
-					qdrant.NewMatch("tenant", "acme"),
+					qdrant.NewMatch("group_id", "user_1"),
 				},
 			},
 		},

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/java.md
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/java.md
@@ -14,7 +14,7 @@ QdrantClient client =
 client
     .queryAsync(
         QueryPoints.newBuilder()
-            .setCollectionName("books")
+            .setCollectionName("{collection_name}")
             .setQuery(
                 nearest(
                     Document.newBuilder()
@@ -24,7 +24,7 @@ client
             .setUsing("title-bm25")
             .setFilter(
                 Filter.newBuilder()
-                    .addMust(matchKeyword("tenant", "acme"))
+                    .addMust(matchKeyword("group_id", "user_1"))
                     .addMust(match("year", 2024))
                     .build())
             .setParams(
@@ -33,7 +33,7 @@ client
                         IdfParams.newBuilder()
                             .setCorpus(
                                 Filter.newBuilder()
-                                    .addMust(matchKeyword("tenant", "acme"))
+                                    .addMust(matchKeyword("group_id", "user_1"))
                                     .build())
                             .build())
                     .build())

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/python.md
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/python.md
@@ -1,19 +1,11 @@
 ```python
-from qdrant_client import QdrantClient, models
-
-client = QdrantClient(
-    url="https://xyz-example.qdrant.io:6333",
-    api_key="<your-api-key>",
-    cloud_inference=True,
-)
-
 client.query_points(
-    collection_name="books",
+    collection_name="{collection_name}",
     query=models.Document(text="time travel", model="qdrant/bm25"),
     using="title-bm25",
     query_filter=models.Filter(
         must=[
-            models.FieldCondition(key="tenant", match=models.MatchValue(value="acme")),
+            models.FieldCondition(key="group_id", match=models.MatchValue(value="user_1")),
             models.FieldCondition(key="year", match=models.MatchValue(value=2024)),
         ]
     ),
@@ -22,7 +14,7 @@ client.query_points(
             corpus=models.Filter(
                 must=[
                     models.FieldCondition(
-                        key="tenant", match=models.MatchValue(value="acme")
+                        key="group_id", match=models.MatchValue(value="user_1")
                     ),
                 ]
             )

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/rust.md
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/rust.md
@@ -6,11 +6,11 @@ use qdrant_client::qdrant::{
 
 client
     .query(
-        QueryPointsBuilder::new("books")
+        QueryPointsBuilder::new("{collection_name}")
             .query(Query::new_nearest(Document::new("time travel", "qdrant/bm25")))
             .using("title-bm25")
             .filter(Filter::must([
-                Condition::matches("tenant", "acme".to_string()),
+                Condition::matches("group_id", "user_1".to_string()),
                 Condition::matches("year", 2024),
             ]))
             .params(SearchParamsBuilder::default().idf(

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/typescript.md
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/generated/typescript.md
@@ -1,5 +1,5 @@
 ```typescript
-client.query("books", {
+client.query("{collection_name}", {
   query: {
     text: "time travel",
     model: "qdrant/bm25",
@@ -7,14 +7,14 @@ client.query("books", {
   using: "title-bm25",
   filter: {
     must: [
-      { key: "tenant", match: { value: "acme" } },
+      { key: "group_id", match: { value: "user_1" } },
       { key: "year", match: { value: 2024 } },
     ],
   },
   params: {
     idf: {
       corpus: {
-        must: [{ key: "tenant", match: { value: "acme" } }],
+        must: [{ key: "group_id", match: { value: "user_1" } }],
       },
     },
   },

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/go.go
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/go.go
@@ -21,7 +21,7 @@ func Main() {
 	// @hide-end
 
 	client.Query(context.Background(), &qdrant.QueryPoints{
-		CollectionName: "books",
+		CollectionName: "{collection_name}",
 		Query: qdrant.NewQueryNearest(
 			qdrant.NewVectorInputDocument(&qdrant.Document{
 				Model: "qdrant/bm25",
@@ -31,7 +31,7 @@ func Main() {
 		Using: qdrant.PtrOf("title-bm25"),
 		Filter: &qdrant.Filter{
 			Must: []*qdrant.Condition{
-				qdrant.NewMatch("tenant", "acme"),
+				qdrant.NewMatch("group_id", "user_1"),
 				qdrant.NewMatchInt("year", 2024),
 			},
 		},
@@ -39,7 +39,7 @@ func Main() {
 			Idf: &qdrant.IdfParams{
 				Corpus: &qdrant.Filter{
 					Must: []*qdrant.Condition{
-						qdrant.NewMatch("tenant", "acme"),
+						qdrant.NewMatch("group_id", "user_1"),
 					},
 				},
 			},

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/http.md
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/http.md
@@ -1,5 +1,5 @@
 ```http
-POST /collections/books/points/query
+POST /collections/{collection_name}/points/query
 {
     "query": {
         "text": "time travel",
@@ -8,7 +8,7 @@ POST /collections/books/points/query
     "using": "title-bm25",
     "filter": {
         "must": [
-            { "key": "tenant", "match": { "value": "acme" } },
+            { "key": "group_id", "match": { "value": "user_1" } },
             { "key": "year", "match": { "value": 2024 } }
         ]
     },
@@ -16,7 +16,7 @@ POST /collections/books/points/query
         "idf": {
             "corpus": {
                 "must": [
-                    { "key": "tenant", "match": { "value": "acme" } }
+                    { "key": "group_id", "match": { "value": "user_1" } }
                 ]
             }
         }

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/java.java
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/java.java
@@ -18,7 +18,7 @@ public class Snippet {
     client
         .queryAsync(
             QueryPoints.newBuilder()
-                .setCollectionName("books")
+                .setCollectionName("{collection_name}")
                 .setQuery(
                     nearest(
                         Document.newBuilder()
@@ -28,7 +28,7 @@ public class Snippet {
                 .setUsing("title-bm25")
                 .setFilter(
                     Filter.newBuilder()
-                        .addMust(matchKeyword("tenant", "acme"))
+                        .addMust(matchKeyword("group_id", "user_1"))
                         .addMust(match("year", 2024))
                         .build())
                 .setParams(
@@ -37,7 +37,7 @@ public class Snippet {
                             IdfParams.newBuilder()
                                 .setCorpus(
                                     Filter.newBuilder()
-                                        .addMust(matchKeyword("tenant", "acme"))
+                                        .addMust(matchKeyword("group_id", "user_1"))
                                         .build())
                                 .build())
                         .build())

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/python.py
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/python.py
@@ -1,18 +1,14 @@
-from qdrant_client import QdrantClient, models
+from qdrant_client import QdrantClient, models  # @hide
 
-client = QdrantClient(
-    url="https://xyz-example.qdrant.io:6333",
-    api_key="<your-api-key>",
-    cloud_inference=True,
-)
+client = QdrantClient(url="http://localhost:6333")  # @hide
 
 client.query_points(
-    collection_name="books",
+    collection_name="{collection_name}",
     query=models.Document(text="time travel", model="qdrant/bm25"),
     using="title-bm25",
     query_filter=models.Filter(
         must=[
-            models.FieldCondition(key="tenant", match=models.MatchValue(value="acme")),
+            models.FieldCondition(key="group_id", match=models.MatchValue(value="user_1")),
             models.FieldCondition(key="year", match=models.MatchValue(value=2024)),
         ]
     ),
@@ -21,7 +17,7 @@ client.query_points(
             corpus=models.Filter(
                 must=[
                     models.FieldCondition(
-                        key="tenant", match=models.MatchValue(value="acme")
+                        key="group_id", match=models.MatchValue(value="user_1")
                     ),
                 ]
             )

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/rust.rs
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/rust.rs
@@ -8,11 +8,11 @@ pub async fn main() -> anyhow::Result<()> {
 
     client
         .query(
-            QueryPointsBuilder::new("books")
+            QueryPointsBuilder::new("{collection_name}")
                 .query(Query::new_nearest(Document::new("time travel", "qdrant/bm25")))
                 .using("title-bm25")
                 .filter(Filter::must([
-                    Condition::matches("tenant", "acme".to_string()),
+                    Condition::matches("group_id", "user_1".to_string()),
                     Condition::matches("year", 2024),
                 ]))
                 .params(SearchParamsBuilder::default().idf(

--- a/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/typescript.ts
+++ b/qdrant-landing/content/documentation/headless/snippets/text-search/query-bm25-idf-corpus/typescript.ts
@@ -2,7 +2,7 @@ import { QdrantClient } from "@qdrant/js-client-rest"; // @hide
 
 const client = new QdrantClient({ host: "localhost", port: 6333 }); // @hide
 
-client.query("books", {
+client.query("{collection_name}", {
   query: {
     text: "time travel",
     model: "qdrant/bm25",
@@ -10,14 +10,14 @@ client.query("books", {
   using: "title-bm25",
   filter: {
     must: [
-      { key: "tenant", match: { value: "acme" } },
+      { key: "group_id", match: { value: "user_1" } },
       { key: "year", match: { value: 2024 } },
     ],
   },
   params: {
     idf: {
       corpus: {
-        must: [{ key: "tenant", match: { value: "acme" } }],
+        must: [{ key: "group_id", match: { value: "user_1" } }],
       },
     },
   },

--- a/qdrant-landing/content/documentation/manage-data/multitenancy.md
+++ b/qdrant-landing/content/documentation/manage-data/multitenancy.md
@@ -49,7 +49,7 @@ Next, insert points with the tenant ID in the payload:
     The key doesn't need to be named <code>group_id</code>. You can choose any name.
 </aside>
 
-Query with a filter on `group_id` to return only one tenant's data:
+Query with a filter on the tenant field (`group_id`) to return only one tenant's data:
 
 {{< code-snippet path="/documentation/headless/snippets/query-points/with-filter-by-group-id/" >}}
 
@@ -96,7 +96,7 @@ This filter is independent of the retrieval filter. The filter that determines t
 
 Instead of filtering tenants by a payload field, another way to separate tenants is to give each tenant its own dedicated shard. Qdrant lets you specify the shard for each point individually, so operations for a tenant only ever touch that tenant's shard. This trades some resource overhead (each shard has its own storage and index structures) for stronger isolation, and works best for a modest number of large tenants.
 
-To use this approach, create a collection with [custom sharding](/documentation/scaling/distributed_deployment/#user-defined-sharding) enabled:
+To use this approach, create a collection with [user-defined sharding](/documentation/scaling/distributed_deployment/#user-defined-sharding) (also known as custom sharding) enabled:
 
 {{< code-snippet path="/documentation/headless/snippets/create-collection/with-custom-sharding/" >}}
 
@@ -137,7 +137,7 @@ There are three components in Qdrant that allow you to implement tiered multiten
 
 ### Configure Tiered Multitenancy
 
-To take advantage of tiered multitenancy, you need to create a collection with user-defined (also known as `custom`) sharding and create a fallback shard in it.
+To take advantage of tiered multitenancy, you need to create a collection with user-defined sharding and create a fallback shard in it.
 
 {{< code-snippet path="/documentation/headless/snippets/create-collection/with-custom-sharding/" >}}
 
@@ -150,7 +150,7 @@ Let's name it `default`.
 
 Similar to creating a collection, set `shards_number` to 1.
 
-Since the collection will allow both dedicated and shared tenants, you still need to configure payload-based tenancy the same way as described in the [Partition by Payload](#partition-by-payload) section. Specifically, create a payload index for the `group_id` field with `is_tenant=true`.
+Since the collection will allow both dedicated and shared tenants, you still need to configure payload-based tenancy the same way as described in the [Partition by Payload](#partition-by-payload) section. Specifically, create a payload index for the tenant field (`group_id` in this example) with `is_tenant=true`.
 
 {{< code-snippet path="/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/" >}}
 
@@ -170,7 +170,7 @@ The routing logic works as follows:
 
 ### Query Tiered Multitenant Collection
 
-When querying points, specify the same shard key selector and filter by tenant key (`group_id` in this example). The tenant filter value must match the `target` shard key.
+When querying points, specify the same shard key selector and filter on the tenant field (`group_id` in this example). The tenant filter value must match the `target` shard key.
 
 {{< code-snippet path="/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/" >}}
 

--- a/qdrant-landing/content/documentation/manage-data/multitenancy.md
+++ b/qdrant-landing/content/documentation/manage-data/multitenancy.md
@@ -141,10 +141,14 @@ To take advantage of tiered multitenancy, you need to create a collection with u
 
 {{< code-snippet path="/documentation/headless/snippets/create-collection/with-custom-sharding/" >}}
 
+Set `shard_number` to 1. Promoting tenants to dedicated shards later can only be done with single shards. Configuring a `replication_factor` greater than 1 is fine.
+
 Start by creating a fallback shard, which will be used to store small tenants.
 Let's name it `default`.
 
 {{< code-snippet path="/documentation/headless/snippets/create-shard/create-named-shard-default/" >}}
+
+Similar to creating a collection, set `shards_number` to 1.
 
 Since the collection will allow both dedicated and shared tenants, you still need to configure payload-based tenancy the same way as described in the [Partition by Payload](#partition-by-payload) section. Specifically, create a payload index for the `group_id` field with `is_tenant=true`.
 
@@ -178,7 +182,7 @@ To do this, first create a new shard for the tenant:
 
 {{< code-snippet path="/documentation/headless/snippets/create-shard/create-named-shard-for-promotion/" >}}
 
-The shard is created in `Partial` state, since it still needs to receive data.
+The shard is created in `Partial` state, since it still needs to receive data. Similar to before, use the collection's default `shards_number` of 1. The `replication_factor` should initially be set to 1 too. You can create replicas after you've replicated the tenant's data to the new shard.
 
 Use the `replicate_points` API to initiate data transfer:
 
@@ -187,9 +191,12 @@ Use the `replicate_points` API to initiate data transfer:
 Once the transfer is complete, the target shard will become `Active`, and all requests for the tenant will be routed to it automatically.
 At this point it's safe to delete the tenant's data from the shared fallback shard to free up space.
 
+You can now [create replicas](/documentation/scaling/distributed_deployment/#creating-new-shard-replicas) for the new shard.
 
 ### Limitations
 
-- The fallback shard is limited to a single shard, though it can still be replicated across nodes for availability. This means all small tenants sharing the fallback shard must fit within the storage and write capacity of a single node. We plan to remove this restriction in a future release.
+- The fallback shard and the dedicated tenant shards must have a `shards_number` of 1. A new dedicated tenant shard also needs to have a `replication_factor` of 1 at creation time. This is because the shard transfer mechanism only works with single shards. If you wish, you can increase the replication factor after the point transfer is complete.
+
+  This means all small tenants sharing the fallback shard must fit within the storage and write capacity of a single shard, and thus that of a single node. The same applies to dedicated tenant shards. We plan to remove this restriction in a future release.
 - Similar to collections, dedicated shards introduce some resource overhead. Don't create more than a thousand dedicated shards per cluster. The recommended threshold for promoting a tenant is the same as the indexing threshold for a single collection, which is approximately 20,000 points.
 

--- a/qdrant-landing/content/documentation/manage-data/multitenancy.md
+++ b/qdrant-landing/content/documentation/manage-data/multitenancy.md
@@ -154,26 +154,25 @@ Since the collection will allow both dedicated and shared tenants, you still nee
 
 {{< code-snippet path="/documentation/headless/snippets/create-payload-index/with-group-id-as-tenant/" >}}
 
-### Query Tiered Multitenant Collection
+### Write to a Tiered Multitenant Collection
 
-Now you can start uploading data into the collection. Unlike basic payload-based multitenancy, you need to specify the **Shard Key Selector** in each request to reach the correct shard.
+Now you can start uploading data into the collection. Specify a **shard key selector** in each request to reach the correct shard. The shard key selector needs to specify two keys:
 
-The Shard Key Selector will specify two keys:
- 
- - `target` shard - name of the tenant's dedicated shard (which may or may not exist).
- - `fallback` shard - name of the shared fallback shard (in this example, `default`).
-
+- `target` shard - name of the tenant's dedicated shard (which may or may not exist).
+- `fallback` shard - name of the shared fallback shard (in this example, `default`).
 
 {{< code-snippet path="/documentation/headless/snippets/insert-points/with-tenant-group-id-and-fallback-shard-key/" >}}
 
-The routing logic will work as follows:
+The routing logic works as follows:
 
-- If the `target` shard exists and is active, the request will be routed to it.
-- If the `target` shard does not exist, the request will be routed to the `fallback` shard.
+- If the `target` shard exists and is active, the request routes to it.
+- If the `target` shard does not exist, the request routes to the `fallback` shard.
 
-Similarly, when querying points, specify the Shard Key Selector and filter by `group_id`.
-The `group_id` filter value must match the `target` shard key.
+### Query Tiered Multitenant Collection
 
+When querying points, specify the same shard key selector and filter by tenant key (`group_id` in this example). The tenant filter value must match the `target` shard key.
+
+{{< code-snippet path="/documentation/headless/snippets/query-points/with-filter-by-group-id-and-fallback-shard-key/" >}}
 
 ### Promote Tenant to Dedicated Shard
 


### PR DESCRIPTION
Several improvements to the multitenancy docs page:

- Provide more details about the `shard_number: 1` tiered multitenancy limitation (https://github.com/qdrant/landing_page/commit/7c02900a4b43a981a94d8d25eeadc9348ad616f7).
- Add a new section about ingesting data into a tiered multitenancy collection and a code snippet for querying (https://github.com/qdrant/landing_page/commit/24564175cee5e741fbd8baf7db34b447eb0e8b19).
- Make all code snippets consistent by using the same tenant field (`group_id`) (https://github.com/qdrant/landing_page/commit/fc7a59016ba542f8502a3ba51d9d1d07ffc1fdb4).
- Hide client initialization from all snippets (https://github.com/qdrant/landing_page/commit/b509f1140fdc2cc825f7be4b5c5cc28a272ab6b1)

@timvisee https://github.com/qdrant/landing_page/commit/7c02900a4b43a981a94d8d25eeadc9348ad616f7 is the commit to review. The rest is fairly trivial.