### PR TITLE
Move the Security link to Developers and give the page its own metadata

### DIFF
--- a/qdrant-landing/content/headless/menu.md
+++ b/qdrant-landing/content/headless/menu.md
@@ -32,14 +32,10 @@ menuItems:
           icon: cloud-inference.svg
           url: /cloud-inference/
         - id: subMenu-0-5
-          name: Security
-          icon: security.svg
-          url: /security/
-        - id: subMenu-0-6
           name: Qdrant Edge (Beta)
           icon: edge.svg
           url: /edge/
-        - id: subMenu-0-7
+        - id: subMenu-0-6
           name: Qdrant Serverless (Coming soon)
           icon: serverless.svg
           url: /serverless/
@@ -130,6 +126,10 @@ menuItems:
             name: Certification
             icon: certificate.svg
             url: http://train.qdrant.dev/
+          - id: subMenu-2-6
+            name: Security
+            icon: security.svg
+            url: /security/
   - id: menu-3
     name: Resources
     mainMenuItems:

--- a/qdrant-landing/content/security/_index.md
+++ b/qdrant-landing/content/security/_index.md
@@ -1,5 +1,7 @@
 ---
-title: Security
+title: 'Qdrant Security: Compliance, Isolation, and Encryption Across Every Deployment'
+description: See what security you get on each Qdrant deployment model. SOC 2 Type 2 and HIPAA certifications with reports in the Trust Center, cluster isolation, encryption in transit and at rest, in-region data residency, and audit logging. Hybrid Cloud and Private Cloud add full data isolation for stricter residency and compliance requirements.
+keywords: qdrant security, vector database security, SOC 2 Type 2, HIPAA compliance, data residency, cluster isolation, encryption at rest, audit logging
 build:
   render: always
 cascade:


### PR DESCRIPTION
## What this is

Two things, both on the Security page.

## 1. The nav entry moves from Products to Developers

#2716 put Security under Products, sixth in the list. Products is a list of things you
buy; Security is a reference page about how deployments are secured, so it reads better
next to Documentation and Certification.

Products loses the entry and the two items below it renumber, same as #2716 did going
the other way:

```
Qdrant Vector Search Engine
Qdrant Cloud
Qdrant Hybrid Cloud
Qdrant Enterprise Solutions
Qdrant Cloud Inference
Qdrant Edge (Beta)                <- was subMenu-0-6, now 0-5
Qdrant Serverless (Coming soon)   <- was subMenu-0-7, now 0-6
```

Developers gains it at the end, as `subMenu-2-6`:

```
Documentation
Community
GitHub
Roadmap
Change Log
Certification
Security                          <- moved here
```

The icon added in #2716 (`img/menu/security.svg`) carries over unchanged, so there is no
new asset. `content/headless/menu.md` drives the desktop dropdown and the mobile drawer
alike, so the one move covers both.

The Bug Bounty Program link under Resources still points at
`/security/bug-bounty-program/` and is untouched.

## 2. The page gets distinct metadata

`content/security/_index.md` carried only `title: Security` and no description. Per
`partials/seo_schema.html`, a page without `.Params.Description` falls back to
`.Site.Params.Description`, so `/security/` was shipping the site-wide description and
the site-wide keywords — identical to every other page missing them.

It now has its own title, description, and keywords, following the shape used by
`hybrid-cloud/_index.md`. Everything in them is taken from the page's own sections
(hero, enterprise-ready, isolation-and-encryption): SOC 2 Type 2 and HIPAA, Trust Center
reports, cluster isolation, encryption in transit and at rest, in-region data residency,
audit logging. No claims beyond what the page already states.

The title contains "Qdrant", so `head.html` skips the `- Qdrant` suffix. The visible H1
comes from `hero.md` and does not change.

## Checked

Local `hugo` build:

- `/security/index.html` emits its own `<title>` and `<meta name="description">`
- Security renders under Developers in the desktop nav and no longer under Products