### PR TITLE
Apply the quote component to Deutsche Telekom, Voiceflow and Pathwork

### DIFF
--- a/qdrant-landing/content/blog/case-study-deutsche-telekom.md
+++ b/qdrant-landing/content/blog/case-study-deutsche-telekom.md
@@ -23,7 +23,12 @@ partition: case-studies
 
 To achieve this, Telekom developed [*Frag Magenta OneBOT*](https://www.telekom.de/hilfe/frag-magenta?samChecked=true) *(Eng: Ask Magenta)*, a platform that includes chatbots and voice bots, built as a Platform as a Service (PaaS) to ensure scalability across Deutsche Telekom's ten European subsidiaries.
 
-"We knew from the start that we couldn't just deploy RAG, tool calling, and workflows at scale without a platform-first approach," Arun explains. "When I looked at the challenge, it looked a lot like a distributed systems and engineering challenge, not just an AI problem."
+{{< quote
+  text="We knew from the start that we couldn't just deploy RAG, tool calling, and workflows at scale without a platform-first approach. When I looked at the challenge, it looked a lot like a distributed systems and engineering challenge, not just an AI problem."
+  name="Arun Joseph"
+  role="Engineering and Architecture, AI Competence Center"
+  company="Deutsche Telekom"
+  featured="true" >}}
 
 ### Key Requirements for Scaling Enterprise AI Agents
 
@@ -71,7 +76,12 @@ LMOS architecture powering AI agent collaboration and lifecycle management in a 
 
 When Deutsche Telekom began searching for a scalable, high-performance vector database, they faced operational challenges with their initial choice. Seeking a solution better suited to their PaaS-first approach and multitenancy requirements, they evaluated alternatives, and [Qdrant](https://qdrant.tech/qdrant-vector-database/) quickly stood out.
 
-"I was looking for open-source components with deep technical expertise behind them," Arun recalls. "I looked at Qdrant and immediately loved the simplicity, [Rust-based efficiency](https://qdrant.tech/articles/why-rust/), and [memory management capabilities](https://qdrant.tech/articles/memory-consumption/). These guys knew what they were doing."
+{{< quote
+  text="I was looking for open-source components with deep technical expertise behind them. I looked at Qdrant and immediately loved the simplicity, [Rust-based efficiency](https://qdrant.tech/articles/why-rust/), and [memory management capabilities](https://qdrant.tech/articles/memory-consumption/). These guys knew what they were doing."
+  name="Arun Joseph"
+  role="Engineering and Architecture, AI Competence Center"
+  company="Deutsche Telekom"
+  logo="/img/customers-case-studies-logo/telekom.svg" >}}
 
 The team structured its evaluation around two key metrics:
 
@@ -86,7 +96,13 @@ Deutsche Telekom's engineers also cited several standout features that made Qdra
 
 As part of their evaluation, Deutsche Telekom engineers compared multiple solutions, weighing operational simplicity and reliability. 
 
-One engineer summarized their findings: "Qdrant has way fewer components, compared to the other solution that required Kafka, Zookeeper, and only had a hot standby for its index and query nodes. If you rescale it, you get downtime. Qdrant stays up." 
+One engineer summarized their findings.
+
+{{< quote
+  text="Qdrant has way fewer components, compared to the other solution that required Kafka, Zookeeper, and only had a hot standby for its index and query nodes. If you rescale it, you get downtime. Qdrant stays up."
+  name="An engineer on the team"
+  role=""
+  company="Deutsche Telekom" >}}
 
 ### Scaling AI at Deutsche Telekom & The Future of LMOS
 
@@ -94,7 +110,11 @@ Today, LMOS with Qdrant serves as the backbone for Deutsche Telekom's AI service
 
 With [LMOS now part of the Eclipse Foundation](https://projects.eclipse.org/projects/technology.lmos), Deutsche Telekom is opening up its platform to the broader AI engineering community. Arun sees a future ecosystem of like-minded developers coalescing around LMOS, Qdrant, and other AI infrastructure components.
 
-"For enterprises looking to build their own AI agent platforms, the future isn't just about AI models — it's about scalable, open, and opinionated infrastructure. And that's exactly what we've built," says Arun Joseph. 
+{{< quote
+  text="For enterprises looking to build their own AI agent platforms, the future isn't just about AI models — it's about scalable, open, and opinionated infrastructure. And that's exactly what we've built."
+  name="Arun Joseph"
+  role="Engineering and Architecture, AI Competence Center"
+  company="Deutsche Telekom" >}}
 
 You can learn more about Deutsche Telekom's AI Agents and Arun's vision for LMOS in his [talk](https://www.infoq.com/presentations/ai-agents-platform%20) at the InfoQ Dev Summit Boston.
 

--- a/qdrant-landing/content/blog/case-study-pathwork.md
+++ b/qdrant-landing/content/blog/case-study-pathwork.md
@@ -42,7 +42,12 @@ Initially, Pathwork explored various solutions, including Amazon S3, OpenSearch,
 
 ### **Why Pathwork Chose Qdrant**
 
-"We landed on Qdrant after extensive trial and error," Blake shared. "Our engineers found Qdrant’s documentation and support significantly better than other solutions. At critical junctures, Qdrant’s support felt like having an additional principal engineer on our team. Fantastic service through their helpdesk was a standout experience."
+{{< quote
+  text="We landed on Qdrant after extensive trial and error. Our engineers found Qdrant’s documentation and support significantly better than other solutions. At critical junctures, Qdrant’s support felt like having an additional principal engineer on our team. Fantastic service through their helpdesk was a standout experience."
+  name="Blake Butterworth"
+  role="Co-Founder"
+  company="Pathwork"
+  logo="/img/customers-case-studies-logo/pathwork.svg" >}}
 
 ### **The Impact: Increased Accuracy and User Adoption**
 
@@ -53,10 +58,18 @@ After implementing Qdrant, Pathwork rapidly saw significant improvements:
 * **Rapid Growth:** Usage has grown 50% month-over-month, with thousands of insurance cases processed in the last month alone. To maintain low-latency retrieval at scale, Pathwork expanded its Qdrant deployment with additional nodes, implemented sharding to distribute load, and introduced replicas to support high-concurrency read operations. These scaling changes ensured consistent performance as usage surged.  
 * **User Satisfaction:** Accurate, consistent underwriting results drove significant user adoption. As accuracy surpassed a critical threshold, word-of-mouth recommendations propelled user growth.
 
-"We knew we'd achieved something significant when brokers began confidently testing edge cases live during demos, resulting in immediate adoption," Blake remarked.
+{{< quote
+  text="We knew we'd achieved something significant when brokers began confidently testing edge cases live during demos, resulting in immediate adoption."
+  name="Blake Butterworth"
+  role="Co-Founder"
+  company="Pathwork" >}}
 
 ### **Looking Ahead**
 
 Pathwork aims to become the central hub for life insurance underwriting. Future plans involve deeper integration with insurance carriers, further enhancing underwriting accuracy, scalability, and efficiency. Pathwork’s commitment to precision, supported by Qdrant’s reliable vector search capabilities, is setting a new industry standard for accuracy and efficiency in life insurance underwriting.
 
-**"Every aspect of our system depends on precision, and Qdrant has been instrumental in achieving our goals," says Blake Butterworth.**
+{{< quote
+  text="Every aspect of our system depends on precision, and Qdrant has been instrumental in achieving our goals."
+  name="Blake Butterworth"
+  role="Co-Founder"
+  company="Pathwork" >}}

--- a/qdrant-landing/content/blog/case-study-voiceflow.md
+++ b/qdrant-landing/content/blog/case-study-voiceflow.md
@@ -25,6 +25,7 @@ partition: case-studies
 {{< quote
   text="Powered by technologies like Natural Language Understanding (NLU), Large Language Models (LLM), and Qdrant as a vector search engine, Voiceflow serves a diverse range of customers, including enterprises that develop chatbots for internal and external AI use cases."
   name="Xavier Portillo Edo"
+  name_url="https://www.linkedin.com/in/xavierportillaedo/"
   role="Head of Cloud Infrastructure"
   company="Voiceflow"
   logo="/img/customers-case-studies-logo/voiceflow.svg"
@@ -54,7 +55,7 @@ The reasons for the switch included:
 
 ## Migration and Onboarding
 
-Voiceflow began its migration to Qdrant by creating [backups](/documentation/cloud/backups/) and ensuring data consistency through random checks and key customer verifications. “Once we were confident in the stability, we transitioned the primary database to Qdrant, completing the migration smoothly,” Linkov explained.
+Voiceflow began its migration to Qdrant by creating [backups](/documentation/cloud/backups/) and ensuring data consistency through random checks and key customer verifications. "Once we were confident in the stability, we transitioned the primary database to Qdrant, completing the migration smoothly," Linkov explained.
 
 During onboarding, Voiceflow transitioned from namespaces to Qdrant's collections, which offer enhanced flexibility and advanced vector search capabilities. They also implemented Quantization to enhance data processing efficiency. This comprehensive process ensured a seamless transition to Qdrant's robust infrastructure.
 

--- a/qdrant-landing/content/blog/case-study-voiceflow.md
+++ b/qdrant-landing/content/blog/case-study-voiceflow.md
@@ -32,7 +32,14 @@ As part of this development, the Voiceflow engineering team was looking for a [v
 - **Metadata**: The capability to tag data and chunks and retrieve based on those values, essential for organizing and accessing specific information swiftly.
 - **Managed Solution**: The availability of a [managed service](/documentation/cloud/) with automated maintenance, scaling, and security, freeing the team from infrastructure concerns.
 
-*"We started with Pinecone but eventually switched to Qdrant,"* Linkov noted. The reasons for the switch included:
+{{< quote
+  text="We started with Pinecone but eventually switched to Qdrant."
+  name="Denys Linkov"
+  role="Machine Learning Team Lead"
+  company="Voiceflow"
+  logo="/img/customers-case-studies-logo/voiceflow.svg" >}}
+
+The reasons for the switch included:
 
 - **Scaling Capabilities**: Qdrant offers a robust multi-node setup with [horizontal scaling](/documentation/cloud/cluster-scaling/), allowing clusters to grow by adding more nodes and distributing data and load among them. This ensures high performance and resilience, which is crucial for handling large-scale projects.
 - **Infrastructure**: “Qdrant provides robust infrastructure support, allowing integration with virtual private clouds on AWS using AWS Private Links and ensuring encryption with AWS KMS. This setup ensures high security and reliability,” says Portillo Edo.
@@ -40,7 +47,11 @@ As part of this development, the Voiceflow engineering team was looking for a [v
 
 ## Migration and Onboarding
 
-Voiceflow began its migration to Qdrant by creating [backups](/documentation/cloud/backups/) and ensuring data consistency through random checks and key customer verifications. "Once we were confident in the stability, we transitioned the primary database to Qdrant, completing the migration smoothly," Linkov explained.
+Voiceflow began its migration to Qdrant by creating [backups](/documentation/cloud/backups/) and ensuring data consistency through random checks and key customer verifications. {{< quote
+  text="Once we were confident in the stability, we transitioned the primary database to Qdrant, completing the migration smoothly."
+  name="Denys Linkov"
+  role="Machine Learning Team Lead"
+  company="Voiceflow" >}}
 
 During onboarding, Voiceflow transitioned from namespaces to Qdrant's collections, which offer enhanced flexibility and advanced vector search capabilities. They also implemented Quantization to enhance data processing efficiency. This comprehensive process ensured a seamless transition to Qdrant's robust infrastructure.
 

--- a/qdrant-landing/content/blog/case-study-voiceflow.md
+++ b/qdrant-landing/content/blog/case-study-voiceflow.md
@@ -20,7 +20,15 @@ partition: case-studies
 ---
 ![voiceflow/image2.png](/blog/case-study-voiceflow/image1.png)
 
-[Voiceflow](https://www.voiceflow.com/) enables enterprises to create AI agents in a no-code environment by designing workflows through a drag-and-drop interface. The platform allows developers to host and customize chatbot interfaces without needing to build their own RAG pipeline, working out of the box and being easily adaptable to specific use cases. “Powered by technologies like Natural Language Understanding (NLU), Large Language Models (LLM), and Qdrant as a vector search engine, Voiceflow serves a diverse range of customers, including enterprises that develop chatbots for internal and external AI use cases,” says [Xavier Portillo Edo](https://www.linkedin.com/in/xavierportillaedo/), Head of Cloud Infrastructure at Voiceflow.
+[Voiceflow](https://www.voiceflow.com/) enables enterprises to create AI agents in a no-code environment by designing workflows through a drag-and-drop interface. The platform allows developers to host and customize chatbot interfaces without needing to build their own RAG pipeline, working out of the box and being easily adaptable to specific use cases.
+
+{{< quote
+  text="Powered by technologies like Natural Language Understanding (NLU), Large Language Models (LLM), and Qdrant as a vector search engine, Voiceflow serves a diverse range of customers, including enterprises that develop chatbots for internal and external AI use cases."
+  name="Xavier Portillo Edo"
+  role="Head of Cloud Infrastructure"
+  company="Voiceflow"
+  logo="/img/customers-case-studies-logo/voiceflow.svg"
+  featured="true" >}}
 
 ## Evaluation Criteria
 
@@ -36,8 +44,7 @@ As part of this development, the Voiceflow engineering team was looking for a [v
   text="We started with Pinecone but eventually switched to Qdrant."
   name="Denys Linkov"
   role="Machine Learning Team Lead"
-  company="Voiceflow"
-  logo="/img/customers-case-studies-logo/voiceflow.svg" >}}
+  company="Voiceflow" >}}
 
 The reasons for the switch included:
 
@@ -47,11 +54,7 @@ The reasons for the switch included:
 
 ## Migration and Onboarding
 
-Voiceflow began its migration to Qdrant by creating [backups](/documentation/cloud/backups/) and ensuring data consistency through random checks and key customer verifications. {{< quote
-  text="Once we were confident in the stability, we transitioned the primary database to Qdrant, completing the migration smoothly."
-  name="Denys Linkov"
-  role="Machine Learning Team Lead"
-  company="Voiceflow" >}}
+Voiceflow began its migration to Qdrant by creating [backups](/documentation/cloud/backups/) and ensuring data consistency through random checks and key customer verifications. “Once we were confident in the stability, we transitioned the primary database to Qdrant, completing the migration smoothly,” Linkov explained.
 
 During onboarding, Voiceflow transitioned from namespaces to Qdrant's collections, which offer enhanced flexibility and advanced vector search capabilities. They also implemented Quantization to enhance data processing efficiency. This comprehensive process ensured a seamless transition to Qdrant's robust infrastructure.
 
@@ -82,7 +85,13 @@ Voiceflow leverages Qdrant's robust features and infrastructure to optimize thei
 
 *Infrastructure:*
 
-- **Private Link**: The ability to use Private Link connections across different instances is a significant advantage, requiring robust infrastructure support from Qdrant. "This setup was crucial for SOC2 compliance, and Qdrant's support team made the process seamless by ensuring feasibility and aiding in the implementation," Linkov explained.
+- **Private Link**: The ability to use Private Link connections across different instances is a significant advantage, requiring robust infrastructure support from Qdrant.
+
+{{< quote
+  text="This setup was crucial for SOC2 compliance, and Qdrant's support team made the process seamless by ensuring feasibility and aiding in the implementation."
+  name="Denys Linkov"
+  role="Machine Learning Team Lead"
+  company="Voiceflow" >}}
 
 By utilizing these features, Voiceflow ensures that its platform is scalable, secure, and efficient, meeting the diverse needs of its users.
 


### PR DESCRIPTION
Follows #2648. Three more case studies get the quote component — nine cards, all verbatim.

| Case study | Cards | Marked out |
|---|---|---|
| Deutsche Telekom | 4 | "I looked at Qdrant and immediately loved the simplicity, Rust-based efficiency, and memory management capabilities. These guys knew what they were doing." |
| Voiceflow | 2 | "We started with Pinecone but eventually switched to Qdrant." |
| Pathwork | 3 | "We landed on Qdrant after extensive trial and error… Qdrant's support felt like having an additional principal engineer on our team." |

Also lifted: Deutsche Telekom's comparison against the alternative stack — *"Qdrant has way fewer components, compared to the other solution that required Kafka, Zookeeper… If you rescale it, you get downtime. Qdrant stays up."*

## Judgement calls worth a look

**Deutsche Telekom makes the same point three times.** "This is a distributed systems problem, not an AI problem" appears in three separate quotes in near-identical words. Only the first is a card; the other two stay as prose, so the article doesn't shout the same line three times.

**One quote is anonymous in the original** — "One engineer summarized their findings". The card attributes it to `An engineer on the team` rather than inventing a name. It reads a little oddly in the name slot, so say if you'd rather it stayed inline.

**Voiceflow only gets two cards.** Its best remaining quotes — "The Qdrant team is very responsive, ships features quickly and is a great partner to build with", and the SOC2 / Private Link one — all sit inside bullet lists. Lifting those restructures the list, which is a layout decision rather than a mechanical one. Sprinklr has three in the same position. That's seven quotes waiting on one decision, and it will keep recurring.

## Quotes are reproduced exactly

Where the original splits a quotation across an attribution tag — `"A," said X. "B."` — both halves go in the same card, since that is one statement interrupted by the tag. The tag goes and the comma that introduced it becomes a period. No words change, and each half is checked against the original either side of the join.
