### PR TITLE
Guard anchor scrolling and mobile menu against missing targets

### DIFF
--- a/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
@@ -14,8 +14,17 @@ export function isElementInViewport(el) {
 export function scrollIntoViewWithOffset(id, offset) {
   offset = offset || 0;
 
+  if (!id) {
+    return;
+  }
+
+  const el = document.getElementById(id);
+  if (!el) {
+    return;
+  }
+
   const targetPosition =
-    document.getElementById(id).getBoundingClientRect().top - document.body.getBoundingClientRect().top - offset;
+    el.getBoundingClientRect().top - document.body.getBoundingClientRect().top - offset;
 
   window.scrollTo({
     top: targetPosition,

--- a/qdrant-landing/themes/qdrant-2024/assets/js/index.js
+++ b/qdrant-landing/themes/qdrant-2024/assets/js/index.js
@@ -94,14 +94,18 @@ document.addEventListener('DOMContentLoaded', function () {
   const closeBtn = document.querySelector('.menu-mobile__close');
   const menuTrigger = document.querySelector('.main-menu__trigger');
   const menu = document.querySelector('.menu-mobile');
-  menuTrigger.addEventListener('click', () => {
-    menu.classList.add('menu-mobile--visible');
-    body.classList.add('no-scroll');
-  });
-  closeBtn.addEventListener('click', () => {
-    menu.classList.remove('menu-mobile--visible');
-    body.classList.remove('no-scroll');
-  });
+  if (menuTrigger && menu) {
+    menuTrigger.addEventListener('click', () => {
+      menu.classList.add('menu-mobile--visible');
+      body.classList.add('no-scroll');
+    });
+  }
+  if (closeBtn && menu) {
+    closeBtn.addEventListener('click', () => {
+      menu.classList.remove('menu-mobile--visible');
+      body.classList.remove('no-scroll');
+    });
+  }
   function toggleMenu(id) {
     const menuItem = document.querySelector(`[data-path=${id}]`);
     if (menuItem) {
@@ -127,7 +131,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // close mobile menu on resize
   window.addEventListener('resize', () => {
-    if (window.innerWidth >= XXL_BREAKPOINT) {
+    if (window.innerWidth >= XXL_BREAKPOINT && menu) {
       menu.classList.remove('menu-mobile--visible');
     }
   });
@@ -186,7 +190,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // scroll to anchors:
   let offset = DOCS_HEADER_OFFSET;
 
-  if (window.location.hash) {
+  if (window.location.hash && window.location.hash.length > 1) {
     scrollIntoViewWithOffset(window.location.hash.replace('#', ''), offset);
   }
 
@@ -194,6 +198,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
   allLinks.forEach((anchor) => {
     const target = anchor.getAttribute('href');
+    if (!target || target === '#') {
+      return;
+    }
     anchor.addEventListener('click', function (e) {
       e.preventDefault();
       history.pushState(null, null, target);


### PR DESCRIPTION
## Scope

JS robustness only. No visual or content changes.

- qdrant-landing/themes/qdrant-2024/assets/js/helpers.js
- qdrant-landing/themes/qdrant-2024/assets/js/index.js

## What was wrong (all confirmed on qdrant.tech)

1. Footer Cookie Consent link with href="#" threw on every click: pushState to # then getElementById on empty id threw TypeError Cannot read properties of null.
2. Stale hash loads such as /documentation/#nonexistent-id threw the same way, and the throw stopped the rest of the anchor wiring on that load.
3. Agenda layout at /vector-space-day-sf-26/agenda/ has no .menu-mobile markup, so unguarded menuTrigger.addEventListener threw on every load and aborted the rest of DOMContentLoaded.

OneTrust dialog itself still opened. The throws were isolated per listener except agenda, where the whole tail died.

## Fix

- scrollIntoViewWithOffset returns early on empty id and missing element.
- Anchor init skips empty and # targets and only runs on load when hash length is greater than 1.
- Menu trigger, close, and resize handlers null-guard menu before touching classList.

Footer Cookie Consent keeps working via its inline OneTrust handler, just without the trailing-# pushState and console error.

## Proof

Built locally with Hugo 0.160.1 + Dart Sass 1.70.0 using hugo --gc --minify: exit 0, 1697 pages, 0 errors. New bundle contains the guards, old bundle unreferenced.

- node --check clean on both files.
- Stub-DOM sim: empty + missing ids no longer throw. Old logic threw, matching live stacks.
- Segment/OneTrust hunk from #2720 untouched, legacy theme untouched.

Note: customers-hero placeholder href="#" links will now do a default jump-to-top instead of pushState + throw. They are stubs with no handler. Follow-up is real URLs or buttons.