### PR TITLE
Add comparison page to the Edge docs

### DIFF
--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -51,6 +51,7 @@ How each option runs, connects, and scales.
 | **Architecture** | Embedded, in-process library | Client-server, accessed over the network |
 | **Connectivity** | Works fully offline | Requires network access to the server |
 | **Scaling** | Single shard, single device | Horizontal scaling across multiple nodes |
+| **Collections** | No collection concept; use one Edge Shard per dataset | Named collections with aliases, managed through the collection API |
 | **Multitenancy** | Payload-based partitioning within one shard, or one Edge Shard per tenant/device | Payload partitioning, user-defined sharding, or tiered — refer to [Multitenancy](/documentation/manage-data/multitenancy/) |
 
 ### Operations
@@ -62,6 +63,7 @@ How data gets indexed, optimized, and kept available.
 | **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
 | **High availability** | None; a single local shard | Replication and failover across nodes |
 | **Data sync** | Server-Edge via (partial) snapshots; Edge-server via application-level dual-write | Acts as the snapshot source and write target |
+| **Snapshots** | Consume only: unpack, read manifests, and apply full or partial snapshots | Full lifecycle: create, list, download, and restore |
 
 ### API & Features
 
@@ -74,5 +76,10 @@ How you talk to each option, and what you can do once connected.
 | **Quantization** | Supported | Supported |
 | **On-disk storage** | Supported | Supported |
 | **Sparse vectors** | Supported | Supported |
-| **Grouping (`query_groups`)** | Rust only; not exposed in Python | Available |
-| **Search matrix (`search_matrix`)** | Rust only; not exposed in Python | Available |
+| **Hybrid search** | Supported, through prefetches and fusion (RRF, DBSF) | Supported |
+| **Distance metrics** | Cosine, Dot, Euclid, and Manhattan | Cosine, Dot, Euclid, and Manhattan |
+| **Multivectors** | Supported, for late-interaction models | Supported |
+| **Payload indexes** | All field types | All field types |
+| **Query scoring** | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample |
+| **Grouping (`query_groups`)** | Rust only | Available |
+| **Search matrix (`search_matrix`)** | Rust only | Available |

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -51,7 +51,7 @@ How each option runs, connects, and scales.
 | **Architecture** | Embedded, in-process library | Client-server, accessed over the network |
 | **Connectivity** | Works fully offline | Requires network access to the server |
 | **Scaling** | Single shard, single device | Horizontal scaling across multiple nodes |
-| **Multitenancy** | Manual: one Edge Shard per tenant | Native shard-key based multitenancy |
+| **Multitenancy** | Payload-based partitioning within one shard, or one Edge Shard per tenant/device | Payload partitioning, user-defined sharding, or tiered — refer to [Multitenancy](/documentation/manage-data/multitenancy/) |
 
 ### Operations
 
@@ -59,9 +59,9 @@ How data gets indexed, optimized, and kept available.
 
 | | Qdrant Edge | Qdrant Cluster |
 | --- | --- | --- |
-| **Indexing** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
+| **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
 | **High availability** | None; a single local shard | Replication and failover across nodes |
-| **Data sync** | Snapshot-based sync with a server collection ([Data Synchronization Patterns](/documentation/edge/edge-data-synchronization-patterns/)) | Not applicable |
+| **Data sync** | Server-Edge via (partial) snapshots; Edge-server via application-level dual-write | Acts as the snapshot source and write target |
 
 ### API & Features
 

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -59,7 +59,7 @@ How data gets indexed, optimized, and kept available.
 
 | | Qdrant Edge | Qdrant Cluster |
 | --- | --- | --- |
