### PR TITLE
Fix live SEO faults: schema image fallback, ISO dates, og image type

### DIFF
--- a/qdrant-landing/assets/schema/article-schema.json
+++ b/qdrant-landing/assets/schema/article-schema.json
@@ -3,15 +3,21 @@
   "@id": "{{- .Permalink -}}#article",
   "name": "{{- .Params.title | htmlEscape -}}",
   "headline": "{{- .Params.title | htmlEscape -}}",
-  "image": [
-    "{{- if .Params.social_preview_image -}}{{- .Params.social_preview_image | absURL -}}{{- end -}}"
-  ],
+  {{- $schemaImage := "" -}}
+  {{- with .Params.social_preview_image -}}{{- $schemaImage = . | absURL -}}{{- end -}}
+  {{- if and (not $schemaImage) .Params.preview_image -}}{{- $schemaImage = .Params.preview_image | absURL -}}{{- end -}}
+  {{- if and (not $schemaImage) .Site.Params.preview_image -}}{{- $schemaImage = .Site.Params.preview_image | absURL -}}{{- end -}}
+  {{- if $schemaImage }}
+  "image": ["{{- $schemaImage -}}"],
+  {{- end }}
   "url": "{{- .Permalink -}}",
   "description": {{ $description := printf "%s" (.Params.description | plainify | replaceRE "(\n)" "" | replaceRE "[^\\w\\s:\\[\\]{}\"]" "" | htmlEscape ) -}}"{{- $description -}}",
   "abstract": {{- $abstract := .Summary -}}{{- if .Params.description -}}{{- $abstract = .Params.description -}}{{- end -}}{{ $processedAbstract := printf "%s" ($abstract | plainify | replaceRE "(\n)" "" | replaceRE "[^\\w\\s:\\[\\]{}\"]" "" | htmlEscape ) -}}"{{- $processedAbstract -}}",
   "wordCount": "{{- .WordCount -}}",
