### PR TITLE
Show a case study's industry, deployment and region in its byline

### DIFF
--- a/qdrant-landing/content/customers/clients/_index.md
+++ b/qdrant-landing/content/customers/clients/_index.md
@@ -78,7 +78,7 @@ clients:
     industry: E-commerce
     product: Qdrant Cloud
     company_size: 1-50 by
-    locationse: Asia Pacific
+    location: Asia Pacific
     use_cases: ["Recommendations", "E-commerce discovery", "Real-time analytics"]
     title: "How ConvoSearch Boosted Revenue for D2C Brands with Qdrant"
     blog_path: /blog/case-study-convosearch

--- a/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/blog.scss
@@ -7,6 +7,7 @@
 @import 'partials/pagination';
 @import 'partials/newsletter';
 @import 'partials/qdrant-post';
+@import 'partials/case-study-tags';
 @import 'partials/customer-quote';
 @import 'partials/qdrant-articles-hero';
 @import 'partials/qdrant-articles-posts';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/default.scss
@@ -32,6 +32,7 @@
 @import 'partials/pagination';
 @import 'partials/newsletter';
 @import 'partials/qdrant-post';
+@import 'partials/case-study-tags';
 @import 'partials/customer-quote';
 @import 'partials/carousel';
 @import 'partials/leadership';

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-tags.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-tags.scss
@@ -1,0 +1,21 @@
+@use '../helpers/functions' as *;
+
+// Industry, deployment and region for a case study. These sit inside the
+// byline row every blog post already has, so a case study extends that line
+// rather than introducing a header element other posts do not have.
+.case-study-tags {
+  display: contents;
+
+  // display:contents drops the list box but not the item markers.
+  .case-study-tags__tag {
+    margin: 0;
+    list-style: none;
+    padding: 0 pxToRem(10);
+    border: pxToRem(1) solid $neutral-90;
+    border-radius: pxToRem(100);
+    background-color: $neutral-98;
+    font-size: pxToRem(13);
+    line-height: pxToRem(21);
+    color: $neutral-50;
+  }
+}

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-tags.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_case-study-tags.scss
@@ -1,16 +1,21 @@
 @use '../helpers/functions' as *;
 
