### PR TITLE
Put the headline numbers on six case studies into the page as text

### DIFF
--- a/qdrant-landing/content/blog/case-study-lyzr.md
+++ b/qdrant-landing/content/blog/case-study-lyzr.md
@@ -19,7 +19,8 @@ partition: case-studies
 ---
 # How Lyzr Supercharged AI Agent Performance with Qdrant
 
-![How Lyzr Supercharged AI Agent Performance with Qdrant](/blog/case-study-lyzr/case-study-lyzr-summary-dark.png)
+{{< case-study-summary
+  results="90% | Faster query latency under high concurrency; 2x | Faster indexing for large-scale knowledge bases; 30% | Lower infrastructure costs from reduced resource usage" >}}
 
 ## Scaling Intelligent Agents: How Lyzr Supercharged Performance with Qdrant
 
@@ -28,6 +29,8 @@ As AI agents become more capable and pervasive, the infrastructure behind them m
 When their existing vector database infrastructure began to buckle under pressure, the engineering team needed a solution that could do more than just keep up. It had to accelerate them forward.
 
 This is how they rethought their stack and adopted Qdrant as the foundation for fast, scalable agent performance.
+
+![How Lyzr Supercharged AI Agent Performance with Qdrant](/blog/case-study-lyzr/case-study-lyzr-summary-dark.png)
 
 ## The Scaling Limits of Early Stack Choices
 

--- a/qdrant-landing/content/blog/case-study-pariti.md
+++ b/qdrant-landing/content/blog/case-study-pariti.md
@@ -21,7 +21,8 @@ partition: case-studies
 
 ## From Manual Bottlenecks to Millisecond Matching: Connecting Africa’s Best Talent
 
-![Pariti slashes vetting time and boosted candidate placement success.](/blog/case-study-pariti/case-study-pariti-summary-dark.jpg)
+{{< case-study-summary
+  results="20% → 48% | Hiring fill-rate; 4 min → 1 min | Candidate vetting time; 94% | of hires ranked in top 10% of search results" >}}
 
 Pariti’s mission is bold: connect Africa’s best talent with the continent’s most-promising startups—fast. Its referral-driven marketplace lets anyone nominate a great candidate, but viral growth triggered an avalanche of data. A single job post now attracts more than 300 applicants within 72 hours, yet Pariti still promises clients an interview-ready shortlist inside those same five days.
 
@@ -30,6 +31,8 @@ By 2023 the strain was obvious. Analysts spent four minutes vetting each résum�
 ### A Laptop Experiment Shows the Way
 
 Data Scientist Chiara Stramaccioni built a quick Python script on her laptop: encode the text requirements of a new role, embed every candidate’s experience, compare vectors, and rank the results. Quality looked excellent, but each query took half a minute of local compute, and only Chiara could run it. The prototype proved feasibility, but it did not solve scale.
+
+![Pariti slashes vetting time and boosted candidate placement success.](/blog/case-study-pariti/case-study-pariti-summary-dark.jpg)
 
 ### Dropping Qdrant into Production
 

--- a/qdrant-landing/content/blog/case-study-pathwork.md
+++ b/qdrant-landing/content/blog/case-study-pathwork.md
@@ -22,11 +22,14 @@ partition: case-studies
 
 ## **Pathwork Optimizes Life Insurance Underwriting with Precision Vector Search**
 
-![Pathwork Optimizes Life Insurance Underwriting with Precision Vector Search](/blog/case-study-pathwork/case-study-pathwork-summary-dark-b.jpg)
+{{< case-study-summary
+  results="~50% | error reduction; 78% | faster responses, MSE dropped from 3.5 → 1.8; 50% | MoM user growth, query latency cut from 9s → 2s" >}}
 
 ### **About Pathwork**
 
 Pathwork is redesigning life and health insurance workflows for the age of AI. Brokerages and insurance carriers utilize Pathwork's advanced agentic system to automate their underwriting processes and enhance back-office sales operations. Pathwork's solution drastically reduces errors, completes tasks up to 70 times faster, and significantly conserves human capital.
+
+![Pathwork Optimizes Life Insurance Underwriting with Precision Vector Search](/blog/case-study-pathwork/case-study-pathwork-summary-dark-b.jpg)
 
 ### **The Challenge: Accuracy Above All**
 

--- a/qdrant-landing/content/blog/case-study-qovery.md
+++ b/qdrant-landing/content/blog/case-study-qovery.md
@@ -20,11 +20,14 @@ partition: case-studies
 
 ## Qovery Scales Real-Time DevOps Automation with Qdrant
 