-| **Indexing** | Manual, blocking `optimize()` call; no background optimizer | Continuous background optimizer |
+| **Indexing** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
 | **High availability** | None; a single local shard | Replication and failover across nodes |
 | **Data sync** | Snapshot-based sync with a server collection ([Data Synchronization Patterns](/documentation/edge/edge-data-synchronization-patterns/)) | Not applicable |
 

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -36,3 +36,43 @@ To work with a Qdrant Edge Shard, use the [Python Bindings for Qdrant Edge](http
 ### More Examples
 
 The Qdrant GitHub repository contains examples of using the Qdrant Edge API in [Python](https://github.com/qdrant/qdrant/tree/dev/lib/edge/python/examples) and [Rust](https://github.com/qdrant/qdrant/tree/dev/lib/edge/publish/examples).
+
+## Comparison Tables
+
+Qdrant Edge and a Qdrant cluster share the same core search engine, but they're built for different environments.
+Use the following tables to review where they align and diverge.
+
+### Architecture & Deployment
+
+How each option runs, connects, and scales.
+
+| | Qdrant Edge | Qdrant Cluster |
+| --- | --- | --- |
+| **Architecture** | Embedded, in-process library | Client-server, accessed over the network |
+| **Connectivity** | Works fully offline | Requires network access to the server |
+| **Scaling** | Single shard, single device | Horizontal scaling across multiple nodes |
+| **Multitenancy** | Manual: one Edge Shard per tenant | Native shard-key based multitenancy |
+
+### Operations
+
+How data gets indexed, optimized, and kept available.
+
+| | Qdrant Edge | Qdrant Cluster |
+| --- | --- | --- |
+| **Indexing** | Manual, blocking `optimize()` call; no background optimizer | Continuous background optimizer |
+| **High availability** | None; a single local shard | Replication and failover across nodes |
+| **Data sync** | Snapshot-based sync with a server collection ([Data Synchronization Patterns](/documentation/edge/edge-data-synchronization-patterns/)) | Not applicable |
+
+### API & Features
+
+How you talk to each option, and what you can do once connected.
+
+| | Qdrant Edge | Qdrant Cluster |
+| --- | --- | --- |
+| **API** | In-process library API ([Python](https://pypi.org/project/qdrant-edge-py/) and [Rust](https://crates.io/crates/qdrant-edge) bindings) | REST and gRPC, plus all Qdrant client libraries |
+| **HNSW indexing** | Supported | Supported |
+| **Quantization** | Supported | Supported |
+| **On-disk storage** | Supported | Supported |
+| **Sparse vectors** | Supported | Supported |
+| **Grouping (`query_groups`)** | Rust only; not exposed in Python | Available |
+| **Search matrix (`search_matrix`)** | Rust only; not exposed in Python | Available |

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -63,7 +63,7 @@ How data gets indexed, optimized, and kept available.
 | **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
 | **HNSW indexing** | Manual indexing for large shards via `optimize()`; new points are brute-force searchable until then | Automatic background indexing |
 | **High availability** | None; a single local shard | Replication and failover across nodes |
-| **Snapshots** | Consume only: unpack, read manifests, and apply full or partial snapshots | Full lifecycle: create, list, download, and restore |
+| **Snapshots** | Restore snapshots only | Create and restore snapshots |
 
 ### API & Features
 

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -37,9 +37,9 @@ To work with a Qdrant Edge Shard, use the [Python Bindings for Qdrant Edge](http
 
 The Qdrant GitHub repository contains examples of using the Qdrant Edge API in [Python](https://github.com/qdrant/qdrant/tree/dev/lib/edge/python/examples) and [Rust](https://github.com/qdrant/qdrant/tree/dev/lib/edge/publish/examples).
 
-## Comparison Tables
+## Comparing Qdrant Edge and Qdrant Cluster
 
-Qdrant Edge and a Qdrant cluster share the same core search engine, but they're built for different environments.
+Qdrant Edge and a Qdrant cluster share the same core search engine, but they're built for different use cases.
 Use the following tables to review where they align and diverge.
 
 ### Architecture & Deployment
@@ -61,6 +61,7 @@ How data gets indexed, optimized, and kept available.
 | | Qdrant Edge | Qdrant Cluster |
 | --- | --- | --- |
 | **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
+│ **HNSW indexing** │ Manual indexing for large shards via `optimize()`; new points are brute-force searchable until then │ Automatic background indexing │
 | **High availability** | None; a single local shard | Replication and failover across nodes |
 | **Data sync** | Server-Edge via (partial) snapshots; Edge-server via application-level dual-write | Acts as the snapshot source and write target |
 | **Snapshots** | Consume only: unpack, read manifests, and apply full or partial snapshots | Full lifecycle: create, list, download, and restore |
@@ -72,13 +73,14 @@ How you talk to each option, and what you can do once connected.
 | | Qdrant Edge | Qdrant Cluster |
 | --- | --- | --- |
 | **API** | In-process library API ([Python](https://pypi.org/project/qdrant-edge-py/) and [Rust](https://crates.io/crates/qdrant-edge) bindings) | REST and gRPC, plus all Qdrant client libraries |
-| **HNSW indexing** | Supported | Supported |
-| **Quantization** | Supported | Supported |
-| **On-disk storage** | Supported | Supported |
+| **Dense vectors** | Supported | Supported |
 | **Sparse vectors** | Supported | Supported |
-| **Hybrid search** | Supported, through prefetches and fusion (RRF, DBSF) | Supported |
+| **Multivectors** | Supported | Supported |
+| **Named vectors** | Supported | Supported |
+| **Hybrid search** | Supported | Supported |
+| **Quantization** | Supported | Supported |
 | **Distance metrics** | Cosine, Dot, Euclid, and Manhattan | Cosine, Dot, Euclid, and Manhattan |
-| **Multivectors** | Supported, for late-interaction models | Supported |
+| **HNSW indexing** | Supported | Supported |
 | **Payload indexes** | All field types | All field types |
 | **Query scoring** | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample |
 | **Grouping (`query_groups`)** | Rust only | Available |

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -63,7 +63,6 @@ How data gets indexed, optimized, and kept available.
 | **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
 │ **HNSW indexing** │ Manual indexing for large shards via `optimize()`; new points are brute-force searchable until then │ Automatic background indexing │
 | **High availability** | None; a single local shard | Replication and failover across nodes |
-| **Data sync** | Server-Edge via (partial) snapshots; Edge-server via application-level dual-write | Acts as the snapshot source and write target |
 | **Snapshots** | Consume only: unpack, read manifests, and apply full or partial snapshots | Full lifecycle: create, list, download, and restore |
 
 ### API & Features

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -61,7 +61,7 @@ How data gets indexed, optimized, and kept available.
 | | Qdrant Edge | Qdrant Cluster |
 | --- | --- | --- |
 | **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
-│ **HNSW indexing** │ Manual indexing for large shards via `optimize()`; new points are brute-force searchable until then │ Automatic background indexing │
+| **HNSW indexing** | Manual indexing for large shards via `optimize()`; new points are brute-force searchable until then | Automatic background indexing |
 | **High availability** | None; a single local shard | Replication and failover across nodes |
 | **Snapshots** | Consume only: unpack, read manifests, and apply full or partial snapshots | Full lifecycle: create, list, download, and restore |
 

--- a/qdrant-landing/content/documentation/edge/_index.md
+++ b/qdrant-landing/content/documentation/edge/_index.md
@@ -32,55 +32,8 @@ To work with a Qdrant Edge Shard, use the [Python Bindings for Qdrant Edge](http
 | **Reference** | [Data Synchronization Patterns](/documentation/edge/edge-data-synchronization-patterns/) | Overview of patterns for synchronizing data between Edge Shards and Qdrant server collections |
 | **Advanced** | [Synchronize with a Server](/documentation/edge/edge-synchronization-guide/) | Synchronize an Edge Shard with a Qdrant server collection to offload indexing and synchronize data between devices |
 | **Reference** | [Edge API](/documentation/edge/edge-api/)                                 | Reference for the `EdgeShard` methods available in Python and Rust, with their parameters and return values |
+| **Reference** | [Edge vs. Qdrant Cluster](/documentation/edge/edge-vs-qdrant-cluster/) | Comparison of Qdrant Edge and Qdrant Server across architecture, operations, and API surface |
 
 ### More Examples
 
 The Qdrant GitHub repository contains examples of using the Qdrant Edge API in [Python](https://github.com/qdrant/qdrant/tree/dev/lib/edge/python/examples) and [Rust](https://github.com/qdrant/qdrant/tree/dev/lib/edge/publish/examples).
-
-## Comparing Qdrant Edge and Qdrant Cluster
-
-Qdrant Edge and a Qdrant cluster share the same core search engine, but they're built for different use cases.
-Use the following tables to review where they align and diverge.
-
-### Architecture & Deployment
-
-How each option runs, connects, and scales.
-
-| | Qdrant Edge | Qdrant Cluster |
-| --- | --- | --- |
-| **Architecture** | Embedded, in-process library | Client-server, accessed over the network |
-| **Connectivity** | Works fully offline | Requires network access to the server |
-| **Scaling** | Single shard, single device | Horizontal scaling across multiple nodes |
-| **Collections** | No collection concept; use one Edge Shard per dataset | Named collections with aliases, managed through the collection API |
-| **Multitenancy** | Payload-based partitioning within one shard, or one Edge Shard per tenant/device | Payload partitioning, user-defined sharding, or tiered — refer to [Multitenancy](/documentation/manage-data/multitenancy/) |
-
-### Operations
-
-How data gets indexed, optimized, and kept available.
-
-| | Qdrant Edge | Qdrant Cluster |
-| --- | --- | --- |
-| **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
-| **HNSW indexing** | Manual indexing for large shards via `optimize()`; new points are brute-force searchable until then | Automatic background indexing |
-| **High availability** | None; a single local shard | Replication and failover across nodes |
-| **Snapshots** | Restore snapshots only | Create and restore snapshots |
-
-### API & Features
-
-How you talk to each option, and what you can do once connected.
-
-| | Qdrant Edge | Qdrant Cluster |
-| --- | --- | --- |
-| **API** | In-process library API ([Python](https://pypi.org/project/qdrant-edge-py/) and [Rust](https://crates.io/crates/qdrant-edge) bindings) | REST and gRPC, plus all Qdrant client libraries |
-| **Dense vectors** | Supported | Supported |
-| **Sparse vectors** | Supported | Supported |
-| **Multivectors** | Supported | Supported |
-| **Named vectors** | Supported | Supported |
-| **Hybrid search** | Supported | Supported |
-| **Quantization** | Supported | Supported |
-| **Distance metrics** | Cosine, Dot, Euclid, and Manhattan | Cosine, Dot, Euclid, and Manhattan |
-| **HNSW indexing** | Supported | Supported |
-| **Payload indexes** | All field types | All field types |
-| **Query scoring** | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample |
-| **Grouping (`query_groups`)** | Rust only | Available |
-| **Search matrix (`search_matrix`)** | Rust only | Available |

--- a/qdrant-landing/content/documentation/edge/edge-vs-qdrant-cluster.md
+++ b/qdrant-landing/content/documentation/edge/edge-vs-qdrant-cluster.md
@@ -1,0 +1,55 @@
+---
+title: "Edge vs. Qdrant Cluster"
+short_description: "Compare Qdrant Edge and Qdrant Server across architecture, deployment, operations, and API surface."
+description: "Compare Qdrant Edge with Qdrant Server across architecture, deployment, operations, and API surface to decide which fits your use case."
+weight: 5
+partition: develop
+---
+
+# Comparing Qdrant Edge with Qdrant Server
+
+Qdrant Edge and Qdrant Server share the same core search engine, but they're built for different use cases.
+Use the following tables to review where they align and diverge. Rows marked *distributed mode* describe capabilities that require a multi-node Qdrant cluster.
+
+## Architecture & Deployment
+
+How each option runs, connects, and scales.
+
+| | Qdrant Edge | Qdrant Server |
+| --- | --- | --- |
+| **Architecture** | Embedded, in-process library | Client-server, accessed over the network |
+| **Connectivity** | Works fully offline | Requires network access to the server |
+| **Scaling** | Single shard, single device | Horizontal scaling across multiple nodes (*distributed mode*) |
+| **Collections** | No collection concept; use one Edge Shard per dataset | Named collections with aliases, managed through the collection API |
+| **Multitenancy** | Payload-based partitioning within one shard, or one Edge Shard per tenant/device | Payload partitioning, user-defined sharding, or tiered — refer to [Multitenancy](/documentation/manage-data/multitenancy/) |
+
+## Operations
+
+How data gets indexed, optimized, and kept available.
+
+| | Qdrant Edge | Qdrant Server |
+| --- | --- | --- |
+| **Optimization** | Manual, by calling `optimize()`; runs synchronously | Continuous background optimizer |
+| **HNSW indexing** | Manual indexing for large shards via `optimize()`; new points are brute-force searchable until then | Automatic background indexing |
+| **High availability** | None; a single local shard | Replication and failover across nodes (*distributed mode*) |
+| **Snapshots** | Restore snapshots only | Create and restore snapshots |
+
+## API & Features
+
+How you talk to each option, and what you can do once connected.
+
+| | Qdrant Edge | Qdrant Server |
+| --- | --- | --- |
+| **API** | In-process library API ([Python](https://pypi.org/project/qdrant-edge-py/) and [Rust](https://crates.io/crates/qdrant-edge) bindings) | REST and gRPC, plus all Qdrant client libraries |
+| **Dense vectors** | Supported | Supported |
+| **Sparse vectors** | Supported | Supported |
+| **Multivectors** | Supported | Supported |
+| **Named vectors** | Supported | Supported |
+| **Hybrid search** | Supported | Supported |
+| **Quantization** | Supported | Supported |
+| **Distance metrics** | Cosine, Dot, Euclid, and Manhattan | Cosine, Dot, Euclid, and Manhattan |
+| **HNSW indexing** | Supported | Supported |
+| **Payload indexes** | All field types | All field types |
+| **Query scoring** | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample | Nearest neighbor, recommendation, discovery, context, formula, MMR, order-by, and sample |
+| **Grouping (`query_groups`)** | Rust only | Available |
+| **Search matrix (`search_matrix`)** | Rust only | Available |


### PR DESCRIPTION
## Overview

### [Preview](https://deploy-preview-2705--condescending-goldwasser-91acf0.netlify.app/documentation/edge/edge-vs-qdrant-cluster/)

This PR adds a comparison page to the Edge docs, showing where Edge and a Qdrant cluster align and where they diverge.