-// Industry, deployment and region for a case study. These sit inside the
-// byline row every blog post already has, so a case study extends that line
-// rather than introducing a header element other posts do not have.
+// Industry, deployment and region for a case study, on their own row between
+// the title and the byline. Sized and coloured to sit with the byline rather
+// than compete with the title.
 .case-study-tags {
-  display: contents;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: $spacer * 0.5;
+  margin: 0 0 pxToRem(10);
+  padding: 0;
+  list-style: none;
 
-  // display:contents drops the list box but not the item markers.
   .case-study-tags__tag {
     margin: 0;
-    list-style: none;
     padding: 0 pxToRem(10);
+    list-style: none;
     border: pxToRem(1) solid $neutral-90;
     border-radius: pxToRem(100);
     background-color: $neutral-98;

--- a/qdrant-landing/themes/qdrant-2024/assets/css/partials/_qdrant-post.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/partials/_qdrant-post.scss
@@ -22,6 +22,9 @@
 
   &__about {
     display: flex;
+    // Case studies add tags to this row, which overflows a phone otherwise.
+    flex-wrap: wrap;
+    align-items: center;
     justify-content: center;
     gap: pxToRem(6);
     font-size: pxToRem(14);

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/case-study-tags.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/case-study-tags.html
@@ -1,0 +1,42 @@
+{{- /*
+  Industry, deployment and region for a case study, shown under the title.
+
+  The customers catalog at content/customers/clients/_index.md already records
+  these, and the filters on /customers/ run off those exact values. Reading them
+  here rather than repeating them in each article means the two cannot drift:
+  adding a tag means adding it to the catalog, where it also becomes filterable.
+
+  Called from qdrant-post.html with the page as context. A post with no row in
+  the catalog renders nothing, so this is inert on every page that is not a
+  case study.
+
+    {{ partial "case-study-tags" . }}
+*/ -}}
+
+{{- $fields := slice "industry" "product" "location" -}}
+{{- $path := strings.TrimSuffix "/" .RelPermalink -}}
+
+{{- $client := false -}}
+{{- with site.GetPage "/customers/clients" -}}
+  {{- range .Params.clients -}}
+    {{- $blog := strings.TrimSuffix "/" (.blog_path | default "") -}}
+    {{- if and $blog (eq $blog $path) -}}
+      {{- $client = . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with $client -}}
+  {{- $tags := slice -}}
+  {{- range $fields -}}
+    {{- with (index $client .) }}{{ $tags = $tags | append . }}{{ end -}}
+  {{- end -}}
+
+  {{- with $tags }}
+  <ul class="case-study-tags">
+    {{- range . }}
+    <li class="case-study-tags__tag">{{ . }}</li>
+    {{- end }}
+  </ul>
+  {{- end }}
+{{- end -}}

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
@@ -12,6 +12,7 @@
         <p>{{ .context.Params.author }}</p>
         <span>&middot;</span>
         <p>{{ time.Format "January 02, 2006" .context.Date }}</p>
+        {{ partial "case-study-tags" .context }}
       </div>
       {{ if .context.Params.preview_dir }}
         <picture class="qdrant-post__preview">

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/qdrant-post.html
@@ -8,11 +8,11 @@
   <article id="article" class="container">
     <div class="qdrant-post__header">
       <h1 class="qdrant-post__title">{{ .context.Params.title }}</h1>
+      {{ partial "case-study-tags" .context }}
       <div class="qdrant-post__about">
         <p>{{ .context.Params.author }}</p>
         <span>&middot;</span>
         <p>{{ time.Format "January 02, 2006" .context.Date }}</p>
-        {{ partial "case-study-tags" .context }}
       </div>
       {{ if .context.Params.preview_dir }}
         <picture class="qdrant-post__preview">


### PR DESCRIPTION
All of this comes from one file: [`content/customers/clients/_index.md`](https://raw.githubusercontent.com/qdrant/landing_page/refs/heads/master/qdrant-landing/content/customers/clients/_index.md), the customers catalog. It already records each customer's industry, product and region, and the filters on [/customers/](https://qdrant.tech/customers/) run off those exact values. A case study page showed none of it.

The tags render **inside the byline row every blog post already has**:

```
Daniel Azoulai · February 10, 2026 · E-commerce · Hybrid · North America
```

No page gains a header element it did not have before, so case studies stay consistent with the rest of the blog. An earlier attempt gave them their own row and it read as chips appearing from nowhere between the header and the hero image.

## A partial, not a shortcode

Values are read from the catalog by `blog_path`, so **no article is edited** — the diff is seven files, none of them content. It also means the page and the filters cannot drift: adding a tag means adding it to the catalog, where it also becomes filterable.

A post with no catalog row renders nothing, so this is inert everywhere except the **47 case studies** that have one. That includes `iris-agent-qdrant`, whose slug does not match its filename and which a per-article rollout would have been easy to miss.

Five case studies have no catalog row at all and so show no tags: Bayer, GoPerfect, Minima, Sapu, Sunny Health. Adding rows for them is worth doing separately — they are also absent from `/customers/` today.

## Use cases left out

`use_cases` is the richest field, but most customers have three of them. Including it produced six chips, pushed the row onto two lines, and buried the industry behind a list of capabilities.

## Two fixes that came out of this

**The byline row now wraps.** With five items it overflowed a 390px viewport by 52px, giving phones a horizontal scrollbar. It was `flex-wrap: nowrap` and never had enough items to reveal that before.

**`locationse:` on the ConvoSearch row.** It was the only page rendering two tags instead of three, and the same typo had been quietly keeping ConvoSearch out of the Geography filter on `/customers/`.

## Data problems found, deliberately not fixed here

Putting catalog values on public pages makes catalog errors visible. Two need someone to decide the right value rather than correct a typo:

- **Pariti** is recorded as `industry: Technology, location: Global`, while its own article opens *"Pariti is a referral-driven hiring marketplace in Africa."*
- One row has `company_size: 1-50 by`.

## Checked

Clean build: 47 pages render tags, every one showing exactly three, no other page affected. Verified at 390px that the header no longer overflows.


<!-- drag tags-screenshot.png in here -->

## See it

| | Before | After |
|---|---|---|
| Bazaarvoice | [live](https://qdrant.tech/blog/case-study-bazaarvoice/) | [preview](https://deploy-preview-2707--condescending-goldwasser-91acf0.netlify.app/blog/case-study-bazaarvoice/) |
| Deutsche Telekom | [live](https://qdrant.tech/blog/case-study-deutsche-telekom/) | [preview](https://deploy-preview-2707--condescending-goldwasser-91acf0.netlify.app/blog/case-study-deutsche-telekom/) |
| Tripadvisor | [live](https://qdrant.tech/blog/case-study-tripadvisor/) | [preview](https://deploy-preview-2707--condescending-goldwasser-91acf0.netlify.app/blog/case-study-tripadvisor/) |
| Iris Agent | [live](https://qdrant.tech/blog/iris-agent-qdrant/) | [preview](https://deploy-preview-2707--condescending-goldwasser-91acf0.netlify.app/blog/iris-agent-qdrant/) |
| Dust (no catalog row) | [live](https://qdrant.tech/blog/dust-and-qdrant/) | [preview](https://deploy-preview-2707--condescending-goldwasser-91acf0.netlify.app/blog/dust-and-qdrant/) |

The last row is worth opening too: the older Dust article has no catalog row, so it renders no tags at all. That is the intended fallback.
