### PR TITLE
Migration guidance for memory tiers

### DIFF
--- a/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
+++ b/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
@@ -128,7 +128,7 @@ Avoid putting the HNSW vector index in the `cold` tier. If you must store it on 
 
 ## Migrating
 
-When migrating from a pre-1.19 version to a newer version, Qdrant doesn't automatically convert any [legacy settings](#legacy-settings) that control memory placement to the new `memory` setting. The legacy settings have only been deprecated, not removed, so you can continue to use them. A pre-1.19 collection with legacy settings will continue to work on newer versions without having to change its configuration.
+When migrating from a pre-1.19 version to a newer version, Qdrant doesn't automatically convert any [legacy settings](#legacy-settings) that control memory placement to the new `memory` setting. The legacy settings have only been deprecated, not removed, so your existing settings remain working. A pre-1.19 collection with legacy settings will continue to work on newer versions without having to change its configuration.
 
 ### Legacy Settings
 

--- a/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
+++ b/qdrant-landing/content/documentation/ops-configuration/memory-tiers.md
@@ -126,11 +126,15 @@ On-disk retrieval benefits from fast, local storage. If you're self hosting Qdra
 
 Avoid putting the HNSW vector index in the `cold` tier. If you must store it on disk and use quantization, consider enabling [inline storage](/documentation/ops-optimization/optimize/#inline-storage-in-hnsw-index). This reduces I/O operations at the cost of three to four times more disk usage.
 
-## Legacy Settings
+## Migrating
 
-Before version 1.19, memory placement was controlled by a different set of parameters. These parameters are deprecated. If you're on a version older than 1.19, you can use the following tables to map the new `memory` parameter to the legacy parameters.
+When migrating from a pre-1.19 version to a newer version, Qdrant doesn't automatically convert any [legacy settings](#legacy-settings) that control memory placement to the new `memory` setting. The legacy settings have only been deprecated, not removed, so you can continue to use them. A pre-1.19 collection with legacy settings will continue to work on newer versions without having to change its configuration.
 
-### Dense Vectors
+### Legacy Settings
+
+Before version 1.19, memory placement was controlled by a different set of parameters. These parameters are deprecated. Use the following tables to map the new `memory` parameter to the legacy parameters.
+
+#### Dense Vectors
 
 The legacy parameter is `on_disk`.
 
@@ -139,7 +143,7 @@ The legacy parameter is `on_disk`.
 | `cached` | `on_disk: false` |
 | `cold` | `on_disk: true` |
 
-### HNSW Vector Index
+#### HNSW Vector Index
 
 The legacy parameter is `on_disk`, set in `hnsw_config`.
 
@@ -149,7 +153,7 @@ The legacy parameter is `on_disk`, set in `hnsw_config`.
 | `cached` | `on_disk: false` |
 | `cold` | `on_disk: true` |
 
-### Quantized Vectors
+#### Quantized Vectors
 
 The legacy parameter is `always_ram`. `always_ram: true` always resolves to `pinned`. Otherwise, quantized vectors inherit the original vectors' placement: `pinned` if the vectors are in RAM, `cold` if they're on disk.
 
@@ -159,7 +163,7 @@ The legacy parameter is `always_ram`. `always_ram: true` always resolves to `pin
 | `cached` | No legacy equivalent |
 | `cold` | Inherited from the original vectors |
 
-### Sparse Vector Index
+#### Sparse Vector Index
 
 The legacy parameter is `on_disk`.
 
@@ -169,7 +173,7 @@ The legacy parameter is `on_disk`.
 | `cached` | No legacy equivalent |
 | `cold` | `on_disk: true` |
 
-### Payloads
+#### Payloads
 
 The legacy parameter is `on_disk_payload`, set on the collection.
 
@@ -178,7 +182,7 @@ The legacy parameter is `on_disk_payload`, set on the collection.
 | `cached` | `on_disk_payload: false` |
 | `cold` | `on_disk_payload: true` |
 
-### Payload Indexes
+#### Payload Indexes
 
 The legacy parameter is `on_disk`, set on each field index.
 


### PR DESCRIPTION
[Preview](https://deploy-preview-2682--condescending-goldwasser-91acf0.netlify.app/documentation/ops-configuration/memory-tiers/#migrating)

Adds a clarification to the memory tiers documentation that explains that no configuration change is needed to migrate a pre-1.19 collection to newer versions.