### PR TITLE
docs: add Semantica framework integration

### DIFF
--- a/qdrant-landing/content/documentation/frameworks/_index.md
+++ b/qdrant-landing/content/documentation/frameworks/_index.md
@@ -41,6 +41,7 @@ aliases: ["/documentation/frameworks/memgpt/"]
 | [Rig-rs](/documentation/frameworks/rig-rs/)                   | Rust library for building scalable, modular, and ergonomic LLM-powered applications.                                 |
 | [RocketRide](/documentation/frameworks/rocketride/)           | Open-source AI development environment and C++ runtime for building RAG pipelines and agents with Qdrant.             |
 | [Semantic Router](/documentation/frameworks/semantic-router/) | Python library to build a decision-making layer for AI applications using vector search.                             |
+| [Semantica](/documentation/frameworks/semantica/)             | Python library for context graphs and decision intelligence, with Qdrant as the vector store backend.               |
 | [SmolAgents](/documentation/frameworks/smolagents/)           | Barebones library for agents. Agents write python code to call tools and orchestrate other agent.                    |
 | [Spring AI](/documentation/frameworks/spring-ai/)             | Java AI framework for building with Spring design principles such as portability and modular design.                 |
 | [Swiftide](/documentation/frameworks/swiftide/)             | Rust library for building LLM applications. Build fast, streaming indexing and querying pipelines, and composable agents. |

--- a/qdrant-landing/content/documentation/frameworks/semantica.md
+++ b/qdrant-landing/content/documentation/frameworks/semantica.md
@@ -1,0 +1,71 @@
+---
+title: Semantica
+short_description: "Use Qdrant as the vector store backend in Semantica to add scalable, persistent semantic search to context graphs and decision intelligence pipelines."
+description: "Configure Semantica's QdrantStore to back its vector store layer with Qdrant, enabling scalable similarity search over agent decisions, knowledge graph entities, and document embeddings."
+---
+
+# Semantica
+
+[Semantica](https://github.com/semantica-agi/semantica) is a Python library for building context graphs, decision intelligence pipelines, and knowledge graphs with full provenance. Its vector store layer is backend-agnostic: swapping in Qdrant gives you a persistent, scalable store for similarity search over agent decisions, document embeddings, and knowledge graph entities.
+
+## Installation
+
+Install Semantica with the Qdrant extra:
+
+```bash
+pip install "semantica[vectorstore-qdrant]"
+```
+
+## Usage
+
+`QdrantStore` is the direct Qdrant backend class. Call `connect()` first to establish the connection, then `create_collection()` before inserting or searching.
+
+```python
+import os
+import numpy as np
+from semantica.vector_store import QdrantStore
+
+store = QdrantStore(
+    url=os.environ.get("QDRANT_URL"),
+    api_key=os.environ.get("QDRANT_API_KEY"),  # omit for a local instance
+)
+store.connect()
+
+# Create a collection — vector_size must match your embedding dimension
+store.create_collection(
+    collection_name="documents",
+    vector_size=4,
+    distance="Cosine",
+)
+
+# Insert vectors with metadata payloads
+vectors = [
+    np.array([0.1, 0.2, 0.3, 0.4]),
+    np.array([0.9, 0.8, 0.7, 0.6]),
+]
+store.insert_vectors(
+    vectors=vectors,
+    ids=[1, 2],
+    payloads=[
+        {"text": "Qdrant is a vector database."},
+        {"text": "Semantica adds structured context to AI agents."},
+    ],
+)
+
+# Similarity search
+results = store.search_vectors(
+    query_vector=np.array([0.1, 0.2, 0.3, 0.4]),
+    limit=2,
+)
+for r in results:
+    print(r["score"], r["metadata"]["text"])
+```
+
+For a local Qdrant instance, omit `api_key` and set `url` to `"http://localhost:6333"`.
+
+`create_collection()` will raise if the collection already exists. Drop the collection first if you need to re-run the example against the same Qdrant instance.
+
+## Further Reading
+
+- [Semantica Documentation](https://docs.getsemantica.ai)
+- [Source Code](https://github.com/semantica-agi/semantica/blob/main/semantica/vector_store/qdrant_store.py)


### PR DESCRIPTION
## Summary

Add Semantica to Qdrant's public Frameworks integrations documentation.

## Changes

- Add a dedicated Semantica framework integration page.
- Document installation with the `vectorstore-qdrant` extra.
- Add a runnable `QdrantStore` example covering:
  - Qdrant connection
  - collection creation
  - vector insertion with metadata
  - similarity search
- Add Semantica to the Frameworks integrations index.

## Validation

- Verified the example against the current Semantica `QdrantStore` implementation.
- Confirmed the example runs end-to-end with Qdrant.
- Verified the installation command matches Semantica's current Qdrant extra.
- Checked Markdown formatting and links.
- No unrelated changes are included.