### PR TITLE
Rename the vector database nav and footer label

### DIFF
--- a/qdrant-landing/content/headless/footer.md
+++ b/qdrant-landing/content/headless/footer.md
@@ -24,7 +24,7 @@ menuItems:
   - title: Products
     items:
       - id: 0
-        name: Qdrant Vector Database
+        name: Qdrant Vector Search Engine
         url: /qdrant-vector-database/
       - id: 1
         name: Qdrant Cloud

--- a/qdrant-landing/content/headless/menu.md
+++ b/qdrant-landing/content/headless/menu.md
@@ -12,7 +12,7 @@ menuItems:
       - id: mainMenu-0-0
         subMenuItems:
         - id: subMenu-0-0
-          name: Qdrant Vector Database
+          name: Qdrant Vector Search Engine
           icon: qdrant-vector-database.svg
           url: /qdrant-vector-database/
         - id: subMenu-0-1


### PR DESCRIPTION
## What this is

Renames the Products menu item and its footer twin from "Qdrant Vector Database" to
"Qdrant Vector Search Engine".

These two labels were the last places on the site still calling the product a vector
database. The page they link to is already titled "Qdrant High-Performance Vector Search
Engine", so the nav and footer were contradicting their own destination.

Label text only, in `content/headless/menu.md` and `content/headless/footer.md`. Two
lines.

## The slug is deliberately unchanged

The URL stays `/qdrant-vector-database/`. Only the visible label moves.

That is a deliberate split, not an oversight. Renaming the route would mean an alias plus
a redirect, and it would touch a page with existing inbound links, bookmarks and search
ranking. Worth deciding on its own merits rather than riding along with a label change.
Note it also means the icon file keeps its `qdrant-vector-database.svg` name, so the
filename and the label no longer match.

If the slug should move too, the follow-up is: rename the content directory, add
`/qdrant-vector-database/` to the new page's `aliases`, and sweep the internal links that
point at the old path.

## One label left elsewhere

`/use-cases/vectors-use-case/` is still titled "Qdrant Vector Database Use Cases". Left
alone here since it is page copy rather than navigation, but happy to fold it in.

Checked locally with `hugo serve`: both nav instances and the footer render the new label
and still resolve to the same page.
