### PR TITLE
CI: reject images over 1MB in PRs

### DIFF
--- a/.github/workflows/image-size.yml
+++ b/.github/workflows/image-size.yml
@@ -1,0 +1,45 @@
+name: Image Size
+
+on:
+  pull_request:
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.gif'
+      - '**.webp'
+      - '**.svg'
+      - '**.mp4'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-size:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-large-images') }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Reject images over 1MB
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[] | select(.status != "removed") | .filename' \
+            | grep -iE '\.(jpg|jpeg|png|gif|webp|svg|mp4)$' > changed.txt || exit 0
+
+          big=$(xargs -r -d '\n' du -k --apparent-size 2>/dev/null < changed.txt | awk -F'\t' '$1 > 1024')
+          [ -n "$big" ] || exit 0
+
+          echo "$big" | awk -F'\t' '{printf "%6.1f MB  %s\n", $1/1024, $2}' | sort -rn
+          echo
+          echo "Nothing on the site is displayed wider than ~2000px, and qdrant-landing/static/"
+          echo "is copied verbatim by Hugo - a 20MB camera JPEG ships to every reader as-is."
+          echo "Resize before committing:"
+          echo "  mogrify -resize '2000x2000>' -quality 82 -strip <file.jpg>"
+          echo "  pngquant --skip-if-larger --ext .png --force <file.png>"
+          echo "If a file genuinely has to be this big, add the 'allow-large-images' label."
+          echo "::error::Images over 1MB in this PR - see the list above"
+          exit 1


### PR DESCRIPTION
## Why

`qdrant-landing/static/` is copied verbatim by Hugo — there is no image processing anywhere in the templates. So `![Marcel n8n](/blog/vsd25-post-event/breakout-marcel.jpg)` ships a **7008×4672, 23.8 MB** file to every reader of that post.

This is not a legacy problem, it's accelerating:

| year | oversized images added |
|---|---|
| 2022 | 13 MB |
| 2023 | 69 MB |
| 2024 | 274 MB |
| 2025 | 364 MB |
| 2026 | 251 MB (partial) |

19 files / 178 MB added in the last 12 months are still live in `HEAD`. `.git` is now 2.4 GB, of which the current checkout alone is 1.1 GB.

Nobody is doing this on purpose — there's just nothing that stops it.

## What this does

Fails the PR when it adds or modifies an image over 1 MB, listing the offenders and the one-liner that fixes them:

```
  23.8 MB  qdrant-landing/static/blog/vsd25-post-event/breakout-marcel.jpg
  19.1 MB  qdrant-landing/static/blog/vsd25-post-event/networking-marcel.jpg

Resize before committing:
  mogrify -resize '2000x2000>' -quality 82 -strip <file.jpg>
```

Caught at the PR it's a 10-second fix; caught at 2.4 GB it needs a history rewrite.

- Only looks at files the PR touches (via the PR files API), so it needs no deep clone and costs nothing on unrelated PRs.
- `paths:` filter means the job doesn't even start unless an image changed.
- Escape hatch: add the **`allow-large-images`** label and the job is skipped.

Threshold is 1 MB because nothing on the site renders wider than ~2000px — a 2000px q82 JPEG lands around 250 KB.

## Follow-up

Separate PR resizes the existing `vsd25-post-event/` photos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)