### PR TITLE
Warn against using inline storage in the pinned/cached tiers

### DIFF
--- a/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
+++ b/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
@@ -124,7 +124,9 @@ On-disk retrieval benefits from fast, local storage. If you're self hosting Qdra
 
 *Available as of v1.16.0*
 
-Avoid putting the HNSW vector index in the `cold` tier. If you must store it on disk and use quantization, consider enabling [inline storage](/documentation/ops-optimization/optimize/#inline-storage-in-hnsw-index). This reduces I/O operations at the cost of three to four times more disk usage.
+Avoid putting the HNSW vector index in the `cold` tier. If you must store it on disk and use quantization, consider enabling [inline storage](/documentation/ops-optimization/optimize/#inline-storage-in-hnsw-index). This reduces I/O operations at the cost of more disk usage.
+
+Enabling inline storage can significantly increase the size of the HNSW index. Do not use inline storage if the HNSW index is in RAM ([`pinned` or `cached` tiers](/documentation/ops-configuration/memory-tiers/)). To reduce the index size, apply a quantization method [with at least 8x compression](/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method), such as TurboQuant.
 
 ## Legacy Settings
 

--- a/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
+++ b/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
@@ -126,7 +126,7 @@ On-disk retrieval benefits from fast, local storage. If you're self hosting Qdra
 
 Avoid putting the HNSW vector index in the `cold` tier. If you must store it on disk and use quantization, consider enabling [inline storage](/documentation/ops-optimization/optimize/#inline-storage-in-hnsw-index). This reduces I/O operations at the cost of more disk usage.
 
-Enabling inline storage can significantly increase the size of the HNSW index. Do not use inline storage if the HNSW index is in RAM ([`pinned` or `cached` tiers](/documentation/ops-configuration/memory-tiers/)). To reduce the index size, apply a quantization method [with at max 4-bits compressed representations](/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method), such as TurboQuant.
+Enabling inline storage can significantly increase the size of the HNSW index. Do not use inline storage if the HNSW index is in RAM ([`pinned` or `cached` tiers](/documentation/ops-configuration/memory-tiers/)). To keep the index size to roughly 3–6 times the original float32 vectors, apply a quantization method [that compresses to at most 4 bits per dimension](/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method), such as TurboQuant.
 
 ## Legacy Settings
 

--- a/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
+++ b/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
@@ -126,7 +126,7 @@ On-disk retrieval benefits from fast, local storage. If you're self hosting Qdra
 
 Avoid putting the HNSW vector index in the `cold` tier. If you must store it on disk and use quantization, consider enabling [inline storage](/documentation/ops-optimization/optimize/#inline-storage-in-hnsw-index). This reduces I/O operations at the cost of more disk usage.
 
-Enabling inline storage can significantly increase the size of the HNSW index. Do not use inline storage if the HNSW index is in RAM ([`pinned` or `cached` tiers](/documentation/ops-configuration/memory-tiers/)). To reduce the index size, apply a quantization method [with at least 8x compression](/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method), such as TurboQuant.
+Enabling inline storage can significantly increase the size of the HNSW index. Do not use inline storage if the HNSW index is in RAM ([`pinned` or `cached` tiers](/documentation/ops-configuration/memory-tiers/)). To reduce the index size, apply a quantization method [with at max 4-bits compressed representations](/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method), such as TurboQuant.
 
 ## Legacy Settings
 

--- a/qdrant-landing/content/documentation/ops-optimization/optimize.md
+++ b/qdrant-landing/content/documentation/ops-optimization/optimize.md
@@ -75,10 +75,14 @@ You can use [fio](https://gist.github.com/superboum/aaa45d305700a7873a8ebbab1abd
 
 *Available as of v1.16.0*
 
+<aside role="alert">
+Inline storage can increase the HNSW index size by orders of magnitude. Only use it when the HNSW index is in the <a href="/documentation/ops-configuration/memory-tiers/"><code>cold</code> memory tier</a>. To reduce the index size, apply a quantization method <a href="/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method">with at least 8x compression</a>, such as TurboQuant.
+</aside>
+
 When vectors and the HNSW index are in the `cold` memory tier, you can improve search performance by enabling the `inline_storage` option in the `hnsw_config`.
 With inline storage, Qdrant stores copies of vectors directly within the HNSW index file.
-It makes searches faster by reducing the number of IO operations, at the cost of 3-4x increased storage usage.
-It requires quantization to be enabled.
+It makes searches faster by reducing the number of IO operations, at the cost of increased storage usage.
+To enable inline storage, quantization must be enabled.
 
 {{< code-snippet path="/documentation/headless/snippets/create-collection/with-inline-storage/" >}}
 

--- a/qdrant-landing/content/documentation/ops-optimization/optimize.md
+++ b/qdrant-landing/content/documentation/ops-optimization/optimize.md
@@ -76,7 +76,7 @@ You can use [fio](https://gist.github.com/superboum/aaa45d305700a7873a8ebbab1abd
 *Available as of v1.16.0*
 
 <aside role="alert">
-Inline storage can increase the HNSW index size by orders of magnitude. Only use it when the HNSW index is in the <a href="/documentation/ops-configuration/memory-tiers/"><code>cold</code> memory tier</a>. To reduce the index size, apply a quantization method <a href="/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method">with at least 8x compression</a>, such as TurboQuant.
+Inline storage can increase the HNSW index size significantly. Only use it when the HNSW index is in the <a href="/documentation/ops-configuration/memory-tiers/"><code>cold</code> memory tier</a>. To reduce the index size, apply a quantization method <a href="/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method">with at max 4-bit quantized representations</a>, such as TurboQuant.
 </aside>
 
 When vectors and the HNSW index are in the `cold` memory tier, you can improve search performance by enabling the `inline_storage` option in the `hnsw_config`.

--- a/qdrant-landing/content/documentation/ops-optimization/optimize.md
+++ b/qdrant-landing/content/documentation/ops-optimization/optimize.md
@@ -76,7 +76,7 @@ You can use [fio](https://gist.github.com/superboum/aaa45d305700a7873a8ebbab1abd
 *Available as of v1.16.0*
 
 <aside role="alert">
-Inline storage can increase the HNSW index size significantly. Only use it when the HNSW index is in the <a href="/documentation/ops-configuration/memory-tiers/"><code>cold</code> memory tier</a>. To reduce the index size, apply a quantization method <a href="/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method">with at max 4-bit quantized representations</a>, such as TurboQuant.
+Inline storage can increase the HNSW index size significantly. Only use it when the HNSW index is in the <a href="/documentation/ops-configuration/memory-tiers/"><code>cold</code> memory tier</a>. To keep the index size to roughly 3–6 times the original float32 vectors, apply a quantization method <a href="/documentation/manage-data/quantization/#how-to-choose-the-right-quantization-method">that compresses to at most 4 bits per dimension</a>, such as TurboQuant.
 </aside>
 
 When vectors and the HNSW index are in the `cold` memory tier, you can improve search performance by enabling the `inline_storage` option in the `hnsw_config`.


### PR DESCRIPTION
Previews: [1](https://deploy-preview-2675--condescending-goldwasser-91acf0.netlify.app/documentation/ops-optimization/optimize/#inline-storage-in-hnsw-index) and [2](https://deploy-preview-2675--condescending-goldwasser-91acf0.netlify.app/documentation/ops-configuration/memory-tiers/#inline-storage)

This PR adds 
- a warning against using inline storage in the pinned/cached tiers
- a recommendation to use a quantization method that compresses at least 8x