### PR TITLE
Link the two Dust case studies to each other

### DIFF
--- a/qdrant-landing/content/blog/case-study-dust-v2.md
+++ b/qdrant-landing/content/blog/case-study-dust-v2.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ![How Dust Scaled to 5,000+ Data Sources with Qdrant](/blog/case-study-dust-v2/case-study-dust-v2-v2-bento-dark.jpg)
 
+We first wrote about Dust in 2024, in [Dust and Qdrant: Using AI to Unlock Company Knowledge and Drive Employee Productivity](/blog/dust-and-qdrant/). This is what came next.
+
 ### The Challenge: Scaling AI Infrastructure for Thousands of Data Sources
 
 Dust, an OS for AI-native companies enabling users to build AI agents powered by actions and company knowledge, faced a set of growing technical hurdles as it scaled its operations. The company's core product enables users to give AI agents secure access to internal and external data resources, enabling enhanced workflows and faster access to information. However, this mission hit bottlenecks when their infrastructure began to strain under the weight of thousands of data sources and increasingly demanding user queries.

--- a/qdrant-landing/content/blog/case-study-dust.md
+++ b/qdrant-landing/content/blog/case-study-dust.md
@@ -14,6 +14,8 @@ tags:
 weight: 0 
 ---
 
+*This is Dust’s story as it stood in 2024. For how they scaled to 5,000+ data sources and brought search latency under a second, read [How Dust Scaled to 5,000+ Data Sources with Qdrant](/blog/case-study-dust-v2/).*
+
 One of the major promises of artificial intelligence is its potential to
 accelerate efficiency and productivity within businesses, empowering employees
 and teams in their daily tasks. The French company [Dust](https://dust.tt/), co-founded by former
@@ -123,8 +125,6 @@ choice for companies to execute on their internal GenAI strategy, unlocking
 company knowledge and driving team productivity. Over the coming months, Dust
 will add more connections, such as Intercom, Jira, or Salesforce. Additionally,
 Dust will expand on its structured data capabilities.
-
-Dust has since grown well past this. [How Dust Scaled to 5,000+ Data Sources with Qdrant](/blog/case-study-dust-v2/) picks the story up in 2025, when they consolidated thousands of collections and brought search latency under a second.
 
 To learn more about how Dust uses Qdrant to help employees in their day to day
 tasks, check out our [Vector Space Talk](https://www.youtube.com/watch?v=toIgkJuysQ4) featuring Stanislas Polu, Co-Founder of Dust.

--- a/qdrant-landing/content/blog/case-study-dust.md
+++ b/qdrant-landing/content/blog/case-study-dust.md
@@ -14,7 +14,7 @@ tags:
 weight: 0 
 ---
 
-*This is Dust’s story as it stood in 2024. For how they scaled to 5,000+ data sources and brought search latency under a second, read [How Dust Scaled to 5,000+ Data Sources with Qdrant](/blog/case-study-dust-v2/).*
+*This is Dust’s story as it stood in 2024. For how they scaled further, read [How Dust Scaled to 5,000+ Data Sources with Qdrant](/blog/case-study-dust-v2/).*
 
 One of the major promises of artificial intelligence is its potential to
 accelerate efficiency and productivity within businesses, empowering employees

--- a/qdrant-landing/content/blog/case-study-dust.md
+++ b/qdrant-landing/content/blog/case-study-dust.md
@@ -124,6 +124,8 @@ company knowledge and driving team productivity. Over the coming months, Dust
 will add more connections, such as Intercom, Jira, or Salesforce. Additionally,
 Dust will expand on its structured data capabilities.
 
+Dust has since grown well past this. [How Dust Scaled to 5,000+ Data Sources with Qdrant](/blog/case-study-dust-v2/) picks the story up in 2025, when they consolidated thousands of collections and brought search latency under a second.
+
 To learn more about how Dust uses Qdrant to help employees in their day to day
 tasks, check out our [Vector Space Talk](https://www.youtube.com/watch?v=toIgkJuysQ4) featuring Stanislas Polu, Co-Founder of Dust.
 


### PR DESCRIPTION
There are two Dust case studies, 15 months apart, and neither mentioned the other:

| | Published | |
|---|---|---|
| [Dust and Qdrant: Using AI to Unlock Company Knowledge…](https://qdrant.tech/blog/dust-and-qdrant/) | Feb 2024 | the original story |
| [How Dust Scaled to 5,000+ Data Sources with Qdrant](https://qdrant.tech/blog/case-study-dust-v2/) | Apr 2025 | what happened next |

They are also reached from different places, which is how the gap went unnoticed:

- the customers catalog (`clients/_index.md`) points at the **2025** one, so filtering or searching on `/customers/` lands you there
- a "Read Story" card in `customers/case-studies-2.md` and the RAG use-cases page point at the **2024** one

So a reader arriving from the customers page card reads 2024-era numbers with no signal that Dust has since consolidated thousands of collections and scaled past 5,000 data sources.

The 2024 article now points forward, placed in its Outlook section, which already looks ahead to what Dust would build next. The 2025 article points back before its first section, for anyone who wants the origin story.

## Worth deciding separately

Should the legacy "Read Story" card and the RAG use-cases page be repointed at the 2025 article, or is the older story the right one in those contexts? That is a content call rather than a fix, so it is not in this PR.
