### PR TITLE
otel tutorial: fix the restore timeout, source the latency claim, close the coverage gaps

### DIFF
--- a/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
+++ b/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
@@ -470,13 +470,154 @@ Change the `exporters` block. Endpoint and an auth header are all that differ.
 
 Confirm the endpoint and header against your vendor's own OTLP documentation before you rely on a row. This tutorial was verified end to end against `grafana/otel-lgtm` only.
 
+## Run the collector in Kubernetes
+
+Compose is the fastest way to see the bridge work, but production usually means running the collector inside your own cluster. Nothing about the scrape configuration changes. You reuse the same `otelcol-config.yaml` from Step 2 and wrap it in Kubernetes objects, with the API key coming from a secret instead of a `.env` file.
+
+### Plain manifests
+
+This path assumes no operators and no custom resources. Create the namespace, the secret, and the config map from the file you already have:
+
+```bash
+kubectl create namespace observability
+
+kubectl -n observability create secret generic qdrant-cluster-api-key \
+  --from-literal=apiKey="$QDRANT_API_KEY"
+
+kubectl -n observability create configmap otelcol-config \
+  --from-file=config.yaml=otelcol-config.yaml
+```
+
+In your copy of `otelcol-config.yaml`, point the exporter at an endpoint the cluster can reach, then apply the deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otelcol
+          image: otel/opentelemetry-collector-contrib:0.158.0
+          args: ["--config=/etc/otelcol/config.yaml"]
+          env:
+            # Hostname only. No scheme, no port, no trailing slash.
+            - name: QDRANT_HOST
+              value: "<cluster-id>.<region>.<provider>.cloud.qdrant.io"
+            - name: QDRANT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: qdrant-cluster-api-key
+                  key: apiKey
+          ports:
+            - containerPort: 4317
+            - containerPort: 4318
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: otelcol-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: observability
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+```
+
+Point your application's `OTEL_EXPORTER_OTLP_ENDPOINT` at `http://otel-collector.observability:4318`, then confirm both jobs are scraping:
+
+```bash
+kubectl -n observability logs -f deploy/otel-collector
+```
+
+Two alternating scrapes means both jobs work, one per endpoint:
+
+```text
+Metrics ... "metrics": 109, "data points": 1809    <- /sys_metrics
+Metrics ... "metrics": 60,  "data points": 866     <- /metrics
+```
+
+Add the `debug` exporter with `verbosity: basic` to your metrics pipeline while you wire this up, and remove it once the counts look right.
+
+### OpenTelemetry Operator
+
+If you already run the operator, skip the deployment and the config map. Put the Step 2 configuration inside an `OpenTelemetryCollector` resource and let the operator own the rest:
+
+```yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: qdrant
+  namespace: observability
+spec:
+  image: otel/opentelemetry-collector-contrib:0.158.0
+  env:
+    - name: QDRANT_HOST
+      value: "<cluster-id>.<region>.<provider>.cloud.qdrant.io"
+    - name: QDRANT_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: qdrant-cluster-api-key
+          key: apiKey
+  config:
+    # The receivers, processors, exporters and service blocks from Step 2,
+    # unchanged. Point the exporter at an endpoint the cluster can reach.
+```
+
+<aside role="status">
+Check the <code>apiVersion</code> against the operator version you run. <code>v1beta1</code> takes <code>config</code> as a structured field, and the older <code>v1alpha1</code> takes it as a YAML string.
+</aside>
+
+Multi-node clusters need one `qdrant-node` target per node, exactly as in Step 2. The `qdrant-cloud-sys` job still needs only the one cluster endpoint.
+
+### When your backend is already Prometheus
+
+If you run kube-prometheus-stack and Prometheus is where the metrics end up, you do not need a collector at all. Give Prometheus a `ScrapeConfig` instead, which is the path described in [Managed Cloud Prometheus monitoring](/documentation/ops-monitoring/managed-cloud-prometheus/).
+
+<aside role="alert">
+A single <code>ScrapeConfig</code> against <code>/sys_metrics</code> gives you node and edge metrics but not <code>collection_running_optimizations</code>. Add a second <code>ScrapeConfig</code> for <code>/metrics</code> to get the optimizer signal, which is the first thing to check when queries slow down.
+</aside>
+
 ## Scrape targets and alerting are separate
 
 This page sets up scrape targets. It does not configure alerts. Once the signals land in your backend, write alerting rules there against `collection_running_optimizations`, `qdrant_node_rssanon_bytes`, and the request histograms. On Kubernetes, the Qdrant operator can install its own Prometheus rules, which are configured separately from anything on this page.
 
 ## Verified against
 
