### PR TITLE
Islands: shared design system and brand palette

### DIFF
--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.css
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.css
@@ -1,205 +1,55 @@
-/* tenant-defrag island. Scoped under .qi-td. Chrome colors switch on the host
-   theme via CSS custom properties; tenant hues stay constant (categorical). */
+/* tenant-defrag island. Scoped under .qi-td. Controls, frame and labels come
+   from the shared island design system (islands.scss); this file only styles
+   the point bars and the contiguity underline. Tenant hues are the shared
+   categorical palette (--qi-cat-*), constant across themes. */
 
 .qi-td {
-  /* Light theme (default). Values from _theme-variables.scss. */
-  --td-frame: #d4d9e6; /* neutral-90 */
-  --td-fg: #28324d; /* neutral-30 */
-  --td-muted: #576280; /* neutral-50 */
-  --td-control-bg: #f0f3fa; /* neutral-98 */
-  --td-control-border: #d4d9e6; /* neutral-90 */
-  --td-track: #b4bacc; /* neutral-80 */
-  --td-accent: #dc244c; /* primary-50 */
-
-  /* Tenant palette (shared across themes). */
-  --td-a: #2f6ff0; /* secondary-blue-50 */
-  --td-b: #008a53; /* success-50 */
-  --td-c: #e0700d; /* warning-50 */
-  --td-d: #e02828; /* error-50 */
+  --td-a: var(--qi-cat-1);
+  --td-b: var(--qi-cat-2);
+  --td-c: var(--qi-cat-3);
+  --td-d: var(--qi-cat-4);
 
   display: block;
-  color: var(--td-fg);
 }
 
