### PR TITLE
Publish each page's markdown at /path.md as well as /path/index.md

### DIFF
--- a/install-and-build.sh
+++ b/install-and-build.sh
@@ -31,4 +31,5 @@ curl -LJO "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSI
     tar -xf "${SASS_ARCHIVE}" && \
     rm "${SASS_ARCHIVE}" && \
     export PATH="${CURRENT_DIR}/dart-sass:${PATH}" && \
-    cd qdrant-landing && npm install && hugo --gc --minify --config config.toml,config-theme.toml --buildFuture -b ${DEPLOY_PRIME_URL}
+    cd qdrant-landing && npm install && hugo --gc --minify --config config.toml,config-theme.toml --buildFuture -b ${DEPLOY_PRIME_URL} && \
+    ./scripts/emit-md-aliases.sh public

--- a/qdrant-landing/package.json
+++ b/qdrant-landing/package.json
@@ -38,5 +38,8 @@
   "version": "0.1.0",
   "workspaces": [
     "packages/hugoautogen"
-  ]
+  ],
+  "scripts": {
+    "md:test": "node --test \"test/markdown/**/*.test.mjs\""
+  }
 }

--- a/qdrant-landing/scripts/emit-md-aliases.sh
+++ b/qdrant-landing/scripts/emit-md-aliases.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Publish every /path/index.md a second time as /path.md.
+#
+# Hugo writes the Markdown output format beside the HTML it belongs to, so a
+# page at /articles/foo/ gets /articles/foo/index.md. That is what the llms.txt
+# convention prescribes for directory-style URLs, and it is what /llms.txt
+# advertises, so it stays exactly as it is. These are additions, never moves.
+#
+# The reason to also publish /articles/foo.md is that it is the GUESSABLE form.
+# Every other documentation site we compared exposes the markdown of a page by
+# swapping its extension, so a client holding only a URL can construct it
+# without first fetching the HTML to read <link rel="alternate">. Supporting
+# both costs a copy of files that are already tiny (~7.6 MB against a 1.4 GB
+# build, 0.5%) and changes nothing about how anything renders.
+#
+# Deliberately a build step rather than a Netlify redirect: a splat has to be
+# terminal, so /articles/*.md is not a pattern Netlify accepts, and a rule we
+# cannot verify locally is worse than a copy we can.
+set -euo pipefail
+
+PUBLIC="${1:-public}"
+[ -d "$PUBLIC" ] || { echo "md-aliases: no such directory: $PUBLIC" >&2; exit 1; }
+
+written=0
+skipped=0
+while IFS= read -r -d '' src; do
+  dir=$(dirname "$src")
+  # The site root would produce a sibling of the publish directory, not a page.
+  [ "$dir" = "$PUBLIC" ] && continue
+  dest="${dir}.md"
+  if [ -e "$dest" ]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  cp "$src" "$dest"
+  written=$((written + 1))
+done < <(find "$PUBLIC" -type f -name index.md -print0)
+
+echo "md-aliases: wrote ${written}, skipped ${skipped} (a file was already there)"

