### PR TITLE
Update top banner for the 10B document benchmarking dataset launch

### DIFF
--- a/qdrant-landing/content/headless/top-banner.md
+++ b/qdrant-landing/content/headless/top-banner.md
@@ -10,12 +10,12 @@ icon: <svg width="16" height="16" viewBox="0 0 16 16" fill="none"
   7.86204 15.74L14.5287 7.07333C14.6834 6.87199 14.71 6.59999 14.598 6.37199Z"
   fill="#8547FF"/></g><defs><clipPath id="clip0_770_2716"><rect width="16"
   height="16" fill="white"/></clipPath></defs></svg>
-text: "Qdrant 1.19 - TurboQuant Datatype & Memory Tiers"
+text: "We built the benchmark the industry was missing: 10 billion documents, with ground truth."
 link:
-  text: Read more
-  url: https://qdrant.tech/blog/qdrant-1.19.x/
-start: 2026-08-06T11:50:00.000Z
+  text: Read how we did it
+  url: https://qdrant.tech/blog/supernova-release
+start: 2026-09-01T12:00:00.000Z
 sitemapExclude: true
-end: 2026-08-30T14:00:00.000Z
+end: 2026-09-03T12:00:00.000Z
 
 ---


### PR DESCRIPTION
Sets the site top banner for the 10 billion document benchmarking dataset launch.

**Live window:** September 1, 2026 8:00 AM EST to September 3, 2026 8:00 AM EST (`2026-09-01T12:00:00.000Z` to `2026-09-03T12:00:00.000Z`).

**Copy**

> We built the benchmark the industry was missing: 10 billion documents, with ground truth. [Read how we did it](https://qdrant.tech/blog/qdrant-fineweb-10b-release/)

This leans into the reframing from the August 31 launch check-in: the story is the industry-wide benchmarking gap and a community resource, not our own infrastructure work. Someone closer to the data should sanity check the "the industry was missing" claim before this goes live.

### One thing to resolve before merge

**Start time vs. publish time.** The war room plan has Hugging Face assets going public at 8:30 AM EST and the blog post at 8:45 AM EST. This banner starts at 8:00, so the link would 404 for 45 minutes. Suggest moving `start` to `2026-09-01T12:45:00.000Z` unless the blog lands earlier.

### Alternates considered

Same link in every case, in case the team wants to swap.

| Banner text | Link text |
|---|---|
| We released a 10 billion document benchmarking dataset and ground truth queries. | Read the announcement |
| A 10 billion document dataset with ground truth queries, free for anyone benchmarking search. | Read the announcement |
| Vector search benchmarks stop at a million vectors. Ours has 10 billion documents. | See the dataset |
| New: 10 billion documents and ground truth queries, open for the whole search community. | Read the announcement |
| 10 billion documents. Real ground truth queries. Yours to benchmark against. | Get the dataset |