-  "datePublished": "{{ .Date }}" ,
-  "dateModified": "{{ .Date }}",{{- if .Params.author -}}
+  {{- if not .Date.IsZero }}
+  "datePublished": "{{- .Date.Format "2006-01-02T15:04:05Z07:00" -}}",
+  "dateModified": "{{- .Date.Format "2006-01-02T15:04:05Z07:00" -}}",
+  {{- end }}{{- if .Params.author -}}
   "author": {
     "@type": "Person",
     "name": "{{- .Params.author | htmlEscape -}}"

--- a/qdrant-landing/assets/schema/product-schema.json
+++ b/qdrant-landing/assets/schema/product-schema.json
@@ -9,7 +9,13 @@
   "description" : "{{- .Site.Params.description | htmlEscape -}}",
   "keywords" : [ {{- if .Params.Keywords -}}{{- range .Params.Keywords -}}"{{ . }}", {{- end -}}{{- else if .Site.Params.Keywords -}}{{- range .Site.Params.Keywords -}}"{{ . }}", {{- end -}}{{- end -}} "Qdrant" ],
   "name": "Qdrant",
-  "image": "{{- if .Params.social_preview_image -}}{{- .Params.social_preview_image | absURL -}}{{- end -}}",
+  {{- $productImage := "" -}}
+  {{- with .Params.social_preview_image -}}{{- $productImage = . | absURL -}}{{- end -}}
+  {{- if and (not $productImage) .Params.preview_image -}}{{- $productImage = .Params.preview_image | absURL -}}{{- end -}}
+  {{- if and (not $productImage) .Site.Params.preview_image -}}{{- $productImage = .Site.Params.preview_image | absURL -}}{{- end -}}
+  {{- if $productImage }}
+  "image": "{{- $productImage -}}",
+  {{- end }}
   "offers": {
     "@type": "AggregateOffer",
     "lowPrice": "0",

--- a/qdrant-landing/themes/qdrant-2024/layouts/partials/seo_schema.html
+++ b/qdrant-landing/themes/qdrant-2024/layouts/partials/seo_schema.html
@@ -97,7 +97,7 @@
 {{ if .Params.seo_schema }}
   <!-- if schema is defined in front matter -->
 <script type="application/ld+json">
-    {{ .Params.seo_schema | jsonify | unmarshal }}
+    {{ .Params.seo_schema | jsonify | safeJS }}
 </script>
 {{ end }}
 
@@ -135,7 +135,7 @@
 {{ $image := .Site.Params.preview_image }}
 
 {{ if .Params.preview_image }}
-  {{ $image := .Params.preview_image }}
+  {{ $image = .Params.preview_image }}
 {{ end }}
 
 {{ $slug := .Params.slug }}
@@ -204,9 +204,13 @@
 
 <meta name="image" property="og:image" content="{{ $image | absURL }}" />
 <meta name="image" property="og:image:secure_url" content="{{ $image | absURL }}" />
-<meta property="og:image:type" content="image/jpeg" />
+{{ $imageExt := lower (path.Ext $image) }}
+{{ $imageType := "image/jpeg" }}
+{{ if eq $imageExt ".png" }}{{ $imageType = "image/png" }}{{ else if eq $imageExt ".webp" }}{{ $imageType = "image/webp" }}{{ else if eq $imageExt ".gif" }}{{ $imageType = "image/gif" }}{{ end }}
+<meta property="og:image:type" content="{{ $imageType }}" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
+<meta name="twitter:image" content="{{ $image | absURL }}" />
 <meta name="twitter:image:src" content="{{ $image | absURL }}" />
 
 <!-- Author -->


### PR DESCRIPTION
## Scope

Schema + meta output only. No layout or content changes.

- qdrant-landing/themes/qdrant-2024/layouts/partials/seo_schema.html
- qdrant-landing/assets/schema/article-schema.json
- qdrant-landing/assets/schema/product-schema.json

## What was wrong (all confirmed on qdrant.tech)

1. Empty schema images: homepage Product emitted `"image":""`, blog Article emitted `"image":[""]` even when the page had a working og:image.
2. Dates not ISO8601: e.g. `2024-01-09 10:30:10.952 +0000 UTC`, benchmarks list emitted zero-date `0001-01-01`.
3. `og:image:type` hardcoded to `image/jpeg` while serving PNG (homepage + benchmarks return image/png). Only legacy `twitter:image:src` was emitted.

Two latent issues fixed in the same files since they were one-liners:
- `preview_image` shadowing (`:=\" instead of `=`) so the param was ignored.
- Inline `seo_schema` used `jsonify | unmarshal` with no `safeJS`.

## Fix

- Schema image now falls back `social_preview_image -> preview_image -> Site preview_image`, omitted only if all empty (same pattern event-schema.json already used).
- Dates use `.Date.Format 2006-01-02T15:04:05Z07:00`, skipped when `.Date.IsZero`.
- `og:image:type` derived from extension (png/webp/gif, default jpeg). Added `twitter:image`, kept `twitter:image:src` for compat.
- `preview_image` assignment fixed to `=`. Inline `seo_schema` now `jsonify | safeJS`.

## Proof

Built locally with the repo toolchain (Hugo 0.160.1 + Dart Sass 1.70.0, `hugo --gc --minify`): exit 0, 1697 pages, 0 errors.

- Homepage: Product `image: http://localhost:1313/images/social_preview.png`, `og:image:type=image/png`, both twitter tags present, JSON-LD parses.
- Article with social_preview: image absolute non-empty, dates `2022-11-16T00:00:00-08:00`.
- Post with only preview_image (blog/binary-quantization): image falls back to preview_image instead of `[\"\"]`, date `2024-01-09T10:30:10Z`.
- Benchmarks list: `0001-01-01` gone (0 matches), both JSON-LD blocks parse.
- Inline benchmarks schema parses. Note: `datepublished/datemonth` keys stay lowercase — pre-existing Hugo frontmatter normalization, also present before this change, out of scope.