--- a/qdrant-landing/test/markdown/aliases.test.mjs
+++ b/qdrant-landing/test/markdown/aliases.test.mjs
@@ -1,0 +1,87 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, existsSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+/*
+ * Guards scripts/emit-md-aliases.sh, which publishes every /path/index.md a
+ * second time as /path.md so the markdown of a page can be reached by swapping
+ * its extension, the form a client can guess without first fetching the HTML.
+ *
+ * Builds once into a temp dir and runs the script over it, rather than asserting
+ * on a checked-in fixture: the thing worth protecting is the shape of the real
+ * build output, which is what a hosting change would break.
+ */
+// A full build is ~1.4 GB, so a run that leaves its temp directory behind costs
+// more disk than most people notice until the volume is full. Clean up even when
+// a test throws.
+let built = null;
+process.on('exit', () => {
+  if (built) rmSync(built.out, { recursive: true, force: true });
+});
+
+function buildAndAlias() {
+  if (built) return built;
+  const out = mkdtempSync(join(tmpdir(), 'md-alias-'));
+  execFileSync('hugo', ['--baseURL', 'http://localhost:1313/',
+    '--destination', out, '--logLevel', 'error'], { stdio: 'pipe' });
+  const log = execFileSync('bash', ['scripts/emit-md-aliases.sh', out], { encoding: 'utf8' });
+  built = { out, log };
+  return built;
+}
+
+function everyIndexMd(root) {
+  const found = [];
+  (function walk(dir) {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name === 'index.md') found.push(p);
+    }
+  })(root);
+  return found;
+}
+
+test('every index.md gains a sibling .md alias with identical bytes', () => {
+  const { out } = buildAndAlias();
+  const sources = everyIndexMd(out);
+  assert.ok(sources.length > 100, `expected a real build, found ${sources.length} index.md files`);
+
+  const missing = [];
+  const differing = [];
+  for (const src of sources) {
+    const dir = dirname(src);
+    if (dir === out) continue; // site root would write outside the publish dir
+    const alias = `${dir}.md`;
+    if (!existsSync(alias)) { missing.push(alias); continue; }
+    if (readFileSync(alias, 'utf8') !== readFileSync(src, 'utf8')) differing.push(alias);
+  }
+  assert.deepEqual(missing, [], 'these pages have no .md alias');
+  assert.deepEqual(differing, [], 'these aliases do not match their index.md');
+});
+
+test('the canonical /index.md form is preserved, not replaced', () => {
+  // /llms.txt advertises 670 index.md URLs. The aliases are additions; moving
+  // them would break every link already published.
+  const { out } = buildAndAlias();
+  const canonical = join(out, 'articles', 'immutable-data-structures', 'index.md');
+  assert.ok(existsSync(canonical), 'the original index.md must still be published');
+  assert.ok(existsSync(join(out, 'articles', 'immutable-data-structures.md')),
+    'and the alias must sit beside it');
+  assert.ok(existsSync(join(out, 'articles', 'immutable-data-structures', 'index.html')),
+    'the HTML page must be untouched');
+});
+
+test('nothing is written outside the publish directory', () => {
+  const { out } = buildAndAlias();
+  assert.ok(!existsSync(`${out}.md`), 'the site root must not produce a sibling of the publish dir');
+});
+
+test('an existing file is never overwritten', () => {
+  const { out } = buildAndAlias();
+  // Second run: every alias now exists, so all of them must be reported skipped.
+  const again = execFileSync('bash', ['scripts/emit-md-aliases.sh', out], { encoding: 'utf8' });
+  assert.match(again, /wrote 0, skipped \d+/, `expected an idempotent second run, got: ${again}`);
+});


### PR DESCRIPTION
## What

Every page already publishes a markdown version at `/path/index.md`. This adds a second copy at `/path.md`, so both work.

```
/articles/immutable-data-structures.md        404  ->  200 text/markdown
/articles/immutable-data-structures/index.md  200      200 (unchanged)
```

Nothing moves and no published URL changes. These are additions.

## Why

`/path/index.md` is correct and stays. It is what the [llms.txt convention](https://llmstxt.org/) prescribes for directory-style URLs:

> …either with .md appended (page.html.md) or with the extension replaced by .md (page.md). **(URLs without file names should append index.html.md or index.md instead.)**

It is also the form `/llms.txt` advertises for 670 pages, and the target of the `<link rel="alternate" type="text/markdown">` we already emit in every page head. That last one is worth keeping in mind: on discoverability we are ahead of several documentation sites that ship no alternate link at all.

The gap is that `/path/index.md` is not **guessable**. Every other documentation site I checked exposes a page's markdown by swapping the extension:

| site | `page.md` | `/index.md` |
|---|:---:|:---:|
| Stripe | ✅ | ❌ |
| Anthropic | ✅ | ❌ |
| Vercel | ✅ | — |
| **Qdrant (today)** | **❌** | **✅** |

A client holding only a URL can build `/articles/foo.md` on the spot. Reaching `/articles/foo/index.md` means fetching the HTML first to read the alternate link, which is the round trip the markdown endpoint exists to avoid.

## How

A post-build step, `qdrant-landing/scripts/emit-md-aliases.sh`, copies every `public/**/index.md` to `public/**.md` after Hugo runs. Netlify already serves `.md` as `text/markdown`, so there is no header or redirect config to add.

Cost: **7.6 MB against a 1.4 GB build, 0.5%.**

Deliberately a build step rather than a Netlify redirect. A splat has to be terminal, so `/articles/*.md` is not a pattern Netlify accepts, and a rule that cannot be verified locally is worse than a copy that can.

## Testing

`npm run md:test` builds the site, runs the script over the output, and asserts:

- all 789 aliases exist and match their source byte for byte
- the canonical `index.md` and `index.html` are untouched
- nothing is written outside the publish directory
- a second run overwrites nothing

4/4 pass. I also stubbed the script out and confirmed the two tests that assert aliases exist do fail, so they are not passing vacuously.

The test removes its build directory on exit. A build is ~1.4 GB, so a suite that leaves temp directories behind fills a disk faster than anyone notices.

## Not in scope

`Accept: text/markdown` content negotiation on the HTML URL. Stripe, Anthropic and Vercel all support it, but on Netlify it needs an edge function running on every request to the site. Worth considering separately if anything actually asks for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)