-![How Qovery Accelerated Developer Autonomy with Qdrant](/blog/case-study-qovery/case-study-qovery-summary-dark.png)
+{{< case-study-summary
+  results=" | Zero-maintenance ops; | Tasks take seconds vs. hours; >100K | vectors indexed" >}}
 
 ### Empowering Developers with Autonomous Infrastructure Management
 
 Qovery, trusted by over 200 companies including Alan, Talkspace, GetSafe, and RxVantage, empowers software engineering teams to autonomously manage their infrastructure through its robust DevOps automation platform. As their platform evolved, Qovery recognized an opportunity to enhance developer autonomy further by integrating an AI-powered DevOps Copilot. To achieve real-time accuracy and rapid responses, Qovery selected Qdrant as the backbone of their vector database infrastructure.
+
+![How Qovery Accelerated Developer Autonomy with Qdrant](/blog/case-study-qovery/case-study-qovery-summary-dark.png)
 
 ### Reducing Dependency on Specialized DevOps Expertise
 

--- a/qdrant-landing/content/blog/case-study-sayone.md
+++ b/qdrant-landing/content/blog/case-study-sayone.md
@@ -23,7 +23,8 @@ partition: case-studies
 ## How SayOne Enhanced Government AI Services with Qdrant
 
 
-![SayOne Enhanced Government AI Services](/blog/case-study-sayone/case-study-sayone-summary-dark.jpg)
+{{< case-study-summary
+  results=" | Improved Latency; | Global Privacy Compliance; | Enhanced Developer Productivity" >}}
 
 
 ### The Challenge
@@ -31,6 +32,8 @@ partition: case-studies
 
 SayOne is an information technology and digital services company headquartered in India. They create end-to-end customized digital solutions, and have completed over 200 projects for clients worldwide. When SayOne embarked on building advanced AI solutions for government institutions, their initial choice was Pinecone, primarily due to its prevalence within AI documentation. However, SayOne soon discovered significant limitations impacting their projects. Key challenges included escalating costs, restrictive customization options, and considerable scalability issues. Furthermore, reliance on external cloud infrastructure posed critical data privacy concerns, especially since governmental entities demanded stringent data sovereignty and privacy controls.
 
+
+![SayOne Enhanced Government AI Services](/blog/case-study-sayone/case-study-sayone-summary-dark.jpg)
 
 ### Evaluation Process
 

--- a/qdrant-landing/content/blog/case-study-tripadvisor.md
+++ b/qdrant-landing/content/blog/case-study-tripadvisor.md
@@ -20,7 +20,8 @@ partition: case-studies
 
 # How Tripadvisor Is Reimagining Travel with Qdrant
 