-Qdrant Cloud 1.17.1, single node, `us-west-1`, the `qdrant-docs` snapshot at 18,828 points and 384 dimensions. Collector image `otel/opentelemetry-collector-contrib`, backend `grafana/otel-lgtm`. The self-hosted scrape path above is described but not verified in this configuration.
+Qdrant Cloud 1.17.1, single node, `us-west-1`, the `qdrant-docs` snapshot at 18,828 points and 384 dimensions. Collector image `otel/opentelemetry-collector-contrib`, backend `grafana/otel-lgtm`.
+
+The plain Kubernetes manifests were applied to a `kind` v1.35.0 cluster and scraped the same live Qdrant Cloud cluster from inside a pod, with bearer auth read from the mounted secret and no scrape errors. The counts above are that run.
+
+Three paths on this page are described but not verified in this configuration: the self-hosted scrape, the `OpenTelemetryCollector` resource, and the vendor endpoints in the backend table.
 
 ## Next
 

--- a/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
+++ b/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
@@ -12,6 +12,12 @@ Qdrant Cloud exposes Prometheus metrics, not OpenTelemetry. You scrape these met
 
 Two existing pages cover the app side. [OpenLLMetry](/documentation/observability/openllmetry/) instruments the `qdrant_client` library and exports spans. [OpenLIT](/documentation/observability/openlit/) sends app traces and metrics. This page covers the third piece. It gets the metrics of Qdrant Cloud into the same backend, and then ties them to a slow trace.
 
+### Which layer reports what
+
+Qdrant reports on the database: request durations, collection state, optimizer activity, and node resources. It does not know your model, your prompt, or your token counts.
+
+Token counts, model latency, and retrieval relevance come from a tracing library in your application, such as OpenLLMetry, OpenLIT, or Arize. Instrument those in your own code. Qdrant needs no per-vendor integration for either layer, because the Collector speaks both OTLP and Prometheus.
+
 ## What you need
 
 - A Qdrant Cloud instance.
