### PR TITLE
docs: add New Relic observability guide

### DIFF
--- a/qdrant-landing/content/documentation/observability/_index.md
+++ b/qdrant-landing/content/documentation/observability/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Observability
-short_description: "Connect Qdrant to your observability stack with integrations for Datadog, OpenLIT, and OpenLLMetry to monitor performance and traces."
-description: "Monitor Qdrant with observability integrations including Datadog, OpenLIT, and OpenLLMetry for metrics, distributed tracing, and LLM application insights."
+short_description: "Connect Qdrant to your observability stack with integrations for Datadog, New Relic, OpenLIT, and OpenLLMetry to monitor performance and traces."
+description: "Monitor Qdrant with observability integrations including Datadog, New Relic, OpenLIT, and OpenLLMetry for metrics, distributed tracing, and LLM application insights."
 weight: 900
 partition: ecosystem
 ---
@@ -13,3 +13,4 @@ partition: ecosystem
 | [OpenLIT](/documentation/observability/openlit/)         | Platform for OpenTelemetry-native Observability & Evals for LLMs and Vector Databases. |
 | [OpenLLMetry](/documentation/observability/openllmetry/) | Set of OpenTelemetry extensions to add Observability for your LLM application.         |
 | [Datadog](/documentation/observability/datadog/)         | Cloud-based monitoring and analytics platform.                                         |
+| [New Relic](/documentation/observability/newrelic/)      | Observability platform with native support for Prometheus metrics and OpenTelemetry.   |

--- a/qdrant-landing/content/documentation/observability/newrelic.md
+++ b/qdrant-landing/content/documentation/observability/newrelic.md
@@ -1,0 +1,65 @@
+---
+title: New Relic
+short_description: "Monitor Qdrant in New Relic by forwarding Prometheus metrics via remote write or the OpenMetrics integration, or by sending OpenTelemetry data over OTLP."
+description: "Send Qdrant metrics to New Relic with Prometheus remote write or the OpenMetrics integration, and ingest OpenTelemetry traces and metrics over OTLP."
+---
+
+# New Relic
+
+[New Relic](https://newrelic.com/) is an observability platform that collects metrics, traces, and logs from servers, databases, and applications. It provides dashboards, alerting, and NRQL queries to analyze the performance of your infrastructure.
+
+Qdrant exposes metrics in the Prometheus/OpenMetrics format at its `/metrics` endpoint, as described in the [monitoring guide](/documentation/ops-monitoring/monitoring/). New Relic can collect these metrics in two ways, and it also ingests OpenTelemetry data natively.
+
+## Usage
+
+### Prometheus remote write
+
+If a Prometheus server already scrapes your Qdrant instance, forward its data to New Relic by adding a [remote write](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration/) block to your `prometheus.yml`:
+
+```yaml
+remote_write:
+  - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=qdrant
+    authorization:
+      credentials: <NEW_RELIC_LICENSE_KEY>
+```
+
+Use `https://metric-api.eu.newrelic.com/prometheus/v1/write` if your account is in the EU data center. The `authorization` block requires Prometheus v2.26 or later. The `prometheus_server` parameter becomes an attribute on your data, so you can filter Qdrant metrics in dashboards and queries.
+
+### Prometheus OpenMetrics integration
+
+Without a Prometheus server, use the standalone [Prometheus OpenMetrics integration](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration/) to scrape the Qdrant `/metrics` endpoint directly. Create a `config.yaml` pointing at your instance:
+
+```yaml
+cluster_name: qdrant
+targets:
+  - description: Qdrant metrics
+    urls: ["http://localhost:6333/metrics"]
+```
+
+Then run the integration as a container with your license key:
+
+```shell
+docker run -d --restart unless-stopped \
+  --name nri-prometheus \
+  -e LICENSE_KEY="<NEW_RELIC_LICENSE_KEY>" \
+  -v "$(pwd)/config.yaml:/config.yaml" \
+  newrelic/nri-prometheus:2.18.0
+```
+
+After a few minutes, the Qdrant metrics appear in New Relic and can be queried with NRQL.
+
+### OpenTelemetry
+
+New Relic ingests [OTLP natively](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/). If you instrument your application with an OpenTelemetry-based tool such as [OpenLIT](/documentation/observability/openlit/) or [OpenLLMetry](/documentation/observability/openllmetry/), point the exporter at the New Relic OTLP endpoint:
+
+```shell
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.nr-data.net"
+export OTEL_EXPORTER_OTLP_HEADERS="api-key=<NEW_RELIC_LICENSE_KEY>"
+```
+
+Use `https://otlp.eu01.nr-data.net` for EU accounts.
+
+## Further Reading
+
+- [Getting started with New Relic](https://docs.newrelic.com/docs/new-relic-solutions/get-started/intro-new-relic/)
+- [Qdrant monitoring and telemetry](/documentation/ops-monitoring/monitoring/)


### PR DESCRIPTION
## Why

The observability section lists OpenLIT, OpenLLMetry, and Datadog, but not New Relic, even though Qdrant's Prometheus-format `/metrics` endpoint feeds it directly. This guide fills that gap for teams already on New Relic.

## Scope

- Adds `qdrant-landing/content/documentation/observability/newrelic.md` covering the three ingestion paths: Prometheus remote write, the standalone Prometheus OpenMetrics integration (`nri-prometheus`), and native OTLP for OpenTelemetry pipelines such as OpenLIT and OpenLLMetry.
- Adds the New Relic row to the table in `_index.md` and names New Relic in that page's frontmatter descriptions.

## Blast Radius

Docs content only. No site code, templates, or existing pages change beyond the two-line `_index.md` frontmatter update.

## Verification

- Every endpoint and config sample checked against the New Relic docs pages the guide links (Prometheus remote write, OpenMetrics integration install, OTLP best practices).
- Every external and internal link in the new page returns HTTP 200 via `curl -L`.
- Frontmatter, heading structure, and length mirror the sibling guides, `datadog.md` in particular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KybsFC28cLtu6pCdwdwBBw