-![How Tripadvisor Drives 2–3x More Revenue with Qdrant-Powered AI](/blog/case-study-tripadvisor/case-study-tripadvisor-summary-dark.jpg)
+{{< case-study-summary
+  results="2-3x | Revenue Uplift; 1B+ | Content Items Indexed; 11M | businesses and 21 countries supported" >}}
 
 {{< quote
   text="Qdrant has been crucial for our transformation. When you're dealing with over a billion plus user-generated, multi-modal pieces of content from hundreds of millions of monthly active users across 21 countries, 11M businesses and all the complex user interactions that come with it, you need a way to bring it all together. Now, we can represent everything from hotel preferences to restaurant choices to user behavior in a unified way. And we’re seeing real business results. Users engaging with our AI-powered features like trip planning are showing 2-3x more revenue."
@@ -39,6 +40,8 @@ Tripadvisor, the world’s largest travel guidance platform, is undergoing a dee
 The shift was driven by [Rahul Todkar](https://www.linkedin.com/in/rahultodkar/), Head of Data and AI who had previously overseen global AI teams. With a background in building complex data and AI products, including LinkedIn’s data, AI and vector systems, he immediately recognized the opportunity at Tripadvisor: a billion user reviews and contributions \- including hundreds of millions of images \- and years of behavioral data across hotels, restaurants, and experiences.
 
 The goal was ambitious: convert this sprawling, multimodal dataset into a dynamic, AI-driven platform that enhances both user experience and business impact.
+
+![How Tripadvisor Drives 2–3x More Revenue with Qdrant-Powered AI](/blog/case-study-tripadvisor/case-study-tripadvisor-summary-dark.jpg)
 
 ## Generative AI at the Core
 

--- a/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
@@ -8,6 +8,7 @@
 @import 'partials/newsletter';
 @import 'partials/qdrant-post';
 @import 'partials/customer-quote';
+@import 'partials/case-study-summary';
 @import 'partials/qdrant-articles-hero';
 @import 'partials/qdrant-articles-posts';
 @import 'partials/carousel';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
@@ -33,6 +33,7 @@
 @import 'partials/newsletter';
 @import 'partials/qdrant-post';
 @import 'partials/customer-quote';
+@import 'partials/case-study-summary';
 @import 'partials/carousel';
 @import 'partials/leadership';
 @import 'partials/open-roles';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-summary.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-summary.scss
@@ -1,0 +1,139 @@
+@use '../helpers/functions' as *;
+
+// Descendants are nested so each rule carries two classes of specificity: the
+// article stylesheet styles bare `p`, `ul` and `li` under .qdrant-post__content
+// and would otherwise win.
+.case-study-summary {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $spacer;
+  margin: $spacer * 3 0;
+
+  .case-study-summary__intro,
+  .case-study-summary__tag,
+  .case-study-summary__result {
+    padding: pxToRem(24) pxToRem(28);
+    border-radius: $spacer * 0.75;
+    background: linear-gradient(180deg, $neutral-20 0%, #0e1424 100%);
+  }
+
+  .case-study-summary__logo {
+    display: block;
+    max-width: pxToRem(160);
+    max-height: pxToRem(40);
+    margin: 0 0 pxToRem(20);
+  }
+
+  // Colour is set on the container as well as on the paragraphs, so the text
+  // stays legible even if it renders without a wrapping <p>.
+  .case-study-summary__text {
+    font-size: pxToRem(18);
+    line-height: pxToRem(28);
+    color: $neutral-94;
+
+    p {
+      margin-bottom: pxToRem(12);
+      font-size: pxToRem(18);
+      line-height: pxToRem(28);
+      color: $neutral-94;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    a {
+      color: $neutral-98;
+      text-decoration: underline;
+    }
+  }
+
+  .case-study-summary__tags,
+  .case-study-summary__results {
+    display: grid;
+    gap: $spacer;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .case-study-summary__results {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .case-study-summary__tag {
+    padding: pxToRem(16) pxToRem(20);
+    font-size: pxToRem(16);
+    line-height: pxToRem(24);
+    color: $neutral-94;
+  }
+
+  .case-study-summary__result-value {
+    margin-bottom: pxToRem(8);
+    font-weight: 600;
+    font-size: pxToRem(32);
+    line-height: pxToRem(40);
+  }
+
+  .case-study-summary__result-label {
+    margin-bottom: 0;
+    font-size: pxToRem(16);
+    line-height: pxToRem(24);
+    color: $neutral-94;
+  }
+
+  // The panels cycle through three accents, as the exported images did.
+  .case-study-summary__result:nth-child(3n + 1) .case-study-summary__result-value {
+    color: $secondary-blue-50;
+  }
+
+  .case-study-summary__result:nth-child(3n + 2) .case-study-summary__result-value {
+    color: $secondary-violet-50;
+  }
+
+  .case-study-summary__result:nth-child(3n + 3) .case-study-summary__result-value {
+    color: $primary-60;
+  }
+
+  @include media-breakpoint-up(lg) {
+    grid-template-columns: 2fr 1fr;
+
+    .case-study-summary__intro {
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .case-study-summary__tags {
+      grid-column: 2;
+      grid-row: 1;
+      align-content: start;
+    }
+
+    .case-study-summary__results {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+  }
+
+  @include media-breakpoint-down(md) {
+    .case-study-summary__results {
+      grid-template-columns: 1fr;
+    }
+
+    .case-study-summary__result-value {
+      font-size: pxToRem(28);
+      line-height: pxToRem(36);
+    }
+  }
+}
+
+// A results-only panel: the numbers on their own, for pages that keep their
+// exported summary image further down and just need the figures as real text.
+.case-study-summary_results-only {
+  grid-template-columns: 1fr;
+
+  .case-study-summary__results {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+}

--- a/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/case-study-summary.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/case-study-summary.html
@@ -1,0 +1,88 @@
+{{- /*
+  Summary panel at the top of a case study: logo, a short description, the
+  Qdrant capabilities used, and the headline results.
+
+  These panels used to be exported as a single large image, which meant the
+  numbers in them were not text: not indexed, not selectable, not readable by
+  a screen reader, and not legible once scaled to a phone.
+
+  Usage:
+    {{< case-study-summary
+        logo="/img/customers-case-studies-logo/lyzr.svg"
+        company="Lyzr"
+        text="Lyzr Agent Studio powers intelligent agents used across industries."
+        tags="AI Agents; AWS"
+        results="90% | Faster query latency under high concurrency;
+                 2x | Faster indexing for large-scale knowledge bases;
+                 30% | Lower infrastructure costs" >}}
+
+  `results` is a semicolon-separated list of `value | label` pairs. Omit the
+  value for a result that has no number of its own:
+
+    results=" | Global privacy compliance; | Improved latency"
+
+  `tags` is a semicolon-separated list of capability names.
+  `text` is rendered as markdown, so links and emphasis work.
+*/ -}}
+
+{{- $page := .Page -}}
+{{- $logo := .Get "logo" -}}
+{{- $company := .Get "company" | default "" -}}
+{{- $text := .Get "text" | default "" -}}
+{{- $tags := .Get "tags" | default "" -}}
+{{- $results := .Get "results" | default "" -}}
+
+{{- if not (or $text $results) -}}
+  {{- errorf "case-study-summary in %q needs a `text` or `results` param" $page.Path -}}
+{{- end -}}
+
+<section class="case-study-summary{{ if not (or $text $logo) }} case-study-summary_results-only{{ end }}">
+  {{- if or $text $logo }}
+  <div class="case-study-summary__intro">
+    {{- with $logo }}
+    <img
+      class="case-study-summary__logo"
+      src="{{ . }}"
+      alt="{{ with $company }}{{ . }}{{ else }}Company logo{{ end }}"
+      loading="lazy"
+    />
+    {{- end }}
+    {{- with $text }}
+    <div class="case-study-summary__text">
+      {{ $page.RenderString (dict "display" "block") (trim . "\n ") }}
+    </div>
+    {{- end }}
+  </div>
+  {{- end }}
+
+  {{- with $tags }}
+  <ul class="case-study-summary__tags">
+    {{- range (split . ";") }}
+      {{- with (trim . " \n") }}
+      <li class="case-study-summary__tag">{{ . }}</li>
+      {{- end }}
+    {{- end }}
+  </ul>
+  {{- end }}
+
+  {{- with $results }}
+  <ul class="case-study-summary__results">
+    {{- range (split . ";") }}
+      {{- $parts := split . "|" -}}
+      {{- $value := trim (index $parts 0) " \n" -}}
+      {{- $label := "" -}}
+      {{- if gt (len $parts) 1 }}{{ $label = trim (index $parts 1) " \n" }}{{ end -}}
+      {{- if or $value $label }}
+      <li class="case-study-summary__result">
+        {{- with $value }}
+        <p class="case-study-summary__result-value">{{ . }}</p>
+        {{- end }}
+        {{- with $label }}
+        <p class="case-study-summary__result-label">{{ . }}</p>
+        {{- end }}
+      </li>
+      {{- end }}
+    {{- end }}
+  </ul>
+  {{- end }}
+</section>


### PR DESCRIPTION
Six case studies open with a large exported summary image. The numbers in it are pixels — not searchable, not selectable, invisible to a screen reader, and unreadable once a 2760px image is scaled to a phone.

These are some of the strongest figures we have, and none of them exists as text anywhere on the page:

| Case study | Numbers now in the page as text |
|---|---|
| Tripadvisor | 2-3x revenue uplift · 1B+ content items indexed · 11M businesses |
| Lyzr | 90% faster query latency · 2x faster indexing · 30% lower infra cost |
| Pariti | 20% → 48% fill rate · 4 min → 1 min vetting · 94% of hires in top 10% |
| Pathwork | ~50% error reduction · 78% faster responses · 9s → 2s query latency |
| Qovery | >100K vectors indexed · zero-maintenance ops · seconds vs hours |
| SayOne | improved latency · global privacy compliance · developer productivity |

## The images stay

They carry icon artwork we have no source assets for, so removing them would lose design work we cannot reproduce. Each image moves below the first subsection instead, and the figures appear above it as text.

That does mean the numbers appear twice on these six pages — once as pixels in the image, once as text. The text version is what search, screen readers and phones can actually use.

## The component

`case-study-summary` renders a row of results, each a value and a label. It takes a value-less entry (`| Label`) for the tiles that carry an icon and a label rather than a number — two of Qovery's and all three of SayOne's — so the label survives even though the icon only exists inside the image.

It also renders an optional logo, description and tag row, which nothing uses yet. That is deliberate: those parts are what a page without a summary image would need, and there are around 36 of those with numbers still buried in prose.

## Checked

Clean build, all six pages: 3 tiles each, image still present, no unparsed shortcodes. Every value and label is transcribed from its image exactly — nothing rounded, reworded or added.

## Known rough edge

Pariti's two arrow values wrap to a second line, since `20% → 48%` is much longer than a bare `90%`. It is the only page where tiles end up uneven. Worth deciding whether long values should step down a size, or whether the tiles should size to content rather than equal thirds.
