### PR TITLE
Fix top banner link to the published blog slug

### DIFF
--- a/qdrant-landing/content/headless/top-banner.md
+++ b/qdrant-landing/content/headless/top-banner.md
@@ -13,7 +13,7 @@ icon: <svg width="16" height="16" viewBox="0 0 16 16" fill="none"
 text: "We built the benchmark the industry was missing: 10 billion documents, with ground truth."
 link:
   text: Read how we did it
-  url: https://qdrant.tech/blog/supernova-release
+  url: https://qdrant.tech/blog/qdrant-fineweb-10b-release/
 start: 2026-09-01T12:00:00.000Z
 sitemapExclude: true
 end: 2026-09-03T12:00:00.000Z


### PR DESCRIPTION
The banner merged in #2686 links to `https://qdrant.tech/blog/supernova-release`, which returns 404. The post published at `https://qdrant.tech/blog/qdrant-fineweb-10b-release/`.

This is live on the site now and the banner runs until September 3, 8:00 AM EST, so it needs to go in as soon as it is reviewed.

One line changed, nothing else touched: same copy, same start and end times.