-@media (prefers-color-scheme: dark) {
-  html:not([data-theme='light']) .qi-td {
-    --td-frame: #28324d; /* neutral-30 */
-    --td-fg: #e1e5f0; /* neutral-94 */
-    --td-muted: #8f98b2; /* neutral-70 */
-    --td-control-bg: #161e33; /* neutral-20 */
-    --td-control-border: #28324d; /* neutral-30 */
-    --td-track: #3d4866; /* neutral-40 */
-  }
+.qi-td__chip--a {
+  --swatch: var(--td-a);
 }
-html[data-theme='dark'] .qi-td {
-  --td-frame: #28324d; /* neutral-30 */
-  --td-fg: #e1e5f0; /* neutral-94 */
-  --td-muted: #8f98b2; /* neutral-70 */
-  --td-control-bg: #161e33; /* neutral-20 */
-  --td-control-border: #28324d; /* neutral-30 */
-  --td-track: #3d4866; /* neutral-40 */
+.qi-td__chip--b {
+  --swatch: var(--td-b);
 }
-
-.qi-td__fig {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+.qi-td__chip--c {
+  --swatch: var(--td-c);
 }
-
-/* --- Controls --- */
-.qi-td__controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 10px 18px;
-}
-
-.qi-td__toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 12px 6px 8px;
-  border: 1px solid var(--td-control-border);
-  border-radius: 999px;
-  background: var(--td-control-bg);
-  color: var(--td-fg);
-  font: inherit;
-  font-size: 14px;
-  cursor: pointer;
-}
-.qi-td__toggle-track {
-  position: relative;
-  width: 38px;
-  height: 22px;
-  border-radius: 999px;
-  background: var(--td-track);
-  transition: background 0.2s ease;
-  flex: none;
-}
-.qi-td__toggle-knob {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #fff;
-  transition: transform 0.2s ease;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-}
-.qi-td__toggle[aria-pressed='true'] .qi-td__toggle-track {
-  background: var(--td-accent);
-}
-.qi-td__toggle[aria-pressed='true'] .qi-td__toggle-knob {
-  transform: translateX(16px);
-}
-.qi-td__toggle-label b {
-  font-variant-numeric: tabular-nums;
-}
-
-.qi-td__legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-.qi-td__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 5px 11px;
-  border: 1px solid var(--td-control-border);
-  border-radius: 999px;
-  background: transparent;
-  color: var(--td-muted);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
-  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
-}
-.qi-td__chip:hover {
-  color: var(--td-fg);
-}
-.qi-td__chip[aria-pressed='true'] {
-  color: var(--td-fg);
-  border-color: currentColor;
-  background: var(--td-control-bg);
-}
-.qi-td__swatch {
-  width: 12px;
-  height: 12px;
-  border-radius: 3px;
-  flex: none;
-}
-.qi-td__chip--a .qi-td__swatch {
-  background: var(--td-a);
-}
-.qi-td__chip--b .qi-td__swatch {
-  background: var(--td-b);
-}
-.qi-td__chip--c .qi-td__swatch {
-  background: var(--td-c);
-}
-.qi-td__chip--d .qi-td__swatch {
-  background: var(--td-d);
-}
-
-/* --- SVG stage --- */
-.qi-td__svg {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-.qi-td__frame {
-  fill: var(--td-control-bg);
-  stroke: var(--td-frame);
-  stroke-width: 1.5;
-}
-.qi-td__frame-label {
-  fill: var(--td-muted);
-  font-size: 15px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
+.qi-td__chip--d {
+  --swatch: var(--td-d);
 }
 
 .qi-td__bar {
   transition: x 0.6s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.25s ease;
 }
-.qi-td__bar--a {
+.qi-td__bar--a,
+.qi-td__run--a {
   fill: var(--td-a);
 }
-.qi-td__bar--b {
+.qi-td__bar--b,
+.qi-td__run--b {
   fill: var(--td-b);
 }
-.qi-td__bar--c {
+.qi-td__bar--c,
+.qi-td__run--c {
   fill: var(--td-c);
 }
-.qi-td__bar--d {
+.qi-td__bar--d,
+.qi-td__run--d {
   fill: var(--td-d);
 }
 .qi-td__bar.is-dim {
   opacity: 0.16;
 }
 
-.qi-td__run--a {
-  fill: var(--td-a);
-}
-.qi-td__run--b {
-  fill: var(--td-b);
-}
-.qi-td__run--c {
-  fill: var(--td-c);
-}
-.qi-td__run--d {
-  fill: var(--td-d);
-}
 .qi-td__run {
   transition: x 0.6s cubic-bezier(0.4, 0, 0.2, 1), width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.qi-td__status {
-  margin: 0;
-  min-height: 20px;
-  font-size: 14px;
-  color: var(--td-fg);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.css
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.css
@@ -1,13 +1,13 @@
 /* tenant-defrag island. Scoped under .qi-td. Controls, frame and labels come
    from the shared island design system (islands.scss); this file only styles
-   the point bars and the contiguity underline. Tenant hues are the shared
-   categorical palette (--qi-cat-*), constant across themes. */
+   the point bars and the contiguity underline. Tenant hues are constant
+   across themes (values from _theme-variables.scss). */
 
 .qi-td {
-  --td-a: var(--qi-cat-1);
-  --td-b: var(--qi-cat-2);
-  --td-c: var(--qi-cat-3);
-  --td-d: var(--qi-cat-4);
+  --td-a: #2f6ff0; /* secondary-blue-50 */
+  --td-b: #008a53; /* success-50 */
+  --td-c: #e0700d; /* warning-50 */
+  --td-d: #e02828; /* error-50 */
 
   display: block;
 }

--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.js
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.js
@@ -6,8 +6,8 @@
  * random disk seeks to read one tenant) to grouped (one sequential read). Pick
  * a tenant to highlight its points and see the seek count.
  *
- * Pure SVG + CSS: all colors come from CSS custom properties that switch on the
- * host theme, so it re-themes with no JS.
+ * Pure SVG + CSS on the shared island design system (islands.scss): chrome
+ * colors switch with the host theme, tenant hues are the categorical palette.
  */
 
 const NS = 'http://www.w3.org/2000/svg';
@@ -68,27 +68,27 @@ export function mount(node) {
   points.forEach((p) => (tenantOf[p.id] = p.tenant));
 
   node.innerHTML = [
-    '<div class="qi-td__fig">',
-    '  <div class="qi-td__controls">',
-    '    <button type="button" class="qi-td__toggle" aria-pressed="false">',
-    '      <span class="qi-td__toggle-track"><span class="qi-td__toggle-knob"></span></span>',
+    '<div class="qi-fig">',
+    '  <div class="qi-controls">',
+    '    <button type="button" class="qi-chip qi-td__toggle" aria-pressed="false">',
+    '      <span class="qi-switch__track"><span class="qi-switch__knob"></span></span>',
     '      <span class="qi-td__toggle-label">is_tenant = <b>false</b></span>',
     '    </button>',
-    '    <div class="qi-td__legend" role="group" aria-label="Highlight a tenant">',
+    '    <div class="qi-group" role="group" aria-label="Highlight a tenant">',
     TENANTS.map(
       (t) =>
-        `<button type="button" class="qi-td__chip qi-td__chip--${t.id}" data-tenant="${t.id}" aria-pressed="false">` +
-        `<span class="qi-td__swatch"></span>${t.label}</button>`,
+        `<button type="button" class="qi-chip qi-td__chip qi-td__chip--${t.id}" data-tenant="${t.id}" aria-pressed="false">` +
+        `<span class="qi-chip__swatch"></span>${t.label}</button>`,
     ).join(''),
     '    </div>',
     '  </div>',
-    `  <svg class="qi-td__svg" viewBox="0 0 ${VB_W} 210" role="img" aria-label="A shard of points colored by tenant, shown scattered and grouped by is_tenant.">`,
-    `    <rect class="qi-td__frame" x="2" y="30" width="${VB_W - 4}" height="${AH + 60}" rx="10"/>`,
-    '    <text class="qi-td__frame-label" x="20" y="52">Shard A</text>',
+    `  <svg class="qi-svg qi-td__svg" viewBox="0 0 ${VB_W} 210" role="img" aria-label="A shard of points colored by tenant, shown scattered and grouped by is_tenant.">`,
+    `    <rect class="qi-frame" x="2" y="30" width="${VB_W - 4}" height="${AH + 60}" rx="6"/>`,
+    '    <text class="qi-frame-label" x="20" y="52">Shard A</text>',
     '    <g class="qi-td__bars"></g>',
     '    <g class="qi-td__runs"></g>',
     '  </svg>',
-    '  <p class="qi-td__status" role="status" aria-live="polite"></p>',
+    '  <p class="qi-status qi-td__status" role="status" aria-live="polite"></p>',
     '</div>',
   ].join('');
 

--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.js
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-defrag/index.js
@@ -7,7 +7,7 @@
  * a tenant to highlight its points and see the seek count.
  *
  * Pure SVG + CSS on the shared island design system (islands.scss): chrome
- * colors switch with the host theme, tenant hues are the categorical palette.
+ * colors switch with the host theme, tenant hues stay constant.
  */
 
 const NS = 'http://www.w3.org/2000/svg';

--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.css
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.css
@@ -1,139 +1,38 @@
-/* tenant-promotion island. Scoped under .qi-tp. Chrome colors switch on the
-   host theme via CSS custom properties; tenant hues stay constant. */
+/* tenant-promotion island. Scoped under .qi-tp. Controls, frames and labels
+   come from the shared island design system (islands.scss); this file only
+   styles the point bars and the promotion connector. Tenant hues are the
+   shared categorical palette (--qi-cat-*), constant across themes. */
 
 .qi-tp {
-  /* Light theme (default). Values from _theme-variables.scss. */
-  --tp-frame: #d4d9e6; /* neutral-90 */
-  --tp-fg: #28324d; /* neutral-30 */
-  --tp-muted: #576280; /* neutral-50 */
-  --tp-control-bg: #f0f3fa; /* neutral-98 */
-  --tp-control-border: #d4d9e6; /* neutral-90 */
-  --tp-arrow: #e0700d; /* warning-50 (matches user_3) */
-
-  --tp-u1: #2f6ff0; /* secondary-blue-50 */
-  --tp-u2: #e02828; /* error-50 */
-  --tp-u3: #e0700d; /* warning-50 */
-  --tp-u4: #008a53; /* success-50 */
+  --tp-u1: var(--qi-cat-1);
+  --tp-u2: var(--qi-cat-2);
+  --tp-u3: var(--qi-cat-3);
+  --tp-u4: var(--qi-cat-4);
+  /* Connector color: set to the promoted tenant's hue from JS. */
+  --tp-arrow: var(--qi-muted);
 
   display: block;
-  color: var(--tp-fg);
 }
 
-@media (prefers-color-scheme: dark) {
-  html:not([data-theme='light']) .qi-tp {
-    --tp-frame: #28324d; /* neutral-30 */
-    --tp-fg: #e1e5f0; /* neutral-94 */
-    --tp-muted: #8f98b2; /* neutral-70 */
-    --tp-control-bg: #161e33; /* neutral-20 */
-    --tp-control-border: #28324d; /* neutral-30 */
-  }
+.qi-tp__btn--u2 {
+  --swatch: var(--tp-u2);
 }
-html[data-theme='dark'] .qi-tp {
-  --tp-frame: #28324d; /* neutral-30 */
-  --tp-fg: #e1e5f0; /* neutral-94 */
-  --tp-muted: #8f98b2; /* neutral-70 */
-  --tp-control-bg: #161e33; /* neutral-20 */
-  --tp-control-border: #28324d; /* neutral-30 */
+.qi-tp__btn--u3 {
+  --swatch: var(--tp-u3);
 }
-
-.qi-tp__fig {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-/* --- Controls --- */
-.qi-tp__controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  min-height: 34px;
-}
-.qi-tp__promote-group {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-}
-.qi-tp__controls-label {
-  font-size: 14px;
-  color: var(--tp-muted);
-  margin-right: 4px;
-}
-.qi-tp__btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 6px 13px;
-  border: 1px solid var(--tp-control-border);
-  border-radius: 8px;
-  background: var(--tp-control-bg);
-  color: var(--tp-fg);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
-  transition: border-color 0.15s ease, opacity 0.15s ease;
-}
-.qi-tp__btn:hover:not(:disabled) {
-  border-color: var(--tp-muted);
-}
-.qi-tp__btn:disabled {
-  opacity: 0.45;
-  cursor: default;
-}
-.qi-tp__btn.is-active {
-  border-color: currentColor;
-  opacity: 1;
-}
-.qi-tp__swatch {
-  width: 12px;
-  height: 12px;
-  border-radius: 3px;
-  flex: none;
-}
-.qi-tp__btn--u2 .qi-tp__swatch {
-  background: var(--tp-u2);
-}
-.qi-tp__btn--u3 .qi-tp__swatch {
-  background: var(--tp-u3);
-}
-.qi-tp__btn--u4 .qi-tp__swatch {
-  background: var(--tp-u4);
-}
-.qi-tp__reset {
-  color: var(--tp-muted);
-}
-.qi-tp__reset-icon {
-  flex: none;
+.qi-tp__btn--u4 {
+  --swatch: var(--tp-u4);
 }
 
 /* --- SVG --- */
-.qi-tp__svg {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-.qi-tp__frame {
-  fill: var(--tp-control-bg);
-  stroke: var(--tp-frame);
-  stroke-width: 1.5;
-}
 .qi-tp__frame--dashed {
-  stroke-dasharray: 6 5;
+  stroke-dasharray: 5 4;
   transition: stroke-dasharray 0.3s ease;
 }
 .qi-tp__frame--dashed.is-active {
   stroke-dasharray: none;
 }
-.qi-tp__frame-label {
-  fill: var(--tp-muted);
-  font-size: 15px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
 .qi-tp__placeholder {
-  fill: var(--tp-muted);
-  font-size: 13px;
   opacity: 0.7;
 }
 
@@ -171,7 +70,7 @@ html[data-theme='dark'] .qi-tp {
 .qi-tp__arrow {
   fill: none;
   stroke: var(--tp-arrow);
-  stroke-width: 2.5;
+  stroke-width: 2;
 }
 .qi-tp__arrowhead {
   fill: var(--tp-arrow);
@@ -181,17 +80,10 @@ html[data-theme='dark'] .qi-tp {
 }
 .qi-tp__pill-text {
   fill: #fff;
-  font-size: 13px;
+  font-family: var(--qi-mono);
+  font-size: 12px;
   font-weight: 600;
   text-anchor: middle;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
-
-.qi-tp__status {
-  margin: 0;
-  min-height: 20px;
-  font-size: 14px;
-  color: var(--tp-fg);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.css
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.css
@@ -1,13 +1,13 @@
 /* tenant-promotion island. Scoped under .qi-tp. Controls, frames and labels
    come from the shared island design system (islands.scss); this file only
-   styles the point bars and the promotion connector. Tenant hues are the
-   shared categorical palette (--qi-cat-*), constant across themes. */
+   styles the point bars and the promotion connector. Tenant hues are
+   constant across themes (values from _theme-variables.scss). */
 
 .qi-tp {
-  --tp-u1: var(--qi-cat-1);
-  --tp-u2: var(--qi-cat-2);
-  --tp-u3: var(--qi-cat-3);
-  --tp-u4: var(--qi-cat-4);
+  --tp-u1: #2f6ff0; /* secondary-blue-50 */
+  --tp-u2: #e02828; /* error-50 */
+  --tp-u3: #e0700d; /* warning-50 */
+  --tp-u4: #008a53; /* success-50 */
   /* Connector color: set to the promoted tenant's hue from JS. */
   --tp-arrow: var(--qi-muted);
 

--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.js
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.js
@@ -10,7 +10,7 @@
  * Layout is balanced: a tall Default shard on the left, and user_1 + the
  * promoted shard stacked on the right at the same total height, so there is no
  * empty space. Pure SVG + CSS on the shared island design system
- * (islands.scss); tenant hues are the categorical palette.
+ * (islands.scss); tenant hues stay constant.
  */
 
 const NS = 'http://www.w3.org/2000/svg';

--- a/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.js
+++ b/qdrant-landing/content/documentation/headless/multitenancy/tenant-promotion/index.js
@@ -9,8 +9,8 @@
  *
  * Layout is balanced: a tall Default shard on the left, and user_1 + the
  * promoted shard stacked on the right at the same total height, so there is no
- * empty space. Pure SVG + CSS; colors come from CSS custom properties that
- * switch on the host theme.
+ * empty space. Pure SVG + CSS on the shared island design system
+ * (islands.scss); tenant hues are the categorical palette.
  */
 
 const NS = 'http://www.w3.org/2000/svg';
@@ -38,21 +38,21 @@ export function mount(node) {
   node.classList.add('qi-tp');
 
   node.innerHTML = [
-    '<div class="qi-tp__fig">',
-    '  <div class="qi-tp__controls">',
-    '    <div class="qi-tp__promote-group">',
-    '      <span class="qi-tp__controls-label">Promote a tenant:</span>',
+    '<div class="qi-fig">',
+    '  <div class="qi-controls">',
+    '    <div class="qi-group qi-tp__promote-group">',
+    '      <span class="qi-hint">Promote a tenant:</span>',
     SMALL.map(
       (t) =>
-        `<button type="button" class="qi-tp__btn qi-tp__btn--${t.id}" data-tenant="${t.id}">` +
-        `<span class="qi-tp__swatch"></span>${t.label}</button>`,
+        `<button type="button" class="qi-chip qi-tp__btn qi-tp__btn--${t.id}" data-tenant="${t.id}">` +
+        `<span class="qi-chip__swatch"></span>${t.label}</button>`,
     ).join(''),
     '    </div>',
-    '    <button type="button" class="qi-tp__btn qi-tp__reset" data-reset hidden>',
-    '      <svg class="qi-tp__reset-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>Reset',
+    '    <button type="button" class="qi-chip qi-tp__reset" data-reset hidden>',
+    '      <svg class="qi-chip__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>Reset',
     '    </button>',
     '  </div>',
-    '  <svg class="qi-tp__svg" viewBox="0 0 720 250" role="img"',
+    '  <svg class="qi-svg qi-tp__svg" viewBox="0 0 720 250" role="img"',
     '    aria-label="Small tenants share the Default shard; user_1 has a dedicated shard. Promoting a tenant moves it to its own dedicated shard.">',
     '    <defs>',
     '      <marker id="qi-tp-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">',
@@ -63,25 +63,25 @@ export function mount(node) {
     '    <g class="qi-tp__promo" style="display: none">',
     `      <path class="qi-tp__arrow" d="M ${DEF.x + DEF.w} ${ARROW_Y} L ${PRO.x - 4} ${ARROW_Y}" marker-end="url(#qi-tp-arrow)"/>`,
     `      <g class="qi-tp__pill" transform="translate(${(DEF.x + DEF.w + PRO.x) / 2 - 46} ${ARROW_Y - 34})">`,
-    '        <rect class="qi-tp__pill-bg" x="0" y="0" width="92" height="26" rx="6"/>',
+    '        <rect class="qi-tp__pill-bg" x="0" y="0" width="92" height="26" rx="4"/>',
     '        <text class="qi-tp__pill-text" x="46" y="17">Promotion</text>',
     '      </g>',
     '    </g>',
     // Default (shared fallback) shard
-    `    <rect class="qi-tp__frame" x="${DEF.x}" y="${DEF.y}" width="${DEF.w}" height="${DEF.h}" rx="10"/>`,
-    `    <text class="qi-tp__frame-label" x="${DEF.x + 16}" y="${DEF.y + 28}">\`Default\` Shard</text>`,
+    `    <rect class="qi-frame" x="${DEF.x}" y="${DEF.y}" width="${DEF.w}" height="${DEF.h}" rx="6"/>`,
+    `    <text class="qi-frame-label" x="${DEF.x + 16}" y="${DEF.y + 28}">\`Default\` Shard</text>`,
     '    <g class="qi-tp__default-bars"></g>',
     // user_1 dedicated shard (static context)
-    `    <rect class="qi-tp__frame" x="${BIG.x}" y="${BIG.y}" width="${BIG.w}" height="${BIG.h}" rx="10"/>`,
-    `    <text class="qi-tp__frame-label" x="${BIG.x + 16}" y="${BIG.y + 28}">\`user_1\` Shard</text>`,
+    `    <rect class="qi-frame" x="${BIG.x}" y="${BIG.y}" width="${BIG.w}" height="${BIG.h}" rx="6"/>`,
+    `    <text class="qi-frame-label" x="${BIG.x + 16}" y="${BIG.y + 28}">\`user_1\` Shard</text>`,
     '    <g class="qi-tp__big-bars"></g>',
     // Promoted (dedicated) shard — placeholder before promotion, fills on promotion
-    `    <rect class="qi-tp__frame qi-tp__frame--dashed" x="${PRO.x}" y="${PRO.y}" width="${PRO.w}" height="${PRO.h}" rx="10"/>`,
-    `    <text class="qi-tp__placeholder" x="${PRO.x + PRO.w / 2}" y="${PRO.y + PRO.h / 2 + 4}" text-anchor="middle">a promoted tenant lands here</text>`,
-    `    <text class="qi-tp__frame-label qi-tp__promoted-label" x="${PRO.x + 16}" y="${PRO.y + 28}" style="display: none"></text>`,
+    `    <rect class="qi-frame qi-tp__frame--dashed" x="${PRO.x}" y="${PRO.y}" width="${PRO.w}" height="${PRO.h}" rx="6"/>`,
+    `    <text class="qi-label qi-tp__placeholder" x="${PRO.x + PRO.w / 2}" y="${PRO.y + PRO.h / 2 + 4}" text-anchor="middle">a promoted tenant lands here</text>`,
+    `    <text class="qi-frame-label qi-tp__promoted-label" x="${PRO.x + 16}" y="${PRO.y + 28}" style="display: none"></text>`,
     '    <g class="qi-tp__pro-bars"></g>',
     '  </svg>',
-    '  <p class="qi-tp__status" role="status" aria-live="polite"></p>',
+    '  <p class="qi-status qi-tp__status" role="status" aria-live="polite"></p>',
     '</div>',
   ].join('');
 
@@ -176,7 +176,7 @@ export function mount(node) {
       } else {
         placeholder.style.display = '';
       }
-      statusEl.innerHTML = 'Small tenants share the <code>Default</code> fallback shard. Promote one to give it a dedicated shard.';
+      statusEl.innerHTML = 'Small tenants share the <code>Default</code> shard. Promote one to give it its own.';
       return;
     }
 
@@ -207,7 +207,7 @@ export function mount(node) {
     timers.push(
       window.setTimeout(() => {
         promotedFrame.classList.add('is-active');
-        statusEl.innerHTML = `<b>${t.label}</b> promoted to its own dedicated shard (<b>Active</b>). Its requests now route there.`;
+        statusEl.innerHTML = `<b>${t.label}</b> now has a dedicated shard (<b>Active</b>); its requests route there.`;
       }, settle * 1000),
     );
   }

--- a/qdrant-landing/content/documentation/headless/quantization/asymmetric/index.css
+++ b/qdrant-landing/content/documentation/headless/quantization/asymmetric/index.css
@@ -1,119 +1,49 @@
-/* asymmetric island. Scoped under .qi-aq. Chrome colors switch on the host
-   theme via CSS custom properties; the data palette (blue value scale,
-   candidate hues) stays constant. */
+/* asymmetric island. Scoped under .qi-aq. Controls and labels come from the
+   shared island design system (islands.scss); this file only styles the cells
+   and the scatter. Sign hues come from the shared palette: blue (--qi-cat-1)
+   for positive, Qdrant red (--qi-cat-4) for negative. */
 
 .qi-aq {
-  /* Light theme (default). Values from _theme-variables.scss. */
-  --aq-fg: #28324d; /* neutral-30 */
-  --aq-muted: #576280; /* neutral-50 */
-  --aq-control-bg: #f0f3fa; /* neutral-98 */
-  --aq-control-border: #d4d9e6; /* neutral-90 */
-  --aq-cell-stroke: rgba(22, 30, 51, 0.3);
-  --aq-hot: #28324d; /* neutral-30: quiet highlight outline */
-
-  /* Data palette (shared across themes): hue = sign, saturation = magnitude. */
-  --aq-pos: #2f6ff0; /* secondary-blue-50 */
-  --aq-neg: #e0700d; /* warning-50 */
+  --aq-pos: var(--qi-cat-1);
+  --aq-neg: var(--qi-cat-4);
 
   display: block;
-  color: var(--aq-fg);
 }
 
-@media (prefers-color-scheme: dark) {
-  html:not([data-theme='light']) .qi-aq {
-    --aq-fg: #e1e5f0; /* neutral-94 */
-    --aq-muted: #8f98b2; /* neutral-70 */
-    --aq-control-bg: #161e33; /* neutral-20 */
-    --aq-control-border: #28324d; /* neutral-30 */
-    --aq-cell-stroke: rgba(225, 229, 240, 0.18);
-    --aq-hot: #f0f3fa; /* neutral-98 */
-  }
-}
-html[data-theme='dark'] .qi-aq {
-  --aq-fg: #e1e5f0; /* neutral-94 */
-  --aq-muted: #8f98b2; /* neutral-70 */
-  --aq-control-bg: #161e33; /* neutral-20 */
-  --aq-control-border: #28324d; /* neutral-30 */
-  --aq-cell-stroke: rgba(225, 229, 240, 0.18);
-  --aq-hot: #f0f3fa; /* neutral-98 */
-}
-
-.qi-aq__fig {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-/* --- Controls --- */
-.qi-aq__controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px 16px;
-}
-.qi-aq__hint {
-  font-size: 13px;
-  color: var(--aq-muted);
-}
-.qi-aq__btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 6px 13px;
-  border: 1px solid var(--aq-control-border);
-  border-radius: 8px;
-  background: var(--aq-control-bg);
-  color: var(--aq-muted);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: border-color 0.15s ease, color 0.15s ease;
-}
-.qi-aq__btn:hover {
-  border-color: var(--aq-muted);
-  color: var(--aq-fg);
-}
-.qi-aq__btn-icon {
-  flex: none;
-}
-
-/* --- SVG --- */
-.qi-aq__svg {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-.qi-aq__title {
-  fill: var(--aq-fg);
-  font-size: 14px;
-  font-weight: 600;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
-.qi-aq__label {
-  fill: var(--aq-muted);
-  font-size: 12px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
 .qi-aq__op {
-  fill: var(--aq-fg);
+  fill: var(--qi-fg);
   font-weight: 600;
 }
+
+/* --- Cells: hue = sign, fill-opacity = magnitude (set from JS) --- */
+.qi-aq__cell {
+  fill: var(--aq-pos);
+  stroke: var(--qi-cell-stroke);
+  stroke-width: 1;
+  transition: fill 0.35s ease, fill-opacity 0.35s ease;
+}
+.qi-aq__cell.is-neg {
+  fill: var(--aq-neg);
+}
+.qi-aq__cell.is-hot {
+  stroke: var(--qi-hot);
+  stroke-width: 2;
+}
+
 /* --- Scatter: estimated vs exact contribution --- */
 .qi-aq__plot {
-  fill: var(--aq-control-bg);
-  stroke: var(--aq-control-border);
+  fill: var(--qi-surface);
+  stroke: var(--qi-border);
   stroke-width: 1;
 }
 .qi-aq__diag {
-  stroke: var(--aq-muted);
+  stroke: var(--qi-muted);
   stroke-width: 1;
   stroke-dasharray: 4 4;
 }
 .qi-aq__dot {
   fill: var(--aq-pos);
-  stroke: var(--aq-control-bg);
+  stroke: var(--qi-surface);
   stroke-width: 1;
   cursor: pointer;
   transition: cx 0.4s ease, cy 0.4s ease;
@@ -122,49 +52,26 @@ html[data-theme='dark'] .qi-aq {
   fill: var(--aq-neg);
 }
 .qi-aq__dot.is-hot {
-  stroke: var(--aq-hot);
+  stroke: var(--qi-hot);
   stroke-width: 2;
   r: 5.5;
 }
 /* Error: from the dot straight to the diagonal. */
 .qi-aq__err {
-  stroke: var(--aq-muted);
+  stroke: var(--qi-muted);
   stroke-width: 1;
   opacity: 0.5;
   pointer-events: none;
   transition: x1 0.4s ease, x2 0.4s ease, y1 0.4s ease, y2 0.4s ease;
 }
 .qi-aq__err.is-hot {
-  stroke: var(--aq-hot);
+  stroke: var(--qi-hot);
   opacity: 1;
   stroke-width: 1.5;
 }
 .qi-aq__gap {
-  fill: var(--aq-muted);
   font-size: 11px;
   font-weight: 600;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
-.qi-aq__cell {
-  fill: var(--aq-pos);
-  stroke: var(--aq-cell-stroke);
-  stroke-width: 1;
-  transition: fill 0.35s ease, fill-opacity 0.35s ease;
-}
-.qi-aq__cell.is-neg {
-  fill: var(--aq-neg);
-}
-.qi-aq__cell.is-hot {
-  stroke: var(--aq-hot);
-  stroke-width: 2;
-}
-/* Two lines are reserved so the text switching on hover never reflows the page. */
-.qi-aq__status {
-  margin: 0;
-  min-height: calc(2 * 1.45em);
-  font-size: 14px;
-  line-height: 1.45;
-  color: var(--aq-fg);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/qdrant-landing/content/documentation/headless/quantization/asymmetric/index.js
+++ b/qdrant-landing/content/documentation/headless/quantization/asymmetric/index.js
@@ -10,8 +10,8 @@
  * query magnitude is lost; with a scalar query they follow the diagonal. "New
  * vectors" draws a fresh pair; hover a dimension (cell or dot) for its numbers.
  *
- * Pure SVG + CSS: chrome colors switch on the host theme via CSS custom
- * properties; the sign hues are constant.
+ * Pure SVG + CSS on the shared island design system (islands.scss); the sign
+ * hues (blue positive, red negative) are constant across themes.
  */
 
 const NS = 'http://www.w3.org/2000/svg';
@@ -73,7 +73,7 @@ function quantizeQuery(q) {
   return q.map((v) => (Math.round(((v + m) / (2 * m)) * levels) / levels) * 2 * m - m);
 }
 
-// Paint a cell: hue by sign (blue positive, orange negative), saturation by
+// Paint a cell: hue by sign (blue positive, red negative), saturation by
 // |v| relative to `scale` (clamped).
 function paint(rect, v, scale) {
   rect.classList.toggle('is-neg', v < 0);
@@ -89,35 +89,35 @@ export function mount(node) {
   node.classList.add('qi-aq');
 
   node.innerHTML = [
-    '<div class="qi-aq__fig">',
-    '  <div class="qi-aq__controls">',
-    '    <span class="qi-aq__hint">Hover a dimension, cell or dot, to see its numbers.</span>',
-    '    <button type="button" class="qi-aq__btn qi-aq__shuffle">',
-    '      <svg class="qi-aq__btn-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>New vectors',
+    '<div class="qi-fig">',
+    '  <div class="qi-controls qi-controls--split">',
+    '    <span class="qi-hint">Hover a cell or dot for its numbers.</span>',
+    '    <button type="button" class="qi-chip qi-aq__shuffle">',
+    '      <svg class="qi-chip__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>New vectors',
     '    </button>',
     '  </div>',
-    `  <svg class="qi-aq__svg" viewBox="-2 0 ${VB_W + 4} ${VB_H}" role="img"`,
+    `  <svg class="qi-svg qi-aq__svg" viewBox="-2 0 ${VB_W + 4} ${VB_H}" role="img"`,
     '    aria-label="Two panels scoring a binary stored vector against a query, with a binary query on the left and a scalar-quantized query on the right. Each panel shows the stored vector, the query, and a scatter of estimated against exact per-dimension contributions.">',
     PANELS.map((p) => {
       const px = p.x + PLOT.dx;
       return [
         `<g class="qi-aq__panel" data-panel="${p.id}">`,
-        `  <text class="qi-aq__title" x="${p.x}" y="16">${p.title}</text>`,
-        `  <text class="qi-aq__label" x="${p.x}" y="${ROWS.stored - 6}">Stored vector · 1 bit / dim</text>`,
+        `  <text class="qi-title" x="${p.x}" y="16">${p.title}</text>`,
+        `  <text class="qi-label" x="${p.x}" y="${ROWS.stored - 6}">Stored vector · 1 bit / dim</text>`,
         `  <g class="qi-aq__row qi-aq__row--stored"></g>`,
-        `  <text class="qi-aq__label" x="${p.x}" y="${ROWS.query - 6}"><tspan class="qi-aq__op">×</tspan> ${p.queryLabel}</text>`,
+        `  <text class="qi-label" x="${p.x}" y="${ROWS.query - 6}"><tspan class="qi-aq__op">×</tspan> ${p.queryLabel}</text>`,
         `  <g class="qi-aq__row qi-aq__row--query"></g>`,
-        `  <text class="qi-aq__label" x="${p.x}" y="${PLOT.y - 8}"><tspan class="qi-aq__op">=</tspan> Estimated vs exact contribution</text>`,
+        `  <text class="qi-label" x="${p.x}" y="${PLOT.y - 8}"><tspan class="qi-aq__op">=</tspan> Estimated vs exact contribution</text>`,
         // Scatter box with the identity diagonal; dots are added per dimension.
         `  <rect class="qi-aq__plot" x="${px}" y="${PLOT.y}" width="${PLOT.w}" height="${PLOT.h}" rx="4"/>`,
         `  <line class="qi-aq__diag" x1="${px + PAD}" y1="${PLOT.y + PLOT.h - PAD}" x2="${px + PLOT.w - PAD}" y2="${PLOT.y + PAD}"/>`,
         `  <g class="qi-aq__dots"></g>`,
-        `  <text class="qi-aq__gap" x="${px + PLOT.w - 8}" y="${PLOT.y + PLOT.h - 8}" text-anchor="end"></text>`,
+        `  <text class="qi-label qi-aq__gap" x="${px + PLOT.w - 8}" y="${PLOT.y + PLOT.h - 8}" text-anchor="end"></text>`,
         '</g>',
       ].join('');
     }).join(''),
     '  </svg>',
-    '  <p class="qi-aq__status" role="status" aria-live="polite"></p>',
+    '  <p class="qi-status qi-status--2 qi-aq__status" role="status" aria-live="polite"></p>',
     '</div>',
   ].join('');
 
@@ -225,8 +225,8 @@ export function mount(node) {
     if (hovered == null) {
       const small = qScalar.filter((v) => Math.abs(v) < NEAR_ZERO).length;
       statusEl.innerHTML =
-        `A dot on the diagonal is a perfect estimate. Binary gives every dimension the same ±1 vote, ` +
-        `even the <b>${small}</b> near-zero ones; scalar weights each by its magnitude.`;
+        `Dots on the diagonal are exact. A binary query gives every dimension the same ±1 vote, ` +
+        `even the <b>${small}</b> near-zero ones; a scalar query weights each by magnitude.`;
       return;
     }
 

--- a/qdrant-landing/content/documentation/headless/quantization/bit-depth/index.css
+++ b/qdrant-landing/content/documentation/headless/quantization/bit-depth/index.css
@@ -1,155 +1,44 @@
-/* bit-depth island. Scoped under .qi-bd. Chrome colors switch on the host
-   theme via CSS custom properties; the data palette (bucket blues, bit
-   greens) stays constant. */
+/* bit-depth island. Scoped under .qi-bd. Controls and labels come from the
+   shared island design system (islands.scss); this file only styles the
+   cells, bits, bars and the histogram. Data palette: blue scale (--qi-cat-1)
+   for buckets/values, teal (--qi-cat-3) for bits, Qdrant red for thresholds. */
 
 .qi-bd {
-  /* Light theme (default). Values from _theme-variables.scss. */
-  --bd-fg: #28324d; /* neutral-30 */
-  --bd-muted: #576280; /* neutral-50 */
-  --bd-control-bg: #f0f3fa; /* neutral-98 */
-  --bd-control-border: #d4d9e6; /* neutral-90 */
-  --bd-axis: #b4bacc; /* neutral-80 */
-  --bd-cell-stroke: rgba(22, 30, 51, 0.3);
-  --bd-accent: #dc244c; /* primary-50 (thresholds only) */
-  --bd-hot: #28324d; /* neutral-30: quiet highlight outline */
-  --bd-bar-float: #b4bacc; /* neutral-80 */
-  --bd-bit-off: #a9e8c4; /* between success-90 and success-70, visible on white */
-
-  /* Data palette. The two light blues are a step darker than in dark mode so
+  --bd-bit-on: var(--qi-cat-3);
+  --bd-bit-off: var(--qi-cat-3-soft);
+  /* Bucket blues. The two light ones are a step darker than in dark mode so
      they read against a white page. */
   --bd-neg: #c5d2fb;
   --bd-zero: #7a9ef7;
   --bd-pos: #0040a1; /* secondary-blue-30 */
-  --bd-bit-on: #008a53; /* success-50 */
 
   display: block;
-  color: var(--bd-fg);
 }
-
 @media (prefers-color-scheme: dark) {
   html:not([data-theme='light']) .qi-bd {
-    --bd-fg: #e1e5f0; /* neutral-94 */
-    --bd-muted: #8f98b2; /* neutral-70 */
-    --bd-control-bg: #161e33; /* neutral-20 */
-    --bd-control-border: #28324d; /* neutral-30 */
-    --bd-axis: #3d4866; /* neutral-40 */
-    --bd-cell-stroke: rgba(225, 229, 240, 0.18);
-    --bd-hot: #f0f3fa; /* neutral-98 */
-    --bd-bar-float: #3d4866; /* neutral-40 */
-    --bd-bit-off: #00522f; /* success-30 */
     --bd-neg: #d9e2fe; /* secondary-blue-90 */
     --bd-zero: #89a9ff; /* secondary-blue-70 */
   }
 }
 html[data-theme='dark'] .qi-bd {
-  --bd-fg: #e1e5f0; /* neutral-94 */
-  --bd-muted: #8f98b2; /* neutral-70 */
-  --bd-control-bg: #161e33; /* neutral-20 */
-  --bd-control-border: #28324d; /* neutral-30 */
-  --bd-axis: #3d4866; /* neutral-40 */
-  --bd-cell-stroke: rgba(225, 229, 240, 0.18);
-  --bd-hot: #f0f3fa; /* neutral-98 */
-  --bd-bar-float: #3d4866; /* neutral-40 */
-  --bd-bit-off: #00522f; /* success-30 */
   --bd-neg: #d9e2fe; /* secondary-blue-90 */
   --bd-zero: #89a9ff; /* secondary-blue-70 */
 }
 
-.qi-bd__fig {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-/* --- Controls --- */
-.qi-bd__controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px 16px;
-}
-.qi-bd__seg {
-  display: inline-flex;
-  padding: 3px;
-  border: 1px solid var(--bd-control-border);
-  border-radius: 10px;
-  background: var(--bd-control-bg);
-}
-.qi-bd__seg-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 12px;
-  border: 0;
-  border-radius: 7px;
-  background: transparent;
-  color: var(--bd-muted);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
-  transition: color 0.15s ease, background 0.15s ease;
-}
-.qi-bd__seg-btn:hover {
-  color: var(--bd-fg);
-}
-.qi-bd__seg-btn[aria-pressed='true'] {
-  background: var(--bd-pos);
-  color: #fff;
-}
-.qi-bd__seg-ratio {
-  font-size: 11px;
-  opacity: 0.75;
-  font-variant-numeric: tabular-nums;
-}
-.qi-bd__btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 6px 13px;
-  border: 1px solid var(--bd-control-border);
-  border-radius: 8px;
-  background: var(--bd-control-bg);
-  color: var(--bd-muted);
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
-  transition: border-color 0.15s ease, color 0.15s ease;
-}
-.qi-bd__btn:hover {
-  border-color: var(--bd-muted);
-  color: var(--bd-fg);
-}
-.qi-bd__btn-icon {
-  flex: none;
-}
-
-/* --- SVG --- */
-.qi-bd__svg {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-.qi-bd__label {
-  fill: var(--bd-muted);
-  font-size: 13px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
-
 .qi-bd__cell {
-  stroke: var(--bd-cell-stroke);
+  stroke: var(--qi-cell-stroke);
   stroke-width: 1;
   cursor: pointer;
   transition: fill 0.4s ease;
 }
 .qi-bd__cell.is-hot {
-  stroke: var(--bd-hot);
+  stroke: var(--qi-hot);
   stroke-width: 2;
 }
 
 .qi-bd__bit {
   fill: var(--bd-bit-off);
-  stroke: var(--bd-cell-stroke);
+  stroke: var(--qi-cell-stroke);
   stroke-width: 0.75;
   cursor: pointer;
   transition: fill 0.25s ease;
@@ -163,7 +52,7 @@ html[data-theme='dark'] .qi-bd {
   stroke-dasharray: 3 2;
 }
 .qi-bd__bit.is-hot {
-  stroke: var(--bd-hot);
+  stroke: var(--qi-hot);
   stroke-width: 2;
   stroke-dasharray: none;
 }
@@ -172,20 +61,15 @@ html[data-theme='dark'] .qi-bd {
   transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 .qi-bd__bar--float {
-  fill: var(--bd-bar-float);
+  fill: var(--qi-line);
 }
 .qi-bd__bar--q {
   fill: var(--bd-bit-on);
 }
-.qi-bd__bar-text {
-  fill: var(--bd-muted);
-  font-size: 12px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
 
 .qi-bd__sq {
   fill: var(--bd-zero);
-  stroke: var(--bd-cell-stroke);
+  stroke: var(--qi-cell-stroke);
   stroke-width: 1;
   cursor: pointer;
   transition: fill 0.35s ease, opacity 0.2s ease;
@@ -197,22 +81,16 @@ html[data-theme='dark'] .qi-bd {
   fill: var(--bd-pos);
 }
 .qi-bd__sq.is-hot {
-  stroke: var(--bd-hot);
+  stroke: var(--qi-hot);
   stroke-width: 2;
 }
-.qi-bd__axis {
-  stroke: var(--bd-axis);
-  stroke-width: 1.5;
-}
 .qi-bd__threshold {
-  stroke: var(--bd-accent);
+  stroke: var(--qi-accent);
   stroke-width: 1.5;
   stroke-dasharray: 4 4;
 }
 .qi-bd__threshold-label {
-  fill: var(--bd-accent);
-  font-size: 12px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
+  fill: var(--qi-accent);
 }
 .qi-bd__band {
   opacity: 0.9;
@@ -221,7 +99,7 @@ html[data-theme='dark'] .qi-bd {
   stroke-width: 2;
 }
 .qi-bd__band.is-hot {
-  stroke: var(--bd-hot);
+  stroke: var(--qi-hot);
 }
 .qi-bd__band.is-neg {
   fill: var(--bd-neg);
@@ -232,25 +110,8 @@ html[data-theme='dark'] .qi-bd {
 .qi-bd__band.is-pos {
   fill: var(--bd-pos);
 }
-.qi-bd__band-label {
-  fill: var(--bd-fg);
-  font-size: 12px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
-}
 .qi-bd__marker {
-  fill: var(--bd-hot);
-}
-
-/* Two lines are reserved so the text switching on hover never reflows the page. */
-.qi-bd__status {
-  margin: 0;
-  min-height: calc(2 * 1.45em);
-  font-size: 14px;
-  line-height: 1.45;
-  color: var(--bd-fg);
-}
-.qi-bd__status sub {
-  font-size: 0.75em;
+  fill: var(--qi-hot);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/qdrant-landing/content/documentation/headless/quantization/bit-depth/index.js
+++ b/qdrant-landing/content/documentation/headless/quantization/bit-depth/index.js
@@ -11,9 +11,8 @@
  * Hover (or click to pin) a component to trace it through the encoding, or
  * hover a histogram bin / bucket band to see which components fall there.
  *
- * Pure SVG + CSS: chrome colors come from CSS custom properties that switch on
- * the host theme; the data palette (blues for buckets, green for bits) is
- * constant.
+ * Pure SVG + CSS on the shared island design system (islands.scss); the data
+ * palette (blues for buckets, teal for bits) is constant across themes.
  */
 
 const NS = 'http://www.w3.org/2000/svg';
@@ -113,40 +112,40 @@ export function mount(node) {
   node.classList.add('qi-bd');
 
   node.innerHTML = [
-    '<div class="qi-bd__fig">',
-    '  <div class="qi-bd__controls">',
-    '    <div class="qi-bd__seg" role="group" aria-label="Bits per dimension">',
+    '<div class="qi-fig">',
+    '  <div class="qi-controls qi-controls--split">',
+    '    <div class="qi-group" role="group" aria-label="Bits per dimension">',
     MODES.map(
       (m) =>
-        `<button type="button" class="qi-bd__seg-btn" data-mode="${m.id}" aria-pressed="false">` +
-        `${m.label}<span class="qi-bd__seg-ratio">${m.ratio}×</span></button>`,
+        `<button type="button" class="qi-chip qi-bd__seg-btn" data-mode="${m.id}" aria-pressed="false">` +
+        `${m.label}<small>${m.ratio}×</small></button>`,
     ).join(''),
     '    </div>',
-    '    <button type="button" class="qi-bd__btn qi-bd__shuffle">',
-    '      <svg class="qi-bd__btn-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>New vector',
+    '    <button type="button" class="qi-chip qi-bd__shuffle">',
+    '      <svg class="qi-chip__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>New vector',
     '    </button>',
     '  </div>',
-    `  <svg class="qi-bd__svg" viewBox="-3 0 ${VB_W + 6} ${VB_H}" role="img"`,
+    `  <svg class="qi-svg qi-bd__svg" viewBox="-3 0 ${VB_W + 6} ${VB_H}" role="img"`,
     '    aria-label="A float vector encoded with 1, 1.5 or 2 bits per dimension, next to the distribution of its component values split into buckets by thresholds.">',
     // Left column: the vector
-    `    <text class="qi-bd__label" x="0" y="14">Float vector · 32 bit / dim</text>`,
+    `    <text class="qi-label" x="0" y="14">Float vector · 32 bit / dim</text>`,
     '    <g class="qi-bd__floats"></g>',
-    `    <text class="qi-bd__label qi-bd__bits-label" x="0" y="80"></text>`,
+    `    <text class="qi-label qi-bd__bits-label" x="0" y="80"></text>`,
     '    <g class="qi-bd__bits"></g>',
-    `    <text class="qi-bd__label" x="0" y="${BAR_FLOAT_Y - 6}">Storage per vector</text>`,
+    `    <text class="qi-label" x="0" y="${BAR_FLOAT_Y - 6}">Storage per vector</text>`,
     `    <rect class="qi-bd__bar qi-bd__bar--float" x="0" y="${BAR_FLOAT_Y}" width="${LEFT_W}" height="${BAR_H}" rx="3"/>`,
-    `    <text class="qi-bd__bar-text" x="${LEFT_W}" y="${BAR_FLOAT_Y + BAR_H + 13}" text-anchor="end">float32 · ${D} × 32 = ${D * 32} bit</text>`,
+    `    <text class="qi-label" x="${LEFT_W}" y="${BAR_FLOAT_Y + BAR_H + 13}" text-anchor="end">float32 · ${D} × 32 = ${D * 32} bit</text>`,
     `    <rect class="qi-bd__bar qi-bd__bar--q" x="0" y="${BAR_Q_Y}" width="0" height="${BAR_H}" rx="3"/>`,
-    `    <text class="qi-bd__bar-text qi-bd__bar-text--q" x="0" y="${BAR_Q_Y + BAR_H + 13}"></text>`,
+    `    <text class="qi-label qi-bd__bar-text--q" x="0" y="${BAR_Q_Y + BAR_H + 13}"></text>`,
     // Right column: distribution + thresholds + buckets
-    `    <text class="qi-bd__label" x="${HX0}" y="14">Distribution of component values</text>`,
+    `    <text class="qi-label" x="${HX0}" y="14">Distribution of component values</text>`,
     '    <g class="qi-bd__hist"></g>',
-    `    <line class="qi-bd__axis" x1="${HX0 - 6}" y1="${BASE_Y}" x2="${HX0 + HW + 6}" y2="${BASE_Y}"/>`,
+    `    <line class="qi-axis" x1="${HX0 - 6}" y1="${BASE_Y}" x2="${HX0 + HW + 6}" y2="${BASE_Y}"/>`,
     '    <g class="qi-bd__thresholds"></g>',
     '    <g class="qi-bd__bands"></g>',
     `    <polygon class="qi-bd__marker" points="0,0 -6,10 6,10" style="display:none"/>`,
     '  </svg>',
-    '  <p class="qi-bd__status" role="status" aria-live="polite"></p>',
+    '  <p class="qi-status qi-status--2 qi-bd__status" role="status" aria-live="polite"></p>',
     '</div>',
   ].join('');
 
@@ -247,7 +246,7 @@ export function mount(node) {
     thresholds.forEach((t) => {
       const x = xOfValue(t);
       thrG.appendChild(el('line', { class: 'qi-bd__threshold', x1: x, y1: 44, x2: x, y2: BASE_Y + 4 }));
-      thrG.appendChild(el('text', { class: 'qi-bd__threshold-label', x, y: 40, 'text-anchor': 'middle' }, t === 0 ? '0' : t < 0 ? '−σ' : '+σ'));
+      thrG.appendChild(el('text', { class: 'qi-label qi-bd__threshold-label', x, y: 40, 'text-anchor': 'middle' }, t === 0 ? '0' : t < 0 ? '−σ' : '+σ'));
     });
 
     // Color the bell by bucket.
@@ -271,7 +270,7 @@ export function mount(node) {
       bandsG.appendChild(el('rect', { class: `qi-bd__band ${cls}`, x: x1 + 1, y: BAND_Y, width: x2 - x1 - 2, height: BAND_H, rx: 3, 'data-bucket': b }));
       const code = mode.id === 'one' ? (b === 1 ? '1' : '0') : twoBits(b).map((z) => (z ? '1' : '0')).join('');
       const name = b === -1 ? '−1' : b === 0 ? '0' : '+1';
-      bandsG.appendChild(el('text', { class: 'qi-bd__band-label', x: (x1 + x2) / 2, y: BAND_LABEL_Y, 'text-anchor': 'middle' }, `${name} → ${code}`));
+      bandsG.appendChild(el('text', { class: 'qi-label qi-label--strong', x: (x1 + x2) / 2, y: BAND_LABEL_Y, 'text-anchor': 'middle' }, `${name} → ${code}`));
     }
   }
 
@@ -301,12 +300,12 @@ export function mount(node) {
     const total = D * mode.bpd;
     const tail = `${D * 32} bit → <b>${total} bit</b> per vector, <b>${mode.ratio}×</b> compression.`;
     if (mode.id === 'one') {
-      return `<b>1 bit per dimension</b>: only the sign survives, so values close to zero become a coin-flip. ${tail}`;
+      return `<b>1 bit per dimension</b>: only the sign survives, so values near zero become a coin-flip. ${tail}`;
     }
     if (mode.id === 'two') {
-      return `<b>2 bits per dimension</b>: three buckets, so values within ±σ are stored as an explicit 0 instead of a random sign. ${tail}`;
+      return `<b>2 bits per dimension</b>: three buckets, so values within ±σ are stored as an explicit 0. ${tail}`;
     }
-    return `<b>1.5 bits per dimension</b>: the same buckets, but two neighbouring values share their +1 bit (the dashed middle cell). ${tail}`;
+    return `<b>1.5 bits per dimension</b>: the same buckets, but neighbouring values share their +1 bit (dashed cell). ${tail}`;
   }
 
   // hot: null | { type: 'dim', i } | { type: 'bin', b } | { type: 'bucket', bucket }

--- a/qdrant-landing/content/documentation/manage-data/multitenancy.md
+++ b/qdrant-landing/content/documentation/manage-data/multitenancy.md
@@ -38,10 +38,11 @@ This example uses `group_id` as the tenant field. Start by creating a keyword pa
 
 The `is_tenant=true` parameter is optional, but specifying it gives Qdrant additional information about the collection's usage patterns.
 When set, Qdrant organizes the storage structure to co-locate vectors of the same tenant together, which can significantly improve performance by utilizing sequential reads during queries.
+Instead of many random disk seeks across the segment, the data of one tenant can be read in a single sequential pass.
 
 {{< island
     path="content/documentation/headless/multitenancy/tenant-defrag"
-    width="90%" title="Grouping tenants together by tenant ID, if `is_tenant=true` is used, enables more efficient disk reads. Rather than many random seeks across the file, Qdrant can read the data for a specific tenant with a sequential read."
+    width="90%" title="With `is_tenant=true`, the points of one tenant are stored together and read sequentially."
 >}}
 ![Tenants defragmentation with is_tenant](/docs/defragmentation.png)
 {{< /island >}}
@@ -139,7 +140,7 @@ There are three components in Qdrant that allow you to implement tiered multiten
 - **Fallback shards** - a special routing mechanism that allows you to route requests to either a dedicated shard (if it exists) or to a shared fallback shard. It allows you to keep requests unified, without the need to know whether a tenant is dedicated or shared.
 - **Tenant promotion** - a mechanism that allows you to move tenants from the shared fallback shard to their own dedicated shard when they grow large enough. This process is based on Qdrant's internal shard transfer mechanism, which makes promotion completely transparent for the application. The promotion process supports both read and write requests.
 
-{{< island path="content/documentation/headless/multitenancy/tenant-promotion" width="90%" title="Tiered multitenancy with tenant promotion" >}}
+{{< island path="content/documentation/headless/multitenancy/tenant-promotion" width="90%" title="Tiered multitenancy: small tenants share the fallback shard, promoted tenants get their own." >}}
 ![Tiered multitenancy with tenant promotion](/docs/tenant-promotion.png)
 {{< /island >}}
 

--- a/qdrant-landing/content/documentation/manage-data/quantization.md
+++ b/qdrant-landing/content/documentation/manage-data/quantization.md
@@ -173,7 +173,7 @@ In order to build 2-bit representation, Qdrant computes values distribution and 
 {{< island
     path="content/documentation/headless/quantization/bit-depth"
     width="80%" ratio="2 / 1"
-    title="Binary quantization at 1, 1.5 and 2 bits per dimension. With 2 bits, the distribution of component values is split into three buckets, so values close to zero are stored as an explicit `0` rather than a random sign. At 1.5 bits, two neighbouring values share one bit."
+    title="Binary quantization at 1, 1.5 and 2 bits per dimension."
 >}}
 ![2-bit quantization](/docs/2-bit-quantization.png)
 {{< /island >}}
@@ -186,11 +186,13 @@ See how to set up 1.5-bit and 2-bit quantization in the [following section](#set
 
 The **Asymmetric Quantization** technique allows Qdrant to use different vector encoding algorithms for stored vectors and queries.
 A particularly interesting combination is binary stored vectors and Scalar quantized queries.
+With a binary query, every dimension contributes the same ±1 vote to the score, even where the query component is close to zero and its sign is mostly noise.
+A scalar-quantized query keeps the magnitude of each component, so each dimension's contribution stays close to the exact float32 value.
 
 {{< island
     path="content/documentation/headless/quantization/asymmetric"
     width="80%" ratio="9 / 5"
-    title="Asymmetric quantization. Stored vectors stay binary in both cases. With a binary query every dimension casts the same ±1 vote, even where the query component is close to zero and its sign is mostly noise. A scalar-quantized query keeps each component's magnitude, so each dimension's contribution to the score stays close to the exact float32 value."
+    title="Asymmetric quantization: a binary stored vector scored against a binary and a scalar-quantized query."
 >}}
 ![Asymmetric quantization](/docs/asymmetric-quantization.png)
 {{< /island >}}

--- a/qdrant-landing/themes/qdrant-2024/assets/css/islands.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/islands.scss
@@ -1,12 +1,17 @@
-// Island shell styles: the wrapper, the fallback, and the loading spinner.
+// Island styles: the shell (wrapper, fallback, spinner) and the shared design
+// system every island builds on (tokens + controls + SVG text/frame classes).
 //
 // This is the CSS half of the content-islands feature; the behavior half (the
 // host loader) is emitted from partials/js.html. This file is loaded as a
 // <link> from partials/css.html, gated on `.HasShortcode "island"` so it only
 // ships on pages that actually embed an island. It is deliberately NOT imported
 // into a section bundle (blog/documentation), to keep those under their CSS
-// budgets. Per-island visual styles live with each island in
-// assets/islands/<name>/index.css.
+// budgets.
+//
+// Per-island CSS (content/documentation/headless/<page>/<island>/index.css)
+// should only style what is specific to that diagram (its bars, cells, dots),
+// and reference the `--qi-*` tokens below. Controls, captions, frames and
+// labels come from the shared `.qi-*` classes so all islands look alike.
 
 .island {
   margin: 1.5rem auto;
@@ -124,4 +129,218 @@
   .island__spinner-dot {
     animation: none;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Island design system
+// ---------------------------------------------------------------------------
+
+// Tokens. Light theme (default); values from _theme-variables.scss. Chrome
+// colors switch with the host theme (`data-theme` on <html>, else the system
+// preference). The categorical palette is theme-independent.
+.island {
+  --qi-fg: #28324d; // neutral-30
+  --qi-muted: #576280; // neutral-50
+  --qi-surface: #f0f3fa; // neutral-98: card / control background
+  --qi-border: #d4d9e6; // neutral-90: thin neutral border
+  --qi-line: #b4bacc; // neutral-80: axes, toggle track, ghost bars
+  --qi-hot: #28324d; // neutral-30: highlight outline
+  --qi-cell-stroke: rgba(22, 30, 51, 0.3);
+  --qi-accent: #dc244c; // primary-50: thresholds, emphasis
+
+  // Categorical palette for neutral categories (tenants, series). These are
+  // brand secondaries, not status colors, so they do not read as ok/warn/error.
+  --qi-cat-1: #2f6ff0; // secondary-blue-50
+  --qi-cat-2: #8547ff; // secondary-violet-50
+  --qi-cat-3: #038585; // secondary-teal-50
+  --qi-cat-4: #dc244c; // primary-50 (Qdrant red)
+  // Tint of the teal, for an "off" state next to a solid "on".
+  --qi-cat-3-soft: #c0f0f0; // secondary-teal-90
+
+  --qi-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --qi-radius: 6px;
+}
+
+@mixin qi-dark-tokens {
+  --qi-fg: #e1e5f0; // neutral-94
+  --qi-muted: #8f98b2; // neutral-70
+  --qi-surface: #161e33; // neutral-20
+  --qi-border: #28324d; // neutral-30
+  --qi-line: #3d4866; // neutral-40
+  --qi-hot: #f0f3fa; // neutral-98
+  --qi-cell-stroke: rgba(225, 229, 240, 0.18);
+  --qi-cat-3-soft: #004f4f; // secondary-teal-30
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme='light']) .island {
+    @include qi-dark-tokens;
+  }
+}
+html[data-theme='dark'] .island {
+  @include qi-dark-tokens;
+}
+
+// Layout: controls row above the SVG, one status line below.
+.qi-fig {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: var(--qi-fg);
+}
+.qi-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  min-height: 30px;
+}
+.qi-controls--split {
+  justify-content: space-between;
+}
+.qi-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.qi-hint {
+  font-family: var(--qi-mono);
+  font-size: 12px;
+  color: var(--qi-muted);
+}
+
+// Chip: the one button shape for every island control. Used for toggles
+// (`aria-pressed`), selections (`.is-active`) and actions (Reset / New vector).
+.qi-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px;
+  border: 1px solid var(--qi-border);
+  border-radius: var(--qi-radius);
+  background: transparent;
+  color: var(--qi-muted);
+  font-family: var(--qi-mono);
+  font-size: 12px;
+  line-height: 18px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+
+  &:hover:not(:disabled) {
+    color: var(--qi-fg);
+    border-color: var(--qi-muted);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--qi-fg);
+    outline-offset: 1px;
+  }
+  &[aria-pressed='true'],
+  &.is-active {
+    color: var(--qi-fg);
+    border-color: var(--qi-fg);
+    background: var(--qi-surface);
+  }
+  &:disabled {
+    opacity: 0.45;
+    cursor: default;
+  }
+  b {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  small {
+    font-size: 11px;
+    opacity: 0.75;
+    font-variant-numeric: tabular-nums;
+  }
+}
+.qi-chip__swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex: none;
+  background: var(--swatch, currentColor);
+}
+.qi-chip__icon {
+  flex: none;
+}
+
+// Switch: a chip carrying a small on/off track. Flat, no shadow.
+.qi-switch__track {
+  position: relative;
+  flex: none;
+  width: 28px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--qi-line);
+  transition: background 0.2s ease;
+}
+.qi-switch__knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--qi-surface); // stays visible on both track colors, in both themes
+  transition: transform 0.2s ease;
+}
+.qi-chip[aria-pressed='true'] .qi-switch__track {
+  background: var(--qi-fg);
+}
+.qi-chip[aria-pressed='true'] .qi-switch__knob {
+  transform: translateX(12px);
+}
+
+// Status line under the diagram. Reserve the line count up front so text that
+// switches on hover never reflows the page.
+.qi-status {
+  margin: 0;
+  min-height: 1.45em;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--qi-fg);
+}
+.qi-status--2 {
+  min-height: calc(2 * 1.45em);
+}
+.qi-status sub {
+  font-size: 0.75em;
+}
+
+// SVG stage and text. Labels are Geist Mono, like the controls.
+.qi-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.qi-frame {
+  fill: var(--qi-surface);
+  stroke: var(--qi-border);
+  stroke-width: 1;
+}
+.qi-frame-label {
+  fill: var(--qi-muted);
+  font-family: var(--qi-mono);
+  font-size: 14px;
+}
+.qi-title {
+  fill: var(--qi-fg);
+  font-family: var(--qi-mono);
+  font-size: 13px;
+  font-weight: 600;
+}
+.qi-label {
+  fill: var(--qi-muted);
+  font-family: var(--qi-mono);
+  font-size: 12px;
+}
+.qi-label--strong {
+  fill: var(--qi-fg);
+}
+.qi-axis {
+  stroke: var(--qi-line);
+  stroke-width: 1.5;
 }

--- a/qdrant-landing/themes/qdrant-2024/assets/css/islands.scss
+++ b/qdrant-landing/themes/qdrant-2024/assets/css/islands.scss
@@ -148,8 +148,8 @@
   --qi-cell-stroke: rgba(22, 30, 51, 0.3);
   --qi-accent: #dc244c; // primary-50: thresholds, emphasis
 
-  // Categorical palette for neutral categories (tenants, series). These are
-  // brand secondaries, not status colors, so they do not read as ok/warn/error.
+  // Categorical palette (brand secondaries) available to islands that need
+  // hues without a status meaning. Islands may also define their own.
   --qi-cat-1: #2f6ff0; // secondary-blue-50
   --qi-cat-2: #8547ff; // secondary-violet-50
   --qi-cat-3: #038585; // secondary-teal-50


### PR DESCRIPTION
Stacked on #2739 (base branch `island-shortcode`). Addresses the design review in https://github.com/qdrant/landing_page/pull/2739#issuecomment-5637870276.

## What changed

- **One design system for all islands**: `islands.scss` now carries `--qi-*` tokens (fg/muted/surface/border/line, mono font, radius, and an optional categorical palette) with light/dark values, plus shared `.qi-*` classes for the controls row, chip/toggle, status line, SVG frame and labels. Each island's own CSS only styles its diagram-specific parts (bars, cells, dots) on top of those tokens. An island can still override any token on its root class if it needs its own scheme.
- **Tenant colors are unchanged** from #2739.
- **Geist Mono** on every control and every diagram label.
- **Cards**: 1px neutral border, 6px radius, no shadows. The toggle knob shadow is gone. The bit-depth segmented control and the promotion buttons are now the same chip as the tenant chips, with one pressed style.
- **Captions** cut to one short sentence each; the removed detail lives in the article paragraphs next to the islands.
- Asymmetric island: negative sign is Qdrant red; bit-depth island: bits are teal.

## Checked

- `hugo` builds cleanly.
- Rendered both docs pages in headless Chrome, light and dark, before and after interacting with each island (toggle + tenant selection, promotion, bit mode + hover, dot hover). Controls and content fit inside the reserved stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
