### PR TITLE
Note that max_segment_size scales with CPU count

### DIFF
--- a/qdrant-landing/content/documentation/ops-optimization/optimizer.md
+++ b/qdrant-landing/content/documentation/ops-optimization/optimizer.md
@@ -51,7 +51,7 @@ Qdrant requires at least one small segment to handle frequently updated data eff
 
 The target number of segments is specified by the `default_segment_number` parameter, which typically defaults to the number of CPUs. During optimization, the optimizer may merge the three smallest segments into one, aiming to balance segment size and system performance.
 
-To prevent oversized segments that could slow down indexing, the `max_segment_size_kb` parameter sets a limit on segment size. Larger segments may improve search performance but can take longer to index. Adjusting this parameter helps strike a balance between indexing speed and search efficiency, especially when dealing with large datasets.
+To prevent oversized segments that could slow down indexing, the `max_segment_size_kb` parameter sets a limit on segment size. Larger segments may improve search performance but can take longer to index. Adjusting this parameter helps strike a balance between indexing speed and search efficiency, especially when dealing with large datasets. When `max_segment_size_kb` is unset, the limit scales with the number of available CPUs, so it differs between machines. Set it explicitly when you need a predictable segment size.
 
 The criteria for starting the optimizer are defined in the configuration file. Here is an example of parameter values:
 


### PR DESCRIPTION
Scope reduced, see comments
Deploy preview: [Merge Optimizer](https://deploy-preview-2717--condescending-goldwasser-91acf0.netlify.app/documentation/ops-optimization/optimizer/#merge-optimizer)

A user asked on Discord how to predict the `max_segment_size_kb` default. The docs said only that it is "automatically selected considering the number of available CPUs".

Adds two sentences to the Merge Optimizer section: the default scales with CPU count and differs between machines, and anyone who needs a predictable segment size should set the parameter explicitly. Per @generall, the calculation itself stays out of the public contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code) - reviewed by hand