### PR TITLE
Tag case studies with the customer's industry, deployment and region

### DIFF
--- a/qdrant-landing/content/blog/case-study-alhena.md
+++ b/qdrant-landing/content/blog/case-study-alhena.md
@@ -23,6 +23,8 @@ partition: case-studies
 
 # How Alhena AI unified its AI stack and accelerated ecommerce outcomes with Qdrant
 
+{{< case-study-tags >}}
+
 ![How Alhena AI unified its AI stack and improved ecommerce conversions with Qdrant](/blog/case-study-alhena/alhena-bento-box-dark.jpg)
 
 ## Building AI agents that drive both revenue and support outcomes

--- a/qdrant-landing/content/blog/case-study-and-ai.md
+++ b/qdrant-landing/content/blog/case-study-and-ai.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ![Bento Box](/blog/case-study-and-ai/and-ai-bento.jpg)
 
+{{< case-study-tags >}}
+
 ## How \&AI scaled global patent retrieval with Qdrant
 
 [&AI](https://tryandai.com/) is on a mission to redefine patent litigation. Their platform helps legal professionals invalidate patents through intelligent prior art search, claim charting, and automated litigation support. To make this work at scale, CTO and co-founder Herbie Turner needed a vector database that could power fast, accurate retrieval across billions of documents without ballooning DevOps complexity. That’s where Qdrant came in.

--- a/qdrant-landing/content/blog/case-study-anima-health.md
+++ b/qdrant-landing/content/blog/case-study-anima-health.md
@@ -23,6 +23,8 @@ partition: case-studies
 
 ![Anima Health scaled privacy-first clinical intelligence with Qdrant](/blog/case-study-anima-health/anima-bento.png)
 
+{{< case-study-tags >}}
+
 Primary care systems across the UK are under intense strain. General practitioners (GPs) balance their time with patient demand, understaffing, administrative burden vs. delivering care. <a href="https://animahealth.com/" target="_blank">Anima Health</a> set out to address this challenge by building a clinical operating system designed to make primary care more efficient, more informed, and more humane for both clinicians and patients.
 
 At the heart of Anima’s platform is the ability to process large volumes of unstructured clinical data, including documents, test results, referral letters, and notes, while maintaining strict privacy guarantees. To achieve this at scale, Anima relies on Qdrant as a core infrastructure component for vector search, similarity analysis, and agentic AI workflows.

--- a/qdrant-landing/content/blog/case-study-aracor.md
+++ b/qdrant-landing/content/blog/case-study-aracor.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ## Precision at Scale: How Aracor Uses Qdrant to Accelerate Legal Due Diligence Resulting in 90% Faster Workflows ##
 
+{{< case-study-tags >}}
+
 ![How Aracor Sped Up Due Diligence Workflows by 90%](/blog/case-study-aracor/case-study-aracor-bento-dark.jpg)
 
 ### How Aracor Accelerated Legal Due Diligence with Qdrant Vector Search

--- a/qdrant-landing/content/blog/case-study-bazaarvoice.md
+++ b/qdrant-landing/content/blog/case-study-bazaarvoice.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ![Bazaarvoice overview](/blog/case-study-bazaarvoice/bazaarvoice-bento.png)
 
+{{< case-study-tags >}}
+
 ## Turning billions of reviews into real-time, actionable intelligence
 
 Bazaarvoice powers ratings and reviews across the global ecommerce ecosystem, connecting brands, retailers, and consumers through authentic product feedback. From brand-owned storefronts to major retailers, Bazaarvoice sources, verifies, and amplifies reviews at a scale few companies ever reach.

--- a/qdrant-landing/content/blog/case-study-bloop.md
+++ b/qdrant-landing/content/blog/case-study-bloop.md
@@ -15,6 +15,8 @@ aliases:
 partition: case-studies
 ---
 
+{{< case-study-tags >}}
+
 Founded in early 2021, [bloop](https://bloop.ai/) was one of the first companies to tackle semantic 
 search for codebases. A fast, reliable Vector Search Database is a core component of a semantic 
 search engine, and bloop surveyed the field of available solutions and even considered building 

--- a/qdrant-landing/content/blog/case-study-convosearch.md
+++ b/qdrant-landing/content/blog/case-study-convosearch.md
@@ -21,6 +21,8 @@ partition: case-studies
 
 ## How ConvoSearch Boosted E-commerce Revenue with Qdrant
 
+{{< case-study-tags >}}
+
 ![How ConvoSearch Boosted E-commerce Revenue with Qdrant](/blog/case-study-convosearch/convosearch-bento-dark.jpg)
 
 ### Driving E-commerce Success Through Enhanced Search

--- a/qdrant-landing/content/blog/case-study-cosmos.md
+++ b/qdrant-landing/content/blog/case-study-cosmos.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ![How Cosmos powered text, color, and hybrid search with Qdrant](/blog/case-study-cosmos/cosmos-bento-box-dark.jpg)
 
+{{< case-study-tags >}}
+
 <a href="https://www.cosmos.so/" target="_blank">Cosmos</a> is redefining how people find inspiration online. It’s a visual search app built for creative professionals and everyday users who want a clean, meditative, ad-free place to collect and curate ideas. In contrast to feeds dominated by doomscrolling, ads, and generative “AI slop,” Cosmos focuses on high-quality, human-made content. AI-powered search and captions connect each image to its creator, making visual discovery richer, more accurate, and easier to navigate. 
 
 Behind this front end sits a complex technical problem: powering text, color, and hybrid visual search for millions of users in real time. For Cosmos, the solution came from Qdrant Cloud. 

--- a/qdrant-landing/content/blog/case-study-dailymotion.md
+++ b/qdrant-landing/content/blog/case-study-dailymotion.md
@@ -25,6 +25,8 @@ partition: case-studies
 ## Dailymotion's Journey to Crafting the Ultimate Content-Driven Video Recommendation Engine with Qdrant Vector Search
 In today's digital age, the consumption of video content has become ubiquitous, with an overwhelming abundance of options available at our fingertips. However, amidst this vast sea of videos, the challenge lies not in finding content, but in discovering the content that truly resonates with individual preferences and interests and yet is diverse enough to not throw users into their own filter bubble. As viewers, we seek meaningful and relevant videos that enrich our experiences, provoke thought, and spark inspiration.
 
+{{< case-study-tags >}}
+
 Dailymotion is not just another video application; it's a beacon of curated content in an ocean of options. With a steadfast commitment to providing users with meaningful and ethical viewing experiences, Dailymotion stands as the bastion of videos that truly matter.
 
 They aim to boost a dynamic visual dialogue, breaking echo chambers and fostering discovery.

--- a/qdrant-landing/content/blog/case-study-datagraphs.md
+++ b/qdrant-landing/content/blog/case-study-datagraphs.md
@@ -21,6 +21,8 @@ tags:
 
 ![How Data Graphs Built a True Hybrid Graph RAG Platform](/blog/case-study-datagraphs/datagraphs-bento.png)
 
+{{< case-study-tags >}}
+
 Data Graphs is a UK-based platform company that provides a knowledge graph-as-a-service polystore, built on a proprietary, high-performance graph database engine. Co-founded by Paul Wilton over 10 years ago as a consultancy, Data Graphs has evolved into a platform that serves industries ranging from sports media and publishing to GLAM (galleries, libraries, archives, museums), Agri-Tech, and Regulatory Technology.
 
 The Data Graphs platform combines a proprietary graph database, full-text search, vector embeddings, workflow automation, and an Agentic AI layer into a single, unified backbone for enterprise data. For organizations managing complex, highly connected data, the platform acts as both the system of record and the context layer that reasons across it.

--- a/qdrant-landing/content/blog/case-study-deutsche-telekom.md
+++ b/qdrant-landing/content/blog/case-study-deutsche-telekom.md
@@ -15,6 +15,8 @@ tags:
 partition: case-studies
 ---
 
+{{< case-study-tags >}}
+
 **How Deutsche Telekom Built a Scalable, Multi-Agent Enterprise Platform Leveraging Qdrant—Powering Over 2 Million Conversations Across Europe**
 
 ![Deutsche Telekom's AI Competence Center team leading the LMOS platform development](/blog/case-study-deutsche-telekom/dtag-team.jpg)

--- a/qdrant-landing/content/blog/case-study-dragonfruit.md
+++ b/qdrant-landing/content/blog/case-study-dragonfruit.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ![Dragonfruit Overview](/blog/case-study-dragonfruit/dragonfruit-bento-box-dark.png)
 
+{{< case-study-tags >}}
+
 ## Dragonfruit AI scales real-time computer vision with Qdrant
 ### Building enterprise-ready computer vision
 

--- a/qdrant-landing/content/blog/case-study-dust-v2.md
+++ b/qdrant-landing/content/blog/case-study-dust-v2.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ## Inside Dust’s Vector Stack Overhaul: Scaling to 5,000+ Data Sources with Qdrant
 
+{{< case-study-tags >}}
+
 ![How Dust Scaled to 5,000+ Data Sources with Qdrant](/blog/case-study-dust-v2/case-study-dust-v2-v2-bento-dark.jpg)
 
 We first wrote about Dust in 2024, in [Dust and Qdrant: Using AI to Unlock Company Knowledge and Drive Employee Productivity](/blog/dust-and-qdrant/). This is what came next.

--- a/qdrant-landing/content/blog/case-study-faz.md
+++ b/qdrant-landing/content/blog/case-study-faz.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 # How FAZ Built a Hybrid Search Engine with Qdrant to Unlock 75 Years of Journalism
 
+{{< case-study-tags >}}
+
 [Frankfurter Allgemeine Zeitung (FAZ)](https://www.frankfurterallgemeine.de/die-faz), a major national newspaper in Germany, has spent decades building a rich archive of journalistic content, stretching back to 1949\. The FAZ archive has long built expertise in making its extensive collection of over 75 years accessible and searchable for both internal and external customers through keyword- and index-based search engines. New AI-powered search technologies were therefore immediately recognized as an opportunity to unlock the potential of the comprehensive archive in entirely new ways and to systematically address the limitations of traditional search methods. The solution they arrived at involved a thoughtful orchestration of technologies \- with Qdrant at the heart.
 
 This undertaking was driven by a cross-functional team:

--- a/qdrant-landing/content/blog/case-study-fieldy.md
+++ b/qdrant-landing/content/blog/case-study-fieldy.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ## Fieldy AI’s migration to Qdrant: Building a fault-tolerant AI memory platform
 
+{{< case-study-tags >}}
+
 ![How Fieldy AI Achieved Reliable AI Memory with Qdrant](/blog/case-study-fieldy/case-study-fieldy-bento-dark.jpg)
 
 ### Capturing and retrieving a lifetime of conversations

--- a/qdrant-landing/content/blog/case-study-flipkart.md
+++ b/qdrant-landing/content/blog/case-study-flipkart.md
@@ -21,6 +21,8 @@ partition: case-studies
 
 ### Tackling fraud and abuse with scalable similarity search 
 
+{{< case-study-tags >}}
+
 At Flipkart, the Trust & Safety team is focused on detecting and preventing platform abuse and fraud. A critical part of this work involves running large-scale similarity searches across customer and seller-submitted data, particularly images. This allows the team to identify patterns associated with fraudulent activity, such as repeat returns or duplicate seller claims, before they cause downstream harm. 
 
 *“Platform integrity is a constant challenge. To stay ahead of fraudulent actors, we needed a system that could compare multimodal data in real time, not just in long-running batch jobs.”* 

--- a/qdrant-landing/content/blog/case-study-garden-intel.md
+++ b/qdrant-landing/content/blog/case-study-garden-intel.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ## Garden Accelerates Patent Intelligence with Qdrant’s Filterable Vector Search
 
+{{< case-study-tags >}}
+
 ![How Garden Unlocked AI Patent Analysis](/blog/case-study-garden/case-study-garden-bento-dark.jpg)
 
 For more than a century, patent litigation has been a slow, people-powered business. Analysts read page after page—sometimes tens of thousands of pages—hunting for the smoking-gun paragraph that proves infringement or invalidity. Garden, a New York-based startup, set out to change that by applying large-scale AI to the entire global patent corpus—more than 200 million patents—in conjunction with terabytes of real world data.

--- a/qdrant-landing/content/blog/case-study-glassdollar.md
+++ b/qdrant-landing/content/blog/case-study-glassdollar.md
@@ -23,6 +23,8 @@ partition: case-studies
 
 ![GlassDollar overview](/blog/case-study-glassdollar/glassdollar-bento-box.png)
 
+{{< case-study-tags >}}
+
 <a href="https://www.glassdollar.com/" target="_blank">GlassDollar</a> helps enterprises such as Siemens, Mahle, and A2A discover, compare, and run proof-of-concepts with innovative startups. The platform combines an chatbot-like experience for discovering innovate companies with tools to manager innovation projects from start to finish.
 
 For GlassDollar, search is not a feature. It is the core mechanism that turns an enterprise problem statement into a shortlist of relevant companies, ranked and contextualized for decision-making.

--- a/qdrant-landing/content/blog/case-study-gooddata.md
+++ b/qdrant-landing/content/blog/case-study-gooddata.md
@@ -22,6 +22,8 @@ partition: case-studies
 ![Gooddata Overview](/blog/case-study-gooddata/gooddata-bento-box-dark.jpg)
 ### GoodData's Evolution into AI-Powered Analytics
 
+{{< case-study-tags >}}
+
 AI is redefining how people interact with data, pushing analytics platforms beyond static dashboards toward intelligent, conversational experiences. While traditionally recognized as a powerful BI platform, GoodData is laser-focused on accelerating both 'time to insight' and 'time to solution' by enhancing productivity for analysts and business users alike. 
 
 What sets GoodData apart is its unique position in the market: a composable, API-first platform designed for teams that build data products, not just consume them. With deep support for white-labeled analytics, embedded use cases, and governed self-service at scale, GoodData delivers the flexibility modern organizations need. With AI being integrated across every layer of the platform, GoodData is helping their over 140,000 end customers move from traditional BI to intelligent, real-time decision-making.

--- a/qdrant-landing/content/blog/case-study-hubspot.md
+++ b/qdrant-landing/content/blog/case-study-hubspot.md
@@ -18,6 +18,8 @@ tags:
 partition: case-studies
 ---
 
+{{< case-study-tags >}}
+
 HubSpot, a global leader in CRM solutions, continuously enhances its product suite with powerful AI-driven features. To optimize Breeze AI, its flagship intelligent assistant, HubSpot chose Qdrant as its vector database.
 
 ## **Challenges Scaling an Intelligent AI**

--- a/qdrant-landing/content/blog/case-study-kairoswealth.md
+++ b/qdrant-landing/content/blog/case-study-kairoswealth.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ![Kairoswealth overview](/blog/case-study-kairoswealth/image2.png)
 
+{{< case-study-tags >}}
+
 ## **About Kairoswealth**
 
 [Kairoswealth](https://kairoswealth.com/) is a comprehensive wealth management platform designed to provide users with a holistic view of their financial portfolio. The platform offers access to unique financial products and automates back-office operations through its AI assistant, Gaia.

--- a/qdrant-landing/content/blog/case-study-kakao.md
+++ b/qdrant-landing/content/blog/case-study-kakao.md
@@ -19,6 +19,8 @@ tags:
 partition: case-studies
 ---
 
+{{< case-study-tags >}}
+
 <a href="https://www.kakaocorp.com/" target="_blank">Kakao</a>  is one of South Korea's leading technology companies, best known for KakaoTalk, the country's dominant messaging platform with over 48 million monthly active users. Beyond messaging, Kakao operates a broad ecosystem of services including maps, mobility, fintech, and enterprise solutions.
 
 ## Helping employees find answers faster without sacrificing precision or control

--- a/qdrant-landing/content/blog/case-study-kern.md
+++ b/qdrant-landing/content/blog/case-study-kern.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ![kern-case-study](/blog/case-study-kern/kern-case-study.png)
 
+{{< case-study-tags >}}
+
 ## About Kern AI
 
 [Kern AI](https://kern.ai/) specializes in data-centric AI. Originally an AI consulting firm, the team led by Co-Founder and CEO Johannes Hötter quickly realized that developers spend 80% of their time reviewing data instead of focusing on model development. This inefficiency significantly reduces the speed of development and adoption of AI. To tackle this challenge, Kern AI developed a low-code platform that enables developers to quickly analyze their datasets and identify outliers using vector search. This innovation led to enhanced data accuracy and streamlined workflows for the rapid deployment of AI applications.

--- a/qdrant-landing/content/blog/case-study-lawme.md
+++ b/qdrant-landing/content/blog/case-study-lawme.md
@@ -21,6 +21,8 @@ partition: case-studies
 
 ## How Lawme Scaled AI Legal Assistants and Cut Costs by 75% with Qdrant
 
+{{< case-study-tags >}}
+
 ![How Lawme Scaled AI Legal Assistants and Cut Costs 75% with Qdrant](/blog/case-study-lawme/lawme-bento-dark.jpg)
 
 Legal technology (LegalTech) is at the forefront of digital transformation in the traditionally conservative legal industry. Lawme.ai, an ambitious startup, is pioneering this transformation by automating routine legal workflows with AI assistants. By leveraging sophisticated AI-driven processes, Lawme empowers law firms to dramatically accelerate legal document preparation, from initial research and analysis to comprehensive drafting. However, scaling their solution presented formidable challenges, particularly around data management, compliance, and operational costs.

--- a/qdrant-landing/content/blog/case-study-lettria-v2.md
+++ b/qdrant-landing/content/blog/case-study-lettria-v2.md
@@ -23,6 +23,8 @@ partition: case-studies
 
 # Scaled Vector & Graph Retrieval: How Lettria Unlocked 20% Accuracy Gains with Qdrant & Neo4j
 
+{{< case-study-tags >}}
+
 ![Lettria increases accuracy by 20% by blending Qdrant's vector search and Neo4j's knowledge graphs](/blog/case-study-lettria/lettria-bento-dark.jpg)
 
 ## Why Complex Document Intelligence Needs More Than Just Vector Search

--- a/qdrant-landing/content/blog/case-study-lyzr.md
+++ b/qdrant-landing/content/blog/case-study-lyzr.md
@@ -19,6 +19,8 @@ partition: case-studies
 ---
 # How Lyzr Supercharged AI Agent Performance with Qdrant
 
+{{< case-study-tags >}}
+
 {{< case-study-summary
   results="90% | Faster query latency under high concurrency; 2x | Faster indexing for large-scale knowledge bases; 30% | Lower infrastructure costs from reduced resource usage" >}}
 

--- a/qdrant-landing/content/blog/case-study-mixpeek.md
+++ b/qdrant-landing/content/blog/case-study-mixpeek.md
@@ -19,6 +19,8 @@ partition: case-studies
 ---
 # How Mixpeek Uses Qdrant for Efficient Multimodal Feature Stores
 
+{{< case-study-tags >}}
+
 ![How Mixpeek Uses Qdrant for Efficient Multimodal Feature Stores](/blog/case-study-mixpeek/Case-Study-Mixpeek-Summary-Dark.jpg)
 
 ## About Mixpeek

--- a/qdrant-landing/content/blog/case-study-my-askai.md
+++ b/qdrant-landing/content/blog/case-study-my-askai.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ![My AskAI overview](/blog/case-study-my-askai/my-askai-bento-box.png)
 
+{{< case-study-tags >}}
+
 <a href="https://myaskai.com" target="_blank">My AskAI</a> built a managed platform for AI customer support agents that plug directly into existing helpdesk tools like <a href="https://myaskai.com/ai-agent-integration/intercom" target="_blank">Intercom</a>
 and <a href="https://myaskai.com/ai-agent-integration/zendesk-tickets" target="_blank">Zendesk</a> . The goal was to make AI behave like a reliable coworker, not a brittle chatbot. In production, My AskAI's agents are designed to resolve a large portion of inbound support requests automatically, then hand over to a human when the agent cannot answer confidently. My AskAI positions this as <a href="https://myaskai.com/blog/my-askai-edel-optics-case-study-2026" target="_blank">deflecting around 75 percent of support requests</a> and sustaining a resolution rate in the low to mid 70s, depending on the time window and workload mix.
 

--- a/qdrant-landing/content/blog/case-study-nyris.md
+++ b/qdrant-landing/content/blog/case-study-nyris.md
@@ -19,6 +19,8 @@ partition: case-studies
 
 ![nyris-case-study](/blog/case-study-nyris/nyris-case-study.png)
 
+{{< case-study-tags >}}
+
 ## About Nyris
 
 Founded in 2015 by CTO Markus Lukasson and his sister Anna Lukasson-Herzig, [Nyris](https://www.nyris.io/) offers advanced visual search solutions for companies, positioning itself as the "Google Lens" for corporate data. Their technology powers use cases such as visual search on websites of large retailers and machine manufacturing companies that require visual identification of spare parts. The primary goal is to identify items in a product catalog or spare parts as quickly as possible. With a strong foundation in e-commerce and nearly a decade of experience in vector search, Nyris is at the forefront of visual search innovation.

--- a/qdrant-landing/content/blog/case-study-opentable.md
+++ b/qdrant-landing/content/blog/case-study-opentable.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ## **Reinventing Restaurant Discovery: How OpenTable built Concierge, an AI Dining Assistant** 
 
+{{< case-study-tags >}}
+
 ### Recognizing that AI would redefine restaurant discovery 
 
 When generative AI tools entered the mainstream, OpenTable knew diners would change how they find and choose restaurants. People were beginning to expect conversational, intelligent and context-aware assistants, rather than static search boxes. 

--- a/qdrant-landing/content/blog/case-study-pariti.md
+++ b/qdrant-landing/content/blog/case-study-pariti.md
@@ -21,6 +21,8 @@ partition: case-studies
 
 ## From Manual Bottlenecks to Millisecond Matching: Connecting Africa’s Best Talent
 
+{{< case-study-tags >}}
+
 {{< case-study-summary
   results="20% → 48% | Hiring fill-rate; 4 min → 1 min | Candidate vetting time; 94% | of hires ranked in top 10% of search results" >}}
 

--- a/qdrant-landing/content/blog/case-study-pathwork.md
+++ b/qdrant-landing/content/blog/case-study-pathwork.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ## **Pathwork Optimizes Life Insurance Underwriting with Precision Vector Search**
 
+{{< case-study-tags >}}
+
 {{< case-study-summary
   results="~50% | error reduction; 78% | faster responses, MSE dropped from 3.5 → 1.8; 50% | MoM user growth, query latency cut from 9s → 2s" >}}
 

--- a/qdrant-landing/content/blog/case-study-pento.md
+++ b/qdrant-landing/content/blog/case-study-pento.md
@@ -21,6 +21,8 @@ partition: case-studies
 
 ![pento bento box](/blog/case-study-pento/pento-bento-box-dark.jpg)
 
+{{< case-study-tags >}}
+
 # Bringing People Together Through Qdrant
 
 ![pento-cover-image](/blog/case-study-pento/pento-cover-image.png)

--- a/qdrant-landing/content/blog/case-study-pienso.md
+++ b/qdrant-landing/content/blog/case-study-pienso.md
@@ -15,6 +15,8 @@ aliases:
 partition: case-studies
 ---
 
+{{< case-study-tags >}}
+
 The partnership between Pienso and Qdrant is set to revolutionize interactive deep learning, making it practical, efficient, and scalable for global customers. Pienso's low-code platform provides a streamlined and user-friendly process for deep learning tasks. This exceptional level of convenience is augmented by Qdrant’s scalable and cost-efficient high vector computation capabilities, which enable reliable retrieval of similar vectors from high-dimensional spaces.
 
 Together, Pienso and Qdrant will empower enterprises to harness the full potential of generative AI on a large scale. By combining the technologies of both companies, organizations will be able to train their own large language models and leverage them for downstream tasks that demand data sovereignty and model autonomy. This collaboration will help customers unlock new possibilities and achieve advanced AI-driven solutions.

--- a/qdrant-landing/content/blog/case-study-portfolio-mind.md
+++ b/qdrant-landing/content/blog/case-study-portfolio-mind.md
@@ -21,6 +21,8 @@ partition: case-studies
 
 ## **How PortfolioMind delivered real-time crypto intelligence with Qdrant**
 
+{{< case-study-tags >}}
+
 The crypto world is an inherently noisy and volatile place. Markets shift quickly, narratives change overnight, and wallet activities conceal subtle yet critical patterns. For PortfolioMind,  Web3-native AI research copilot built using the [SpoonOS framework](https://spoonai.io/), the challenge was not only finding just finding relevant information, but also surfacing it in real-time.
 
 ### Challenge: Moving beyond static insights

--- a/qdrant-landing/content/blog/case-study-qatech.md
+++ b/qdrant-landing/content/blog/case-study-qatech.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ![qdrant-qatech-1](/blog/case-study-qatech/qdrant-qatech-1.png)
 
+{{< case-study-tags >}}
+
 [QA.tech](https://qa.tech/), a company specializing in AI-driven automated testing solutions, found that building and **fully testing web applications, especially end-to-end, can be complex and time-consuming**. Unlike unit tests, end-to-end tests reveal what’s actually happening in the browser, often uncovering issues that other methods miss. 
 
 Traditional solutions like hard-coded tests are not only labor-intensive to set up but also challenging to maintain over time. Alternatively, hiring QA testers can be a solution, but for startups, it quickly becomes a bottleneck. With every release, more testers are needed, and if testing is outsourced, managing timelines and ensuring quality becomes even harder.

--- a/qdrant-landing/content/blog/case-study-qovery.md
+++ b/qdrant-landing/content/blog/case-study-qovery.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ## Qovery Scales Real-Time DevOps Automation with Qdrant
 
+{{< case-study-tags >}}
+
 {{< case-study-summary
   results=" | Zero-maintenance ops; | Tasks take seconds vs. hours; >100K | vectors indexed" >}}
 

--- a/qdrant-landing/content/blog/case-study-sayone.md
+++ b/qdrant-landing/content/blog/case-study-sayone.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ## How SayOne Enhanced Government AI Services with Qdrant
 
+{{< case-study-tags >}}
+
 
 {{< case-study-summary
   results=" | Improved Latency; | Global Privacy Compliance; | Enhanced Developer Productivity" >}}

--- a/qdrant-landing/content/blog/case-study-shakudo.md
+++ b/qdrant-landing/content/blog/case-study-shakudo.md
@@ -14,6 +14,8 @@ tags:
 partition: case-studies
 ---
 
+{{< case-study-tags >}}
+
 We are excited to announce that Qdrant has partnered with [Shakudo](https://www.shakudo.io/), bringing [Qdrant Hybrid Cloud](https://qdrant.tech/hybrid-cloud/) to Shakudo’s virtual private cloud (VPC) deployments. This collaboration allows Shakudo clients to seamlessly integrate Qdrant’s high-performance vector database as a managed service into their private infrastructure, ensuring data sovereignty, scalability, and low-latency vector search for enterprise AI applications.
 
 ## Data Sovereignty and Compliance with Secure Vector Search

--- a/qdrant-landing/content/blog/case-study-sprinklr.md
+++ b/qdrant-landing/content/blog/case-study-sprinklr.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ![case-study-sprinklr-1](/blog/case-study-sprinklr/image1.png)
 
+{{< case-study-tags >}}
+
 
 [Sprinklr](https://www.sprinklr.com/), a leader in unified customer experience management (Unified-CXM), helps global brands engage customers meaningfully across more than 30 digital channels. To achieve this, Sprinklr needed a scalable solution for AI-powered search to support their AI applications, particularly in handling the vast data requirements of customer interactions.
 

--- a/qdrant-landing/content/blog/case-study-tavus.md
+++ b/qdrant-landing/content/blog/case-study-tavus.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ![Tavus Overview](/blog/case-study-tavus/tavus-bento-box-dark.jpg)
 
+{{< case-study-tags >}}
+
 ## How Tavus delivered human-grade conversational AI with edge retrieval on Qdrant
 
 Tavus is a human–computer research lab building CVI, the <a href="https://www.tavus.io/" target="_blank">Conversational Video Interface</a>. CVI presents a face-to-face AI that reads tone, gesture, and on-screen context in real time, allowing for humans to interface with powerful, functional AI like never before. The team’s north star was simple to say and hard to ship: conversations should feel natural. That meant tracking conversational dynamics like utterance-to-utterance timing, back-channeling, and turn-taking while grounding replies in a customer’s private knowledge.

--- a/qdrant-landing/content/blog/case-study-tripadvisor.md
+++ b/qdrant-landing/content/blog/case-study-tripadvisor.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 # How Tripadvisor Is Reimagining Travel with Qdrant
 
+{{< case-study-tags >}}
+
 {{< case-study-summary
   results="2-3x | Revenue Uplift; 1B+ | Content Items Indexed; 11M | businesses and 21 countries supported" >}}
 

--- a/qdrant-landing/content/blog/case-study-trustgraph.md
+++ b/qdrant-landing/content/blog/case-study-trustgraph.md
@@ -23,6 +23,8 @@ partition: case-studies
 
 ![TrustGraph Overview](/blog/case-study-trustgraph/trustgraph-bento-box-dark.jpg)
 
+{{< case-study-tags >}}
+
 # TrustGraph \+ Qdrant: A Technical Deep Dive
 
 When teams first experiment with agentic AI, the journey often starts with a slick demo: a few APIs stitched together, a large language model answering questions, and just enough smoke and mirrors to impress stakeholders.

--- a/qdrant-landing/content/blog/case-study-visua.md
+++ b/qdrant-landing/content/blog/case-study-visua.md
@@ -20,6 +20,8 @@ partition: case-studies
 
 ![visua/image1.png](/blog/case-study-visua/image1.png)
 
+{{< case-study-tags >}}
+
 For over a decade, [VISUA](https://visua.com/) has been a leader in precise, high-volume computer vision data analysis, developing a robust platform that caters to a wide range of use cases, from startups to large enterprises. Starting with social media monitoring, where it excels in analyzing vast data volumes to detect company logos, VISUA has built a diverse ecosystem of customers, including names in social media monitoring, like **Brandwatch**, cybersecurity like **Mimecast**, trademark protection like **Ebay** and several sports agencies like **Vision Insights** for sponsorship evaluation.
 
 ![visua/image3.png](/blog/case-study-visua/image3.png)

--- a/qdrant-landing/content/blog/case-study-voiceflow.md
+++ b/qdrant-landing/content/blog/case-study-voiceflow.md
@@ -20,6 +20,8 @@ partition: case-studies
 ---
 ![voiceflow/image2.png](/blog/case-study-voiceflow/image1.png)
 
+{{< case-study-tags >}}
+
 [Voiceflow](https://www.voiceflow.com/) enables enterprises to create AI agents in a no-code environment by designing workflows through a drag-and-drop interface. The platform allows developers to host and customize chatbot interfaces without needing to build their own RAG pipeline, working out of the box and being easily adaptable to specific use cases. “Powered by technologies like Natural Language Understanding (NLU), Large Language Models (LLM), and Qdrant as a vector search engine, Voiceflow serves a diverse range of customers, including enterprises that develop chatbots for internal and external AI use cases,” says [Xavier Portillo Edo](https://www.linkedin.com/in/xavierportillaedo/), Head of Cloud Infrastructure at Voiceflow.
 
 ## Evaluation Criteria

--- a/qdrant-landing/content/blog/case-study-xaver.md
+++ b/qdrant-landing/content/blog/case-study-xaver.md
@@ -22,6 +22,8 @@ partition: case-studies
 
 ![Xaver Overview](/blog/case-study-xaver/xaver-bento-box-dark.jpg)
 
+{{< case-study-tags >}}
+
 ## How Xaver Built its AI Knowledge Engine with Qdrant
 
 <a href="https://www.xaver.com/" target="_blank">Xaver</a> is tackling a core challenge in the financial industry: scaling personalized financial and retirement advice. As demographic shifts increase demand for private pensions, traditional, manual consultation models are proving too slow and costly to support everyone who needs help.

--- a/qdrant-landing/content/customers/clients/_index.md
+++ b/qdrant-landing/content/customers/clients/_index.md
@@ -78,7 +78,7 @@ clients:
     industry: E-commerce
     product: Qdrant Cloud
     company_size: 1-50 by
-    locationse: Asia Pacific
+    location: Asia Pacific
     use_cases: ["Recommendations", "E-commerce discovery", "Real-time analytics"]
     title: "How ConvoSearch Boosted Revenue for D2C Brands with Qdrant"
     blog_path: /blog/case-study-convosearch

--- a/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
@@ -9,6 +9,7 @@
 @import 'partials/qdrant-post';
 @import 'partials/customer-quote';
 @import 'partials/case-study-summary';
+@import 'partials/case-study-tags';
 @import 'partials/qdrant-articles-hero';
 @import 'partials/qdrant-articles-posts';
 @import 'partials/carousel';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
@@ -34,6 +34,7 @@
 @import 'partials/qdrant-post';
 @import 'partials/customer-quote';
 @import 'partials/case-study-summary';
+@import 'partials/case-study-tags';
 @import 'partials/carousel';
 @import 'partials/leadership';
 @import 'partials/open-roles';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-tags.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-tags.scss
@@ -1,0 +1,28 @@
+@use '../helpers/functions' as *;
+
+// Facts about the customer, read from the customers catalog. Nested so each
+// rule carries two classes: the article stylesheet styles bare `ul` and `li`
+// under .qdrant-post__content and would otherwise win.
+.case-study-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacer * 0.5;
+  margin: 0 0 $spacer * 2;
+  padding: 0;
+  list-style: none;
+
+  .case-study-tags__tag {
+    margin: 0;
+    padding: pxToRem(6) pxToRem(14);
+    border: pxToRem(1) solid $neutral-90;
+    border-radius: pxToRem(100);
+    background-color: $neutral-98;
+    font-size: pxToRem(14);
+    line-height: pxToRem(21);
+    color: $neutral-30;
+
+    &::marker {
+      content: none;
+    }
+  }
+}

--- a/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/case-study-tags.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/shortcodes/case-study-tags.html
@@ -1,0 +1,62 @@
+{{- /*
+  Facts about the customer, taken from the customers catalog.
+
+  The catalog at content/customers/clients/_index.md already records each
+  customer's industry, deployment, region and use cases, and the filters on
+  /customers/ run off those exact values. Reading them here rather than
+  retyping them per article means the two can never drift apart, and adding a
+  tag to a case study means adding it to the catalog, where it also becomes
+  filterable.
+
+  Usage, on any case study whose path appears as a `blog_path` in the catalog:
+
+    {{< case-study-tags >}}
+
+  Choose and order the fields:
+
+    {{< case-study-tags fields="industry product location use_cases" >}}
+
+  Point it at a different customer, for a page whose own path is not in the
+  catalog:
+
+    {{< case-study-tags id="dust" >}}
+
+  Renders nothing at all when the customer has no catalog row, so a page with
+  no entry simply carries no tags.
+*/ -}}
+
+{{- $fields := split (.Get "fields" | default "industry product location") " " -}}
+{{- $want := .Get "id" -}}
+{{- $path := strings.TrimSuffix "/" .Page.RelPermalink -}}
+
+{{- $client := false -}}
+{{- with site.GetPage "/customers/clients" -}}
+  {{- range .Params.clients -}}
+    {{- $blog := strings.TrimSuffix "/" (.blog_path | default "") -}}
+    {{- if or (and $want (eq .id $want)) (and (not $want) $blog (eq $blog $path)) -}}
+      {{- $client = . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with $client -}}
+  {{- $tags := slice -}}
+  {{- range $fields -}}
+    {{- $v := index $client . -}}
+    {{- if $v -}}
+      {{- if reflect.IsSlice $v -}}
+        {{- range $v }}{{ $tags = $tags | append . }}{{ end -}}
+      {{- else -}}
+        {{- $tags = $tags | append $v -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- with $tags }}
+  <ul class="case-study-tags">
+    {{- range . }}
+    <li class="case-study-tags__tag">{{ . }}</li>
+    {{- end }}
+  </ul>
+  {{- end }}
+{{- end -}}


### PR DESCRIPTION
Stacked on #2699 — review that one first.

The customers catalog already records each customer's industry, product, region and use cases, and the filters on `/customers/` run off those exact values. A case study page showed none of it.

Adds a `case-study-tags` shortcode that **reads the catalog by `blog_path`** rather than taking the values as parameters:

```
{{< case-study-tags >}}                                        industry · deployment · region
{{< case-study-tags fields="industry product location use_cases" >}}
{{< case-study-tags id="dust" >}}                              for a page not in the catalog
```

Retyping the values per article would let the page and the filters drift apart. This way adding a tag means adding it to the catalog, where it also becomes filterable.

## Why three fields, not four

`use_cases` is the richest field — RAG appears on 31 customers — but most customers carry three of them, so including it produced six chips wrapping onto two rows and buried the industry and deployment behind a list of capabilities. It stays available as an opt-in.

## Scope

Applied to the **46 case studies whose published URL matches a catalog row**. Six have no row — Bayer, Data Graphs, GoPerfect, Minima, Sapu, Sunny Health — and are left alone rather than carrying a shortcode that renders nothing. Adding rows for them is worth doing separately; they would then also appear in the `/customers/` catalog, which they currently do not.

Placement follows whatever each article opens with: after the hero image, after the title heading, or at the top when it opens straight into prose.

## One data fix included

`locationse:` on the ConvoSearch row. It was the only page rendering two tags instead of three, and the same typo had been quietly keeping ConvoSearch out of the Geography filter on `/customers/`.

## Data problems found but deliberately not fixed here

Putting catalog values on public pages makes catalog errors visible. Two worth a separate pass, because both need someone to decide the right value rather than correct a typo:

- **Pariti** is recorded as `industry: Technology, location: Global`, while its own article opens *"Pariti is a referral-driven hiring marketplace in Africa."*
- One row has `company_size: 1-50 by`.

## Checked

Clean build: 46 pages render tags, every one showing exactly three, no empty tag lists, no unparsed shortcodes.