@@ -19,7 +25,7 @@ Two existing pages cover the app side. [OpenLLMetry](/documentation/observabilit
 - Python.
 - An OTLP endpoint. The tutorial uses `grafana/otel-lgtm`, so you do not need a vendor account.
 
-The `/sys_metrics` endpoint is Cloud-only. Self-hosted Qdrant does not expose it.
+The `/sys_metrics` endpoint is Cloud-only. Self-hosted Qdrant does not expose it. Self-hosted clusters still expose `/metrics` on every node, so drop the `qdrant-cloud-sys` scrape job in Step 2 and list one target per node under `qdrant-node`. You lose the node resource and edge latency series. You keep the request histograms and the optimizer signal.
 
 The data for this example will come from a public snapshot of the Qdrant documentation site.
 
@@ -178,7 +184,7 @@ KEY = os.environ["QDRANT_API_KEY"]
 COLL = os.environ["COLLECTION"]
 SNAPSHOT = os.environ["SNAPSHOT_URL"]
 
-client = QdrantClient(url=URL, api_key=KEY)
+client = QdrantClient(url=URL, api_key=KEY, timeout=600)
 
 if not client.collection_exists(COLL):
     client.recover_snapshot(
@@ -186,6 +192,8 @@ if not client.collection_exists(COLL):
         location=SNAPSHOT,
     )
 ```
+
+`recover_snapshot` blocks until the restore finishes, which takes longer than the client's default timeout. Raise the timeout as shown, or the call fails with `ResponseHandlingException: The read operation timed out` while the restore keeps running on the cluster.
 
 If the `.env` file is loaded, run the script:
 
@@ -416,7 +424,38 @@ histogram_quantile(0.5,
 
 `per_collection=true` is the `params` block on the `qdrant-node` scrape, from Step 2. Without it, `rest_responses_duration_seconds_bucket` has no `collection` label. The query returns nothing.
 
+<aside role="status">
+The docs list <code>per_collection=true</code> as available from v1.18. It works on 1.17.1, duration histograms included. Check your own cluster version rather than assuming either way.
+</aside>
+
 The `collection` label on the histogram matches the `db.collection.name` attribute on the span. You can compare the two values directly.
+
+### Read the ratio, not the total
+
+Compare the span duration against `rest_responses_duration_seconds` for the same window. On Qdrant Cloud the two rarely match, and the gap is the point.
+
+Measured on a single-node 1.17.1 cluster against the `qdrant-docs` collection above, 20 requests per shape, `rest_responses_duration_seconds` read straight from `/metrics`:
+
+| Query shape          | Client median | Mean time inside Qdrant |
+| -------------------- | ------------- | ----------------------- |
+| `docs`, `limit=10`   | 312.6 ms      | 2.71 ms                 |
+| `blog`, `limit=1000` | 316.2 ms      | 3.42 ms                 |
+
+Under 1% of what the client waits for is spent inside the database. Asking for 100 times more results makes Qdrant do 26% more work and moves the client total by 1%. The rest is transit between your machine and the cluster, so treat a slow span as a placement or transport problem until the histogram says otherwise.
+
+Your own numbers will differ with vector dimension, collection size, and region. The ratio is what to watch, not the absolute figures.
+
+This also means the slowest span your app records is often a network outlier on the cheaper query rather than the expensive one. Rank traces by `rest_responses_duration_seconds` when you want to find work the database actually did.
+
+## Import the Grafana dashboard
+
+Qdrant publishes dashboards at [qdrant-cloud-grafana-dashboard](https://github.com/qdrant/qdrant-cloud-grafana-dashboard). Import `qdrant_cloud_dashboard.json` through **Dashboards > New > Import** in the Grafana at <http://localhost:3000>. The other dashboard in that repository targets self-managed Hybrid and Private Cloud, and needs `kube_*` series that this setup does not scrape.
+
+<aside role="alert">
+Several API latency and request rate panels query <code>envoy_cluster_upstream_rq_*</code>. Clusters that route through Traefik emit <code>traefik_*</code> instead, so you see those panels empty. The <code>qdrant_*</code> and <code>container_*</code> panels fill normally. Check which proxy your cluster reports before you read a blank panel as an outage.
+</aside>
+
+These dashboards are community maintained. Treat them as a starting point rather than a supported product surface.
 
 ## Use a different backend
 
@@ -429,10 +468,22 @@ Change the `exporters` block. Endpoint and an auth header are all that differ.
 | New Relic     | `https://otlp.nr-data.net:4317`                 | `api-key: <your-key>`                           |
 | Honeycomb     | `https://api.honeycomb.io:443`                  | `x-honeycomb-team: <your-key>`                  |
 
+Confirm the endpoint and header against your vendor's own OTLP documentation before you rely on a row. This tutorial was verified end to end against `grafana/otel-lgtm` only.
+
+## Scrape targets and alerting are separate
+
+This page sets up scrape targets. It does not configure alerts. Once the signals land in your backend, write alerting rules there against `collection_running_optimizations`, `qdrant_node_rssanon_bytes`, and the request histograms. On Kubernetes, the Qdrant operator can install its own Prometheus rules, which are configured separately from anything on this page.
+
+## Verified against
+
+Qdrant Cloud 1.17.1, single node, `us-west-1`, the `qdrant-docs` snapshot at 18,828 points and 384 dimensions. Collector image `otel/opentelemetry-collector-contrib`, backend `grafana/otel-lgtm`. The Kubernetes and self-hosted paths above are described but not verified in this configuration.
+
 ## Next
 
-- [OpenLLMetry](/documentation/observability/openllmetry/) — instrument `qdrant_client` and export spans.
-- [OpenLIT](/documentation/observability/openlit/) — auto-instrumentation for your app.
-- [Datadog integration](/documentation/observability/datadog/) — managed scrape when Datadog is your only backend.
-- [OpenTelemetry Collector reference](https://opentelemetry.io/docs/collector/) — receivers, processors, exporters.
-- [OpenTelemetry Operator](https://opentelemetry.io/docs/kubernetes/operator/) — wraps the same `otelcol-config.yaml` for Kubernetes.
+- [OpenLLMetry](/documentation/observability/openllmetry/) instruments `qdrant_client` and exports spans.
+- [OpenLIT](/documentation/observability/openlit/) auto-instruments your app.
+- [Datadog integration](/documentation/observability/datadog/) is the managed scrape path when Datadog is your only backend.
+- [Cluster monitoring](/documentation/ops-monitoring/monitoring/) lists every metric Qdrant exposes.
+- [qdrant-opentelemetry-tutorial](https://github.com/meinsta/qdrant-opentelemetry-tutorial) is a runnable version of this page, with a notebook, a check that fails if a signal does not arrive, and three Kubernetes deployment paths.
+- [OpenTelemetry Collector reference](https://opentelemetry.io/docs/collector/) covers receivers, processors, and exporters.
+- [OpenTelemetry Operator](https://opentelemetry.io/docs/kubernetes/operator/) wraps the same `otelcol-config.yaml` for Kubernetes.

--- a/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
+++ b/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
@@ -476,7 +476,7 @@ This page sets up scrape targets. It does not configure alerts. Once the signals
 
 ## Verified against
 
-Qdrant Cloud 1.17.1, single node, `us-west-1`, the `qdrant-docs` snapshot at 18,828 points and 384 dimensions. Collector image `otel/opentelemetry-collector-contrib`, backend `grafana/otel-lgtm`. The Kubernetes and self-hosted paths above are described but not verified in this configuration.
+Qdrant Cloud 1.17.1, single node, `us-west-1`, the `qdrant-docs` snapshot at 18,828 points and 384 dimensions. Collector image `otel/opentelemetry-collector-contrib`, backend `grafana/otel-lgtm`. The self-hosted scrape path above is described but not verified in this configuration.
 
 ## Next
 

--- a/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
+++ b/qdrant-landing/content/documentation/tutorials-build-essentials/opentelemetry-end-to-end.md
@@ -625,6 +625,5 @@ Three paths on this page are described but not verified in this configuration: t
 - [OpenLIT](/documentation/observability/openlit/) auto-instruments your app.
 - [Datadog integration](/documentation/observability/datadog/) is the managed scrape path when Datadog is your only backend.
 - [Cluster monitoring](/documentation/ops-monitoring/monitoring/) lists every metric Qdrant exposes.
-- [qdrant-opentelemetry-tutorial](https://github.com/meinsta/qdrant-opentelemetry-tutorial) is a runnable version of this page, with a notebook, a check that fails if a signal does not arrive, and three Kubernetes deployment paths.
 - [OpenTelemetry Collector reference](https://opentelemetry.io/docs/collector/) covers receivers, processors, and exporters.
 - [OpenTelemetry Operator](https://opentelemetry.io/docs/kubernetes/operator/) wraps the same `otelcol-config.yaml` for Kubernetes.


### PR DESCRIPTION
> Reference implementation: [meinsta/qdrant-opentelemetry-tutorial](https://github.com/meinsta/qdrant-opentelemetry-tutorial), built and measured against a live 1.17.1 cluster when this gap was identified in the observability docs review. The figures and the Kubernetes manifests in this PR come from re-running it.

Fixes from reviewing #2643, into your branch so it stays your PR. Yes, this cuts it. The Collector bridge was the piece missing from the docs and you got it right.

Two bugs, five coverage gaps, three caveats. Everything here is measured against a live 1.17.1 Cloud cluster.

## Two bugs

**`restore.py` failed as written.** `recover_snapshot` blocks until the restore completes, which outlives the client's default timeout, so Step 4 ends in `ResponseHandlingException: The read operation timed out`. The restore does finish on the cluster, which makes it worse: the `collection_exists` guard no-ops on a re-run, so it looks like the script never worked. `timeout=600` on the client.

**Step 7 did not land.** It asked the reader to correlate the slowest span against a cluster signal, but `app.py` ranks spans by client wall clock. Measured over 20 requests per shape:

| Query shape | Client median | Mean time inside Qdrant |
| --- | --- | --- |
| `docs`, `limit=10` | 312.6 ms | 2.71 ms |
| `blog`, `limit=1000` | 316.2 ms | 3.42 ms |

Under 1% of the call is spent in the database. Asking for 100 times more results makes Qdrant do 26% more work and moves the client total by 1%. So the slowest span is usually a network outlier on the *cheaper* query, and a reader who opens it in Tempo finds nothing cluster-side to explain it. I added the measured split and a note to rank traces by `rest_responses_duration_seconds` instead. That change stops readers blaming the database for a transport problem, which is the confusion the page exists to clear up.

Everything else about the snapshot checked out exactly as you documented it: 18,828 points, 384 dimensions, cosine, keyword indexes on `tag` and `sections`, full text on `text`. `sections=blog` holds 3,330 points, so `limit=1000` really is the heavier shape. The collector config validates clean.

## Five coverage gaps

The page answers a P0 from our observability docs review, which asked for one place covering the Prometheus endpoint, the Grafana dashboard, OTel export, and third-party APMs. OTel export and the APM table were already here.

- **The layer boundary.** Qdrant reports on the database. Token counts and model latency come from a tracing library in the app. This is the most common question we get on calls and it was not written down anywhere in the docs.
- **Self-hosted.** The page named `/sys_metrics` as Cloud-only and stopped. `/metrics` works self-hosted with one target per node.
- **The Grafana dashboard,** with the trap that several panels query `envoy_cluster_upstream_rq_*` while Traefik-routed clusters emit `traefik_*`, so those panels render empty. The page already tells readers to look at `traefik_service_request_duration_seconds`, so leaving this out was actively misleading.
- **Scrape targets versus alerting,** called out as separate concerns.
- **Kubernetes,** the biggest addition. Every account that raised this on a call was already running Prometheus in Kubernetes, and the page only had the laptop path. Three sections: plain manifests, the OpenTelemetry operator, and a pointer to the existing managed-cloud-prometheus page for anyone whose backend is already Prometheus. The manifests build the config map from the `otelcol-config.yaml` in Step 2 rather than restating the scrape jobs, so there is one copy of the configuration on the page.

## Three caveats

The vendor endpoint rows are marked unverified. `per_collection=true` is flagged as working before its documented 1.18. And the page now says what it was tested against: the compose path and the Kubernetes manifests are verified, the manifests from a pod in `kind` v1.35.0 against a live 1.17.1 cluster. The self-hosted scrape, the operator resource, and the vendor rows are not, and the verified-against block names all three.

## Not in scope here

The operator's default Prometheus alerting rules are undocumented anywhere. That is its own page rather than anything for this PR, and I will file it.
