### PR TITLE
fix(analytics): gate stored interactions replay on cookie consent (#2593)

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -2,7 +2,7 @@ import scrollHandler from './scroll-handler';
 import { initTabSync } from './tab-sync';
 import { XXL_BREAKPOINT } from './constants';
 import { addUTMToLinks, initGoToTopButton, persistUTMParams } from './helpers';
-import { handleSegmentReady } from './segment-helpers';
+import { handleSegmentReady, trackStoredInteractions } from './segment-helpers';
 import { addOneTrustPreferencesToLinks, registerAndCall } from './onetrust-helpers';
 import TableOfContents from './table-of-content';
 import { DOCS_HEADER_OFFSET } from './constants';
@@ -24,6 +24,8 @@ document.addEventListener('DOMContentLoaded', function () {
       await window.analytics.track('onetrust_consent_preference_updated', {
         onetrust_active_groups: window.OnetrustActiveGroups ?? '',
       });
+
+      trackStoredInteractions();
     });
 
     handleSegmentReady();

--- a/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/segment-helpers.js
@@ -272,14 +272,18 @@ const trackPageView = () => {
   removeSegmentStoredPages(); // TODO: Remove this end of April 2025
 }
 
-const trackStoredInteractions = () => {
+export const trackStoredInteractions = () => {
+  if (!getCookie('cookie-consent')) {
+    return;
+  }
+
   // Iterate over all stored interactions
-  getSegmentStoredInteractions().forEach(interactionPayload => {
+  getSegmentStoredInteractions().forEach((interactionPayload) => {
     trackInteractionEvent(interactionPayload);
   });
-  
+
   removeSegmentStoredInteractions();
-}
+};
 
 const trackEvent = (name, properties = {}) => {
   const originalTimestamp = properties.storedEvent ? properties.storedTimestamp : null;


### PR DESCRIPTION
## Summary

Fixes #2593.

Previously, `trackStoredInteractions()` in `segment-helpers.js` drained and replayed queued pre-consent interactions from `sessionStorage` into Segment as soon as Segment initialized on `analytics.ready()`, without verifying whether cookie consent had actually been given. This bypassed the OneTrust consent gate and emptied the interaction queue even if the user never consented.

## Changes

1. **Gate replay on consent**: `trackStoredInteractions()` now checks `if (!getCookie('cookie-consent')) return;` before processing or removing stored interactions, leaving the `sessionStorage` queue intact until consent is actively granted.
2. **Replay upon consent update**: Exported `trackStoredInteractions` and hooked it into OneTrust's `window.OneTrust.OnConsentChanged(...)` callback in `index.js`, so queued interactions are replayed to Segment as soon as the visitor grants consent.

## Verification

- Built site cleanly with Hugo Extended (`v0.160.1`) and Dart Sass (`v1.70.0`) with 0 errors.
- Verified that stored interactions remain safely queued in `sessionStorage` until consent is given.