### PR TITLE
Add documentation for the slow request log

### DIFF
--- a/qdrant-landing/content/documentation/faq/database-optimization.md
+++ b/qdrant-landing/content/documentation/faq/database-optimization.md
@@ -56,3 +56,5 @@ There are several possible reasons for that:
 - **Using filters without payload index** -- If you're performing a search with a filter but you don't have a payload index, Qdrant will have to load whole payload data from disk to check the filtering condition. Ensure you have adequately configured [payload indexes](/documentation/manage-data/indexing/#payload-index).
 - **Usage of on-disk vector storage with slow disks** -- If you're using on-disk vector storage, ensure you have fast enough disks. We recommend using local SSDs with at least 50k IOPS. Read more about the influence of the disk speed on the search latency in the article about [Memory Consumption](/articles/memory-consumption/).
 - **Large limit or non-optimal query parameters** -- A large limit or offset might lead to significant performance degradation. Please pay close attention to the query/collection parameters that significantly diverge from the defaults. They might be the reason for the performance issues.
+
+To identify which specific requests are slow, use the [Slow Request Log](/documentation/ops-monitoring/slow-request-log/).

--- a/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
+++ b/qdrant-landing/content/documentation/faq/qdrant-fundamentals.md
@@ -120,7 +120,7 @@ For best results, create payload indexes **before** uploading data. When uploadi
 
 To prevent clients from filtering on payload fields that don't have a payload index, enable strict mode and [set unindexed\_filtering\_retrieve to false](/documentation/ops-configuration/administration/#disable-retrieving-via-non-indexed-payload).
 
-See also: [Indexing](/documentation/manage-data/indexing/), [Low-Latency Search](/documentation/search/low-latency-search/)
+See also: [Indexing](/documentation/manage-data/indexing/), [Low-Latency Search](/documentation/search/low-latency-search/), [Slow Request Log](/documentation/ops-monitoring/slow-request-log/)
 
 ### Does Qdrant support a full-text search or a hybrid search?
 

--- a/qdrant-landing/content/documentation/ops-monitoring/_index.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring & Telemetry
-short_description: "Monitor Qdrant deployments with built-in metrics endpoints and Prometheus and Grafana stacks for self-hosted, Hybrid, and Managed Cloud."
-description: "Monitor Qdrant with Prometheus and Grafana using built-in OpenMetrics endpoints, with setup guides for Managed Cloud, Hybrid Cloud, and self-hosted clusters."
+short_description: "Monitor Qdrant deployments with built-in metrics endpoints, Prometheus and Grafana integrations, and built-in tools for diagnosing memory usage and slow requests."
+description: "Monitor Qdrant with Prometheus and Grafana using built-in OpenMetrics endpoints, with setup guides for Managed Cloud, Hybrid Cloud, and self-hosted clusters. Also covers monitoring collection memory usage and identifying slow requests with the built-in slow request log."
 weight: 148
 partition: deploy
 ---
@@ -13,6 +13,14 @@ These pages cover how to observe and measure a running Qdrant deployment using i
 ## Monitoring & Telemetry
 
 [Monitoring & Telemetry](/documentation/ops-monitoring/monitoring/) describes the Prometheus/OpenMetrics-compatible `/metrics` endpoint, the available metrics, and how to connect Qdrant to a Prometheus and Grafana monitoring stack.
+
+## Memory Usage
+
+[Memory Usage](/documentation/ops-monitoring/memory-usage/) explains how to inspect a collection's disk space, RAM, and OS page cache usage across the cluster, broken down by component. Use it to plan capacity and diagnose memory pressure.
+
+## Slow Request Log
+
+[Slow Request Log](/documentation/ops-monitoring/slow-request-log/) describes Qdrant's built-in in-memory log of the slowest unique requests since startup. Use it to identify which queries are responsible for high latency.
 
 ## Managed Cloud Prometheus Monitoring
 

--- a/qdrant-landing/content/documentation/ops-monitoring/memory-usage.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/memory-usage.md
@@ -1,5 +1,7 @@
 ---
 title: Memory Usage
+short_description: "Inspect disk space, RAM, and OS page cache usage for a Qdrant collection across the cluster, broken down by component."
+description: "Use the Qdrant Web UI or API to monitor a collection's disk, RAM, and page cache consumption across the cluster and per component, to plan capacity and diagnose memory pressure."
 weight: 7
 ---
 

--- a/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
@@ -1,0 +1,63 @@
+---
+title: Slow Request Log
+weight: 9
+---
+
+# Slow Request Log
+
+The slow request log records the slowest unique operations on a node since startup. Use it to identify which queries are responsible for high latency.
+
+The log keeps up to 32 entries per request type. Entries are deduplicated by a content hash of the request body and collection name, so repeated identical requests don't fill the log with duplicates. The log keeps count of the number of times each request pattern has been seen. When the queue for a request type is full, a new entry replaces the current fastest entry only if it took longer.
+
+The log is in-memory only and it resets when the server restarts. The only way to read the log is [through the REST endpoint](#reading-the-log). After a deploy or configuration change, restart the server to get a clean baseline.
+
+The log is per-node. Each node tracks operations on its own local shards. Querying the log on one node returns only that node's data. To get a complete picture of slow requests across a cluster, query each node separately and aggregate the results.
+
+The Slow Request Log is enabled by default and cannot be disabled.
+
+## What Gets Captured
+
+The log records shard-level operations that take longer than 50 ms. The following operation types are tracked:
+
+- `core_search` and `query_batch`
+- `count`
+- `retrieve`
+- `facet`
+- Write operations such as upsert and delete
+
+## Reading the Log
+
+`GET /profiler/slow_requests` returns the current state of the log. The endpoint requires `manage` access and is available as a REST API only.
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `limit` | 10 | Maximum number of entries to return. |
+| `request` | — | Substring filter on request type. For example, `search` returns only search operations. |
+
+```bash
+# Top 10 slowest requests across all types
+curl http://YOUR_NODE_URL:6333/profiler/slow_requests \
+  -H "api-key: <your-key>"
+
+# Top 20 slowest search requests only
+curl "http://YOUR_NODE_URL:6333/profiler/slow_requests?limit=20&request=search" \
+  -H "api-key: <your-key>"
+```
+
+## Response Fields
+
+Each entry in the response includes the following fields:
+
+| Field | Description |
+|-------|-------------|
+| `collection_name` | The collection the request ran against. |
+| `duration` | Request duration in seconds. |
+| `datetime` | Timestamp of the request. |
+| `request_name` | Operation type, for example `core_search`. |
+| `approx_count` | Approximate number of times this request pattern was seen since startup. |
+| `cpu_usage_ratio` | CPU utilization during the request (optional). |
+| `request_body` | The full request as JSON. |
+
+Results are sorted slowest-first, then truncated to `limit`.

--- a/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
@@ -7,7 +7,7 @@ weight: 9
 
 # Slow Request Log
 
-*Available as of v1.16.0*
+*Available as of v1.16.0 (beta). Behavior may change in future releases.*
 
 The slow request log records the slowest unique operations on a node since startup. Use it to identify which queries are responsible for high latency.
 

--- a/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
@@ -7,6 +7,8 @@ weight: 9
 
 # Slow Request Log
 
+*Available as of v1.16.0*
+
 The slow request log records the slowest unique operations on a node since startup. Use it to identify which queries are responsible for high latency.
 
 The log keeps up to 32 entries per request type. Entries are deduplicated by a content hash of the request body and collection name, so repeated identical requests don't fill the log with duplicates. The log keeps count of the number of times each request pattern has been seen. When the queue for a request type is full, a new entry replaces the current fastest entry only if it took longer.

--- a/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
+++ b/qdrant-landing/content/documentation/ops-monitoring/slow-request-log.md
@@ -1,5 +1,7 @@
 ---
 title: Slow Request Log
+short_description: "Identify the slowest queries in your Qdrant deployment with the built-in slow request log, which records the slowest unique operations on each node since startup."
+description: "Use the Slow Request Log REST endpoint to find which queries are responsible for high latency, with per-request-type breakdowns, deduplication by request content, and approximate occurrence counts."
 weight: 9
 ---
 

--- a/qdrant-landing/content/documentation/search/low-latency-search.md
+++ b/qdrant-landing/content/documentation/search/low-latency-search.md
@@ -89,3 +89,7 @@ Set the <code>wait</code> parameter to <code>false</code> on write requests when
 *Available as of v1.19.0*
 
 Enabling `prevent_unoptimized` makes cross-replica "blinking" more prominent: points held back until a segment is optimized become visible on each replica at slightly different times, and because reads are spread across replicas, successive requests for the same query can land on different replicas and see a point appear, disappear, then reappear. To keep reads stable for a given client, send the `X-Qdrant-Route-Affinity` HTTP header with a stable value (such as a user or session ID) to pin all of that client's reads to the same replica, without giving up load balancing across other clients. Refer to [Read Affinity](/documentation/scaling/consistency-guarantees/#read-affinity) for details.
+
+## See Also
+
+- [Slow Request Log](/documentation/ops-monitoring/slow-request-log/) — Identify which specific queries are contributing to high latency.


### PR DESCRIPTION
[Preview](https://deploy-preview-2676--condescending-goldwasser-91acf0.netlify.app/documentation/ops-monitoring/slow-request-log/)

Adds documentation for the slow request log to the Monitoring section.

Also adds links to the new page from the FAQ and low latency search docs.