### PR TITLE
Allow pinch-zoom by removing viewport scale restrictions

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/head.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/head.html
@@ -1,8 +1,5 @@
 <head>
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui"
-  />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta charset="UTF-8" />
 
   <!-- If the title contains "qdrant", don't add the - Qdrant suffix -->


### PR DESCRIPTION
Hi,

The live site currently blocks pinch-zoom. Both the homepage and /documentation/ serve:

width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui

That means mobile users can't zoom past 100%, which fails WCAG 1.4.4.

This just drops the extra restrictions in the active theme (qdrant-2024) so it becomes:

width=device-width, initial-scale=1

Checked there is no other viewport handling depending on the old values, and left the unused legacy theme alone. Screenshots and head dumps from qdrant.tech are in my local proof folder if